### PR TITLE
Fix for request.state.cache error when no cache is set.

### DIFF
--- a/titiler/api/utils.py
+++ b/titiler/api/utils.py
@@ -17,7 +17,7 @@ from starlette.requests import Request
 
 def get_cache(request: Request) -> CacheLayer:
     """Get Memcached Layer."""
-    return request.state.cache
+    return getattr(request.state, "cache", None)
 
 
 def get_hash(**kwargs: Any) -> str:

--- a/titiler/api/utils.py
+++ b/titiler/api/utils.py
@@ -17,7 +17,7 @@ from starlette.requests import Request
 
 def get_cache(request: Request) -> CacheLayer:
     """Get Memcached Layer."""
-    return request.state.get("cache", None)
+    return request.state.get("cache")
 
 
 def get_hash(**kwargs: Any) -> str:

--- a/titiler/api/utils.py
+++ b/titiler/api/utils.py
@@ -17,7 +17,7 @@ from starlette.requests import Request
 
 def get_cache(request: Request) -> CacheLayer:
     """Get Memcached Layer."""
-    return getattr(request.state, "cache", None)
+    return request.state.get("cache", None)
 
 
 def get_hash(**kwargs: Any) -> str:

--- a/titiler/api/utils.py
+++ b/titiler/api/utils.py
@@ -15,9 +15,12 @@ from titiler.db.memcache import CacheLayer
 from starlette.requests import Request
 
 
-def get_cache(request: Request) -> CacheLayer:
+def get_cache(request: Request) -> Optional[CacheLayer]:
     """Get Memcached Layer."""
-    return request.state.get("cache")
+    try:
+        return request.state.cache
+    except AttributeError:
+        return None
 
 
 def get_hash(**kwargs: Any) -> str:


### PR DESCRIPTION
Use getattr when requesting state.cache to avoid errors when cache no cache is set.

If not using cache_middleware, request.state.cache is not set and causes an error in get_cache. This makes sure that get_cache uses getattr on request.state.