### PR TITLE
[WIP] move business logic out of api routes

### DIFF
--- a/titiler/clients/__init__.py
+++ b/titiler/clients/__init__.py
@@ -1,0 +1,1 @@
+"""titiler.clients"""

--- a/titiler/clients/base.py
+++ b/titiler/clients/base.py
@@ -27,9 +27,7 @@ class Tiler(COGReader, BaseTiler):
     """
 
     @classmethod
-    def create_from_request(
-        cls, request: Request
-    ) -> Generator["StacTiler", Request, None]:
+    def create_from_request(cls, request: Request) -> Generator["Tiler", Request, None]:
         """
         Create an instance of the class from a starlette request, used for dependency injection
         """

--- a/titiler/clients/base.py
+++ b/titiler/clients/base.py
@@ -1,0 +1,81 @@
+"""api clients."""
+
+import abc
+from typing import Dict, Generator
+
+from cogeo_mosaic.backends import BaseBackend as CogeoMosaicBackend
+from cogeo_mosaic.backends import MosaicBackend
+from rio_tiler.io import COGReader, STACReader
+
+from starlette.requests import Request
+
+
+class BaseTiler(abc.ABC):
+    """
+    Base class
+    """
+
+    @abc.abstractmethod
+    def get_bounds(self) -> Dict:
+        """Create /bounds API response"""
+        ...
+
+
+class Tiler(COGReader, BaseTiler):
+    """
+    COG tiler
+    """
+
+    @classmethod
+    def create_from_request(
+        cls, request: Request
+    ) -> Generator["StacTiler", Request, None]:
+        """
+        Create an instance of the class from a starlette request, used for dependency injection
+        """
+        with cls(filepath=request.query_params["url"]) as tiler:
+            yield tiler
+
+    def get_bounds(self) -> Dict:
+        """Create /bounds API response"""
+        return {"bounds": self.bounds}
+
+
+class StacTiler(STACReader, BaseTiler):
+    """
+    STAC tiler
+    """
+
+    @classmethod
+    def create_from_request(
+        cls, request: Request
+    ) -> Generator["StacTiler", Request, None]:
+        """
+        Create an instance of the class from a starlette request, used for dependency injection
+        """
+        with cls(filepath=request.query_params["url"]) as tiler:
+            yield tiler
+
+    def get_bounds(self) -> Dict:
+        """Create /bounds API response"""
+        return {"bounds": self.bounds}
+
+
+class MosaicTiler(CogeoMosaicBackend, BaseTiler):
+    """
+    Mosaic tiler
+    """
+
+    @classmethod
+    def create_from_request(
+        cls, request: Request
+    ) -> Generator["MosaicTiler", Request, None]:
+        """
+        Create an instance of the class from a starlette request, used for dependency injection
+        """
+        with MosaicBackend(url=request.query_params["url"]) as mosaic:
+            yield mosaic
+
+    def get_bounds(self) -> Dict:
+        """Create /bounds API response"""
+        return {"bounds": self.mosaic_def.bounds}

--- a/titiler/endpoints/cog.py
+++ b/titiler/endpoints/cog.py
@@ -10,6 +10,7 @@ from rio_cogeo.cogeo import cog_info as rio_cogeo_info
 from rio_tiler_crs import COGReader
 
 from titiler import utils
+from titiler.clients.base import Tiler
 from titiler.db.memcache import CacheLayer
 from titiler.dependencies import (
     CommonImageParams,
@@ -49,10 +50,12 @@ def cog_validate(
     response_model=cogBounds,
     responses={200: {"description": "Return the bounds of the COG."}},
 )
-async def cog_bounds(url: str = Query(..., description="Cloud Optimized GeoTIFF URL.")):
+async def cog_bounds(
+    url: str = Query(..., description="Cloud Optimized GeoTIFF URL."),
+    tiler: Tiler = Depends(Tiler.create_from_request),
+):
     """Return the bounds of the COG."""
-    with COGReader(url) as cog:
-        return {"bounds": cog.bounds}
+    return tiler.get_bounds()
 
 
 @router.get(

--- a/titiler/endpoints/mosaic.py
+++ b/titiler/endpoints/mosaic.py
@@ -13,6 +13,7 @@ from rio_tiler.constants import MAX_THREADS
 from rio_tiler_crs.cogeo import geotiff_options
 
 from titiler import utils
+from titiler.clients.base import MosaicTiler
 from titiler.dependencies import CommonTileParams, MosaicPath
 from titiler.errors import BadRequestError, TileNotFoundError
 from titiler.models.cog import cogBounds
@@ -89,10 +90,12 @@ def update_mosaicjson(body: UpdateMosaicJSON):
     response_model=cogBounds,
     responses={200: {"description": "Return the bounds of the MosaicJSON"}},
 )
-def mosaicjson_bounds(mosaic_path: str = Depends(MosaicPath)):
+def mosaicjson_bounds(
+    mosaic_path: str = Depends(MosaicPath),
+    tiler: MosaicTiler = Depends(MosaicTiler.create_from_request),
+):
     """Read MosaicJSON bounds"""
-    with MosaicBackend(mosaic_path) as mosaic:
-        return {"bounds": mosaic.mosaic_def.bounds}
+    return tiler.get_bounds()
 
 
 @router.get("/info", response_model=mosaicInfo)

--- a/titiler/endpoints/stac.py
+++ b/titiler/endpoints/stac.py
@@ -10,6 +10,7 @@ from rio_tiler.errors import MissingAssets
 from rio_tiler_crs import STACReader
 
 from titiler import utils
+from titiler.clients.base import StacTiler
 from titiler.db.memcache import CacheLayer
 from titiler.dependencies import (
     CommonImageParams,
@@ -37,10 +38,12 @@ router = APIRouter()
     response_model=cogBounds,
     responses={200: {"description": "Return the bounds of the STAC item."}},
 )
-async def stac_bounds(url: str = Query(..., description="STAC item URL.")):
+async def stac_bounds(
+    url: str = Query(..., description="STAC item URL."),
+    tiler: StacTiler = Depends(StacTiler.create_from_request),
+):
     """Return the bounds of the STAC item."""
-    with STACReader(url) as stac:
-        return {"bounds": stac.bounds}
+    return tiler.get_bounds()
 
 
 @router.get(


### PR DESCRIPTION
This PR moves business logic out of api routes.  This is the first step in transforming titiler from an application to a python library which builds an application.