### PR TITLE
add mkdocs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,45 @@
+# titiler
+
+<p align="center">
+  <img src="https://user-images.githubusercontent.com/10407788/84913491-99c3ac80-b088-11ea-846d-75db9e3ab31c.jpg"/>
+  <p align="center">A lightweight Cloud Optimized GeoTIFF dynamic tile server.</p>
+</p>
+
+<p align="center">
+  <a href="https://circleci.com/gh/developmentseed/titiler" target="_blank">
+      <img src="https://circleci.com/gh/developmentseed/titiler.svg?style=svg" alt="Test">
+  </a>
+  <a href="https://codecov.io/gh/developmentseed/titiler" target="_blank">
+      <img src="https://codecov.io/gh/developmentseed/titiler/branch/master/graph/badge.svg" alt="Coverage">
+  </a>
+  <a href="https://github.com/developmentseed/titiler/blob/master/LICENSE" target="_blank">
+      <img src="https://img.shields.io/github/license/developmentseed/titiler.svg" alt="Downloads">
+  </a>
+</p>
+
+Titiler, pronounced **tee-tiler** (*ti* is the diminutive version of the french *petit* which means small), is lightweight service, which sole goal is to create map tiles dynamically from Cloud Optimized GeoTIFF [COG](cogeo.org).
+
+This project is the descendant of https://github.com/developmentseed/cogeo-tiler
+
+## Features
+
+- Multiple TileMatrixSets via [morecantile](https://github.com/developmentseed/morecantile). Default is set to WebMercatorQuad which is the usual Web Mercator projection used in most of Wep Map libraries.) (see [docs/TMS](/docs/TMS.md))
+- Cloud Optimized GeoTIFF support (see [docs/COG](/docs/COG.md))
+- SpatioTemporal Asset Catalog support (see [docs/STAC](/docs/STAC.md))
+- MosaicJSON support (Optional)
+- OGC WMTS support
+- Caching layer for tiles (Optional)
+- AWS Lambda / ECS deployement options
+
+## Installation
+```bash
+$ git clone https://github.com/developmentseed/titiler.git
+
+$ cd titiler && pip install -e .["server"]
+$ uvicorn titiler.main:app --reload
+```
+Or with Docker
+```
+$ docker-compose build
+$ docker-compose up 
+```

--- a/docs/titiler/advanced/custom_application.md
+++ b/docs/titiler/advanced/custom_application.md
@@ -1,0 +1,3 @@
+# Create your own app
+
+placeholder

--- a/docs/titiler/concepts/data_formats.md
+++ b/docs/titiler/concepts/data_formats.md
@@ -1,0 +1,3 @@
+# Data Formats
+
+placeholder

--- a/docs/titiler/concepts/dynamic_tiling.md
+++ b/docs/titiler/concepts/dynamic_tiling.md
@@ -1,0 +1,3 @@
+# Dynamic Tiling
+
+placeholder

--- a/docs/titiler/concepts/tile_matrix_sets.md
+++ b/docs/titiler/concepts/tile_matrix_sets.md
@@ -1,0 +1,3 @@
+# Tile Matrix Sets
+
+placeholder

--- a/docs/titiler/deployment/ecs.md
+++ b/docs/titiler/deployment/ecs.md
@@ -1,0 +1,3 @@
+# AWS ECS
+
+placeholder

--- a/docs/titiler/deployment/lambda.md
+++ b/docs/titiler/deployment/lambda.md
@@ -1,0 +1,3 @@
+# AWS Lambda
+
+placeholder

--- a/docs/titiler/deployment/settings.md
+++ b/docs/titiler/deployment/settings.md
@@ -1,0 +1,3 @@
+# Configuration/Settings
+
+placeholder

--- a/docs/titiler/endpoints/cog.md
+++ b/docs/titiler/endpoints/cog.md
@@ -1,0 +1,3 @@
+# Cloud Optimized GeoTiff
+
+placeholder

--- a/docs/titiler/endpoints/mosaic.md
+++ b/docs/titiler/endpoints/mosaic.md
@@ -1,0 +1,3 @@
+# Mosaic
+
+placeholder

--- a/docs/titiler/endpoints/stac.md
+++ b/docs/titiler/endpoints/stac.md
@@ -1,0 +1,3 @@
+# SpatioTemporal Asset Catalog
+
+placeholder

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,67 @@
+site_name: titiler
+site_description: Titiler is a lightweight service for creating map tiles from Cloud Optimized GeoTiff
+
+theme:
+  name: material
+  palette:
+    primary: indigo
+    scheme: default
+
+# TODO: Add edit_uri/site_uri
+
+repo_name: "developmentseed/titiler"
+repo_url: "https://github.com/developmentseed/titiler"
+
+extra:
+  social:
+    - icon: 'fontawesome/brands/github'
+      link: 'https://github.com/developmentseed'
+    - icon: 'fontawesome/brands/twitter'
+      link: 'https://twitter.com/developmentseed'
+
+
+nav:
+  - Titiler: "index.md"
+  - Concepts:
+      - "titiler/concepts/dynamic_tiling.md"
+      - "titiler/concepts/data_formats.md"
+      - "titiler/concepts/tile_matrix_sets.md"
+  - Endpoints:
+      - "titiler/endpoints/cog.md"
+      - "titiler/endpoints/mosaic.md"
+      - "titiler/endpoints/stac.md"
+  - Deployment:
+      - "titiler/deployment/settings.md"
+      - "titiler/deployment/ecs.md"
+      - "titiler/deployment/lambda.md"
+  - Advanced:
+      - "titiler/advanced/custom_application.md"
+
+
+# https://github.com/kylebarron/cogeo-mosaic/blob/mkdocs/mkdocs.yml#L50-L75
+markdown_extensions:
+    - admonition
+    - attr_list
+    - codehilite:
+        guess_lang: false
+    - def_list
+    - footnotes
+    - pymdownx.arithmatex
+    - pymdownx.betterem
+    - pymdownx.caret:
+        insert: false
+    - pymdownx.details
+    - pymdownx.emoji
+    - pymdownx.escapeall:
+        hardbreak: true
+        nbsp: true
+    - pymdownx.magiclink:
+        hide_protocol: true
+        repo_url_shortener: true
+    - pymdownx.smartsymbols
+    - pymdownx.superfences
+    - pymdownx.tasklist:
+        custom_checkbox: true
+    - pymdownx.tilde
+    - toc:
+        permalink: true

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,15 @@ inst_reqs = [
     "rio-tiler-crs==3.0b2",
 ]
 extra_reqs = {
-    "dev": ["pytest", "pytest-cov", "pytest-asyncio", "pre-commit", "requests"],
+    "dev": [
+        "pytest",
+        "pytest-cov",
+        "pytest-asyncio",
+        "pre-commit",
+        "requests",
+        "mkdocs",
+        "mkdocs-material",
+    ],
     "mosaic": ["cogeo-mosaic~=3.0a5"],
     "server": ["uvicorn", "click==7.0"],
     "lambda": ["mangum>=0.9.0"],


### PR DESCRIPTION
Add docs page with `mkdocs` (closes #60)

Currently all of the pages are empty, PRs against this branch to update pages are welcome.  The following pages need to be updated:
- [ ] `docs/titiler/advanced/custom_application.md `
- [ ] `docs/titiler/concepts/data_formats.md`
- [ ] `docs/titiler/concepts/dynamic_tiling.md`
- [ ] `docs/titiler/concepts/tile_matrix_sets.md`
- [ ] `docs/titiler/deployment/ecs.md`
- [ ] `docs/titiler/deployment/lambda.md`
- [ ] `docs/titiler/deployment/settings.md`
- [ ] `docs/titiler/endpoints/cog.md`
- [ ] `docs/titiler/endpoints/mosaic.md`
- [ ] `docs/titiler/endpoints/stac.md`

I've left the current docs in the `/docs` folder, I imagine the content from the current docs will be moved into the mkdocs pages.

## Index
![image](https://user-images.githubusercontent.com/40916268/88984138-751b4100-d292-11ea-854a-e95907eb81df.png)
