### PR TITLE
support Non TMS Readers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,26 @@ stac = TilerFactory(reader=STACReader, add_asset_deps=True, router_prefix="stac"
 app.include_router(cog.router, prefix="/stac", tags=["Cloud Optimized GeoTIFF"])
 ```
 
+### Readers / TileMatrixSets
+
+The tiler factory will automatically fallback to WebMercator TMS if the `Reader` doesn't support TMS.
+
+```python
+from rio_tiler_crs import COGReader as COGReaderWithTMS
+from rio_tiler.io import COGReader as COGReaderNoTMS
+
+from titiler.endpoints import factory
+from titiler.dependencies import WebMercatorTMSParams, TMSParams
+
+app = factory.TilerFactory(reader=COGReaderWithTMS)
+assert app.reader_supports_tms
+assert app.tms_dependency == TMSParams
+
+app = factory.TilerFactory(reader=COGReaderNoTMS)
+assert not app.reader_supports_tms
+assert app.tms_dependency == WebMercatorTMSParams
+```
+
 ### Other changes
 
 * add mosaic support  (#17 author @geospatial-jeff)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,9 +13,9 @@ from starlette.testclient import TestClient
 DATA_DIR = os.path.join(os.path.dirname(__file__), "fixtures")
 
 
-@pytest.fixture(autouse=True)
-def app(monkeypatch) -> TestClient:
-    """Make sure we use monkeypatch env."""
+@pytest.fixture
+def set_env(monkeypatch):
+    """Set Env variables."""
     monkeypatch.setenv("AWS_ACCESS_KEY_ID", "jqt")
     monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "rde")
     monkeypatch.setenv("AWS_DEFAULT_REGION", "us-west-2")
@@ -25,6 +25,10 @@ def app(monkeypatch) -> TestClient:
     monkeypatch.setenv("DEFAULT_MOSAIC_BACKEND", "file://")
     monkeypatch.setenv("DEFAULT_MOSAIC_HOST", DATA_DIR)
 
+
+@pytest.fixture(autouse=True)
+def app(set_env) -> TestClient:
+    """Create App."""
     from titiler.main import app
 
     return TestClient(app)

--- a/tests/test_factories.py
+++ b/tests/test_factories.py
@@ -1,0 +1,53 @@
+# """Test TiTiler Tiler Factories."""
+
+from rio_tiler.io import COGReader as COGReaderNoTMS
+from rio_tiler_crs import COGReader as COGReaderWithTMS
+
+
+def test_TilerFactory(set_env):
+    """Test TilerFactory class."""
+    from titiler.dependencies import (
+        AssetsParams,
+        DefaultDependency,
+        TMSParams,
+        WebMercatorTMSParams,
+    )
+    from titiler.endpoints import factory
+
+    app = factory.TilerFactory(reader=COGReaderWithTMS)
+    assert len(app.router.routes) == 19
+
+    assert app.reader_supports_tms
+    assert app.tms_dependency == TMSParams
+    assert app.options == DefaultDependency
+    assert not app.router_prefix
+
+    app = factory.TilerFactory(reader=COGReaderNoTMS)
+    assert not app.reader_supports_tms
+    assert app.tms_dependency == WebMercatorTMSParams
+
+    app = factory.TilerFactory(
+        reader=COGReaderWithTMS,
+        add_asset_deps=True,
+        router_prefix="cog",
+        add_preview=False,
+        add_part=False,
+    )
+    assert len(app.router.routes) == 16
+    assert app.options == AssetsParams
+    for route in app.router.routes:
+        assert route.name.startswith("cog_")
+
+
+def test_MosaicTilerFactory(set_env):
+    """Test MosaicTilerFactory class."""
+    from titiler.dependencies import AssetsParams, WebMercatorTMSParams
+    from titiler.endpoints import factory
+
+    app = factory.MosaicTilerFactory()
+    assert len(app.router.routes) == 18
+    assert app.tms_dependency == WebMercatorTMSParams
+
+    app = factory.MosaicTilerFactory(add_create=False, add_update=False)
+    assert len(app.router.routes) == 16
+    assert app.options == AssetsParams

--- a/titiler/dependencies.py
+++ b/titiler/dependencies.py
@@ -42,11 +42,11 @@ ColorMapNames = Enum(  # type: ignore
 ResamplingNames = Enum(  # type: ignore
     "ResamplingNames", [(r.name, r.name) for r in Resampling]
 )
+WebMercatorTileMatrixSetName = Enum(  # type: ignore
+    "WebMercatorTileMatrixSetName", [("WebMercatorQuad", "WebMercatorQuad")]
+)
 TileMatrixSetNames = Enum(  # type: ignore
     "TileMatrixSetNames", [(a, a) for a in sorted(morecantile.tms.list())]
-)
-MosaicTileMatrixSetNames = Enum(  # type: ignore
-    "MosaicTileMatrixSetNames", [("WebMercatorQuad", "WebMercatorQuad")]
 )
 
 
@@ -55,9 +55,9 @@ async def request_hash(request: Request) -> str:
     return get_hash(**dict(request.query_params), **request.path_params)
 
 
-def TMSParams(
-    TileMatrixSetId: TileMatrixSetNames = Query(
-        TileMatrixSetNames.WebMercatorQuad,  # type: ignore
+def WebMercatorTMSParams(
+    TileMatrixSetId: WebMercatorTileMatrixSetName = Query(
+        WebMercatorTileMatrixSetName.WebMercatorQuad,  # type: ignore
         description="TileMatrixSet Name (default: 'WebMercatorQuad')",
     )
 ) -> morecantile.TileMatrixSet:
@@ -65,9 +65,9 @@ def TMSParams(
     return morecantile.tms.get(TileMatrixSetId.name)
 
 
-def MosaicTMSParams(
-    TileMatrixSetId: MosaicTileMatrixSetNames = Query(
-        MosaicTileMatrixSetNames.WebMercatorQuad,  # type: ignore
+def TMSParams(
+    TileMatrixSetId: TileMatrixSetNames = Query(
+        TileMatrixSetNames.WebMercatorQuad,  # type: ignore
         description="TileMatrixSet Name (default: 'WebMercatorQuad')",
     )
 ) -> morecantile.TileMatrixSet:


### PR DESCRIPTION

The tiler factory will automatically fallback to WebMercator TMS if the `Reader` doesn't support TMS.

```python
from rio_tiler_crs import COGReader as COGReaderWithTMS
from rio_tiler.io import COGReader as COGReaderNoTMS

from titiler.endpoints import factory
from titiler.dependencies import WebMercatorTMSParams, TMSParams


app = factory.TilerFactory(reader=COGReaderWithTMS)
assert app.reader_supports_tms
assert app.tms_dependency == TMSParams

app = factory.TilerFactory(reader=COGReaderNoTMS)
assert not app.reader_supports_tms
assert app.tms_dependency == WebMercatorTMSParams
```