### PR TITLE
Default to web mercator

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,26 @@ stac = TilerFactory(reader=STACReader, add_asset_deps=True, router_prefix="stac"
 app.include_router(cog.router, prefix="/stac", tags=["Cloud Optimized GeoTIFF"])
 ```
 
+### Readers / TileMatrixSets
+
+The tiler factory will automatically fallback to WebMercator TMS if the `Reader` doesn't support TMS.
+
+```python
+from rio_tiler_crs import COGReader as COGReaderWithTMS
+from rio_tiler.io import COGReader as COGReaderNoTMS
+
+from titiler.endpoints import factory
+from titiler.dependencies import WebMercatorTMSParams, TMSParams
+
+app = factory.TilerFactory(reader=COGReaderWithTMS)
+assert app.reader_supports_tms
+assert app.tms_dependency == TMSParams
+
+app = factory.TilerFactory(reader=COGReaderNoTMS)
+assert not app.reader_supports_tms
+assert app.tms_dependency == WebMercatorTMSParams
+```
+
 ### Other changes
 
 * add mosaic support  (#17 author @geospatial-jeff)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # Release Notes
 
-## 0.0.1 (2020-08-27)
+## 0.1.0 (2020-08-27)
 
 **First release on pypi**
 
@@ -10,7 +10,7 @@ For this release we created new Tiler Factories class which handle creation of F
 
 ```python
 from titiler.endpoints.factory import TilerFactory
-from rio_tiler_crs import COGReader, STACReader
+from rio_tiler.io import COGReader, STACReader
 
 from fastapi import FastAPI
 
@@ -23,24 +23,32 @@ stac = TilerFactory(reader=STACReader, add_asset_deps=True, router_prefix="stac"
 app.include_router(cog.router, prefix="/stac", tags=["Cloud Optimized GeoTIFF"])
 ```
 
-### Readers / TileMatrixSets
+#### Readers / TileMatrixSets
 
-The tiler factory will automatically fallback to WebMercator TMS if the `Reader` doesn't support TMS.
+The `titiler.endpoints.factory.TilerFactory` class will create a tiler with `Web Mercator` as uniq supported Tile Matrix Set.
 
+For other TMS support, tiler needs to be created with `titiler.endpoints.factory.TMSTilerFactory` and with a TMS friendly reader (e.g `rio_tiler_crs.COGReader`).
+
+**Simple tiler with only Web Mercator support**
 ```python
-from rio_tiler_crs import COGReader as COGReaderWithTMS
-from rio_tiler.io import COGReader as COGReaderNoTMS
+from rio_tiler.io import COGReader
 
 from titiler.endpoints import factory
-from titiler.dependencies import WebMercatorTMSParams, TMSParams
+from titiler.dependencies import WebMercatorTMSParams
 
-app = factory.TilerFactory(reader=COGReaderWithTMS)
-assert app.reader_supports_tms
-assert app.tms_dependency == TMSParams
-
-app = factory.TilerFactory(reader=COGReaderNoTMS)
-assert not app.reader_supports_tms
+app = factory.TilerFactory(reader=COGReader)
 assert app.tms_dependency == WebMercatorTMSParams
+```
+
+**tiler with more morecantile's TMS support**
+```python
+from rio_tiler_crs import COGReader
+
+from titiler.endpoints import factory
+from titiler.dependencies import TMSParams
+
+app = factory.TMSTilerFactory(reader=COGReader)
+assert app.tms_dependency == TMSParams
 ```
 
 ### Other changes
@@ -56,7 +64,9 @@ assert app.tms_dependency == WebMercatorTMSParams
 * Add 'X-Assets' in response headers for mosaic tiles (#51)
 * add cog validation via rio-cogeo (co-author with @geospatial-jeff, #37)
 
-### Breaking changes 
+### Breaking changes
+
+* default tiler to Web Mercator only
 * removed cache layer for tiles
 * updated html templates
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,7 +40,7 @@ app = factory.TilerFactory(reader=COGReader)
 assert app.tms_dependency == WebMercatorTMSParams
 ```
 
-**tiler with more morecantile's TMS support**
+**Tiler with more TMS support (from morecantile)**
 ```python
 from rio_tiler_crs import COGReader
 

--- a/docs/concepts/tiler_factories.md
+++ b/docs/concepts/tiler_factories.md
@@ -49,6 +49,10 @@ Router created with the Tiler Factories will have basic routes:
 
 placeholder
 
+### TMSTilerFactory
+
+placeholder
+
 ### MosaicTilerFactory
 
 placeholder

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ extra_reqs = {
 
 setup(
     name="titiler",
-    version="3.0.0",
+    version="0.1.0",
     description=u"",
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -47,6 +47,7 @@ setup(
         "License :: OSI Approved :: BSD License",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
     keywords="COG STAC MosaicJSON FastAPI Serverless",
     author=u"Vincent Sarago",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,9 +13,9 @@ from starlette.testclient import TestClient
 DATA_DIR = os.path.join(os.path.dirname(__file__), "fixtures")
 
 
-@pytest.fixture(autouse=True)
-def app(monkeypatch) -> TestClient:
-    """Make sure we use monkeypatch env."""
+@pytest.fixture
+def set_env(monkeypatch):
+    """Set Env variables."""
     monkeypatch.setenv("AWS_ACCESS_KEY_ID", "jqt")
     monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "rde")
     monkeypatch.setenv("AWS_DEFAULT_REGION", "us-west-2")
@@ -25,6 +25,10 @@ def app(monkeypatch) -> TestClient:
     monkeypatch.setenv("DEFAULT_MOSAIC_BACKEND", "file://")
     monkeypatch.setenv("DEFAULT_MOSAIC_HOST", DATA_DIR)
 
+
+@pytest.fixture(autouse=True)
+def app(set_env) -> TestClient:
+    """Create App."""
     from titiler.main import app
 
     return TestClient(app)

--- a/tests/test_factories.py
+++ b/tests/test_factories.py
@@ -1,0 +1,53 @@
+# """Test TiTiler Tiler Factories."""
+
+from rio_tiler.io import COGReader as COGReaderNoTMS
+from rio_tiler_crs import COGReader as COGReaderWithTMS
+
+
+def test_TilerFactory(set_env):
+    """Test TilerFactory class."""
+    from titiler.dependencies import (
+        AssetsParams,
+        DefaultDependency,
+        TMSParams,
+        WebMercatorTMSParams,
+    )
+    from titiler.endpoints import factory
+
+    app = factory.TilerFactory(reader=COGReaderWithTMS)
+    assert len(app.router.routes) == 19
+
+    assert app.reader_supports_tms
+    assert app.tms_dependency == TMSParams
+    assert app.options == DefaultDependency
+    assert not app.router_prefix
+
+    app = factory.TilerFactory(reader=COGReaderNoTMS)
+    assert not app.reader_supports_tms
+    assert app.tms_dependency == WebMercatorTMSParams
+
+    app = factory.TilerFactory(
+        reader=COGReaderWithTMS,
+        add_asset_deps=True,
+        router_prefix="cog",
+        add_preview=False,
+        add_part=False,
+    )
+    assert len(app.router.routes) == 16
+    assert app.options == AssetsParams
+    for route in app.router.routes:
+        assert route.name.startswith("cog_")
+
+
+def test_MosaicTilerFactory(set_env):
+    """Test MosaicTilerFactory class."""
+    from titiler.dependencies import AssetsParams, WebMercatorTMSParams
+    from titiler.endpoints import factory
+
+    app = factory.MosaicTilerFactory()
+    assert len(app.router.routes) == 18
+    assert app.tms_dependency == WebMercatorTMSParams
+
+    app = factory.MosaicTilerFactory(add_create=False, add_update=False)
+    assert len(app.router.routes) == 16
+    assert app.options == AssetsParams

--- a/tests/test_factories.py
+++ b/tests/test_factories.py
@@ -14,20 +14,18 @@ def test_TilerFactory(set_env):
     )
     from titiler.endpoints import factory
 
-    app = factory.TilerFactory(reader=COGReaderWithTMS)
+    app = factory.TMSTilerFactory(reader=COGReaderWithTMS)
     assert len(app.router.routes) == 19
 
-    assert app.reader_supports_tms
     assert app.tms_dependency == TMSParams
     assert app.options == DefaultDependency
     assert not app.router_prefix
 
     app = factory.TilerFactory(reader=COGReaderNoTMS)
-    assert not app.reader_supports_tms
     assert app.tms_dependency == WebMercatorTMSParams
 
     app = factory.TilerFactory(
-        reader=COGReaderWithTMS,
+        reader=COGReaderNoTMS,
         add_asset_deps=True,
         router_prefix="cog",
         add_preview=False,

--- a/titiler/dependencies.py
+++ b/titiler/dependencies.py
@@ -225,9 +225,6 @@ class TileParams(CommonParams):
     color_map: Optional[ColorMapNames] = Query(
         None, description="rio-tiler's colormap name"
     )
-    resampling_method: ResamplingNames = Query(
-        ResamplingNames.nearest, description="Resampling method."  # type: ignore
-    )
     colormap: Optional[Dict[int, Tuple[int, int, int, int]]] = field(init=False)
 
     def __post_init__(self):

--- a/titiler/dependencies.py
+++ b/titiler/dependencies.py
@@ -42,11 +42,11 @@ ColorMapNames = Enum(  # type: ignore
 ResamplingNames = Enum(  # type: ignore
     "ResamplingNames", [(r.name, r.name) for r in Resampling]
 )
+WebMercatorTileMatrixSetName = Enum(  # type: ignore
+    "WebMercatorTileMatrixSetName", [("WebMercatorQuad", "WebMercatorQuad")]
+)
 TileMatrixSetNames = Enum(  # type: ignore
     "TileMatrixSetNames", [(a, a) for a in sorted(morecantile.tms.list())]
-)
-MosaicTileMatrixSetNames = Enum(  # type: ignore
-    "MosaicTileMatrixSetNames", [("WebMercatorQuad", "WebMercatorQuad")]
 )
 
 
@@ -55,9 +55,9 @@ async def request_hash(request: Request) -> str:
     return get_hash(**dict(request.query_params), **request.path_params)
 
 
-def TMSParams(
-    TileMatrixSetId: TileMatrixSetNames = Query(
-        TileMatrixSetNames.WebMercatorQuad,  # type: ignore
+def WebMercatorTMSParams(
+    TileMatrixSetId: WebMercatorTileMatrixSetName = Query(
+        WebMercatorTileMatrixSetName.WebMercatorQuad,  # type: ignore
         description="TileMatrixSet Name (default: 'WebMercatorQuad')",
     )
 ) -> morecantile.TileMatrixSet:
@@ -65,9 +65,9 @@ def TMSParams(
     return morecantile.tms.get(TileMatrixSetId.name)
 
 
-def MosaicTMSParams(
-    TileMatrixSetId: MosaicTileMatrixSetNames = Query(
-        MosaicTileMatrixSetNames.WebMercatorQuad,  # type: ignore
+def TMSParams(
+    TileMatrixSetId: TileMatrixSetNames = Query(
+        TileMatrixSetNames.WebMercatorQuad,  # type: ignore
         description="TileMatrixSet Name (default: 'WebMercatorQuad')",
     )
 ) -> morecantile.TileMatrixSet:

--- a/titiler/endpoints/cog.py
+++ b/titiler/endpoints/cog.py
@@ -2,10 +2,11 @@
 
 import pkg_resources
 from rio_cogeo.cogeo import cog_info as rio_cogeo_info
+from rio_tiler_crs import COGReader
 
 from ..dependencies import PathParams
 from ..models.cog import RioCogeoInfo
-from .factory import TilerFactory
+from .factory import TMSTilerFactory
 
 from fastapi import Depends, Query
 
@@ -17,7 +18,7 @@ template_dir = pkg_resources.resource_filename("titiler", "templates")
 templates = Jinja2Templates(directory=template_dir)
 
 # Create Router using Tiler Factory
-cog = TilerFactory(router_prefix="cog")
+cog = TMSTilerFactory(reader=COGReader, router_prefix="cog")
 
 
 @cog.router.get("/validate", response_model=RioCogeoInfo)

--- a/titiler/endpoints/factory.py
+++ b/titiler/endpoints/factory.py
@@ -1,7 +1,6 @@
 """TiTiler Router factories."""
 
 import abc
-import inspect
 import os
 from dataclasses import dataclass, field
 from typing import Callable, Dict, List, Optional, Type, Union
@@ -13,8 +12,8 @@ from cogeo_mosaic.mosaic import MosaicJSON
 from cogeo_mosaic.utils import get_footprints
 from rasterio.transform import from_bounds
 from rio_tiler.constants import MAX_THREADS
-from rio_tiler.io import BaseReader
-from rio_tiler_crs import COGReader
+from rio_tiler.io import BaseReader, COGReader, MultiBaseReader
+from rio_tiler_crs import COGReader as TMSCOGReader
 
 from .. import utils
 from ..dependencies import (
@@ -50,23 +49,26 @@ from starlette.templating import Jinja2Templates
 template_dir = pkg_resources.resource_filename("titiler", "templates")
 templates = Jinja2Templates(directory=template_dir)
 
+default_readers_type = Union[Type[BaseReader], Type[MultiBaseReader]]
+
 
 # ref: https://github.com/python/mypy/issues/5374
 @dataclass  # type: ignore
 class BaseFactory(metaclass=abc.ABCMeta):
     """BaseTiler Factory."""
 
-    reader: Type[BaseReader] = COGReader
+    reader: default_readers_type = field(default=COGReader)
     reader_options: Dict = field(default_factory=dict)
 
     # FastAPI router
     router: APIRouter = field(default_factory=APIRouter)
 
     # Endpoint Dependencies
-    tms_dependency: Callable = field(default=TMSParams)
     path_dependency: Type[PathParams] = field(default=PathParams)
     tiles_dependency: Type[TileParams] = field(default=TileParams)
     point_dependency: Type[PointParams] = field(default=PointParams)
+
+    tms_dependency: Callable = WebMercatorTMSParams
 
     # Add `assets` options in endpoint
     add_asset_deps: bool = False
@@ -79,13 +81,6 @@ class BaseFactory(metaclass=abc.ABCMeta):
 
     def __post_init__(self):
         """Post Init: register route and configure specific options."""
-        self.reader_supports_tms = (
-            True if inspect.signature(self.reader).parameters.get("tms") else False
-        )
-        # If the reader doesn't support TileMatrixSet we fallback to only WebMercator TMS
-        if not self.reader_supports_tms:
-            self.tms_dependency = WebMercatorTMSParams
-
         self.options = AssetsParams if self.add_asset_deps else DefaultDependency
 
         if self.router_prefix:
@@ -282,12 +277,7 @@ class TilerFactory(BaseFactory):
 
             with utils.Timer() as t:
                 reader = src_path.reader or self.reader
-                reader_options = (
-                    {**self.reader_options, "tms": tms}
-                    if self.reader_supports_tms
-                    else self.reader_options
-                )
-                with reader(src_path.url, **reader_options) as src_dst:
+                with reader(src_path.url, **self.reader_options) as src_dst:
                     tile, mask = src_dst.tile(
                         x,
                         y,
@@ -394,12 +384,7 @@ class TilerFactory(BaseFactory):
             tiles_url += f"?{qs}"
 
             reader = src_path.reader or self.reader
-            reader_options = (
-                {**self.reader_options, "tms": tms}
-                if self.reader_supports_tms
-                else self.reader_options
-            )
-            with reader(src_path.url, **reader_options) as src_dst:
+            with reader(src_path.url, **self.reader_options) as src_dst:
                 center = list(src_dst.center)
                 if minzoom:
                     center[-1] = minzoom
@@ -463,12 +448,7 @@ class TilerFactory(BaseFactory):
             tiles_endpoint += f"?{qs}"
 
             reader = src_path.reader or self.reader
-            reader_options = (
-                {**self.reader_options, "tms": tms}
-                if self.reader_supports_tms
-                else self.reader_options
-            )
-            with reader(src_path.url, **reader_options) as src_dst:
+            with reader(src_path.url, **self.reader_options) as src_dst:
                 bounds = src_dst.bounds
                 minzoom = minzoom if minzoom is not None else src_dst.minzoom
                 maxzoom = maxzoom if maxzoom is not None else src_dst.maxzoom
@@ -685,6 +665,271 @@ class TilerFactory(BaseFactory):
 
 
 @dataclass
+class TMSTilerFactory(TilerFactory):
+    """Tiler Factory with TMS."""
+
+    reader: default_readers_type = field(default=TMSCOGReader)
+    tms_dependency: Callable = TMSParams
+
+    ############################################################################
+    # /tiles
+    ############################################################################
+    def _tile(self):  # noqa: C901
+        tile_endpoint_params = img_endpoint_params.copy()
+        tile_endpoint_params["name"] = f"{self.router_prefix}tile"
+
+        @self.router.get(r"/tiles/{z}/{x}/{y}", **tile_endpoint_params)
+        @self.router.get(r"/tiles/{z}/{x}/{y}.{format}", **tile_endpoint_params)
+        @self.router.get(r"/tiles/{z}/{x}/{y}@{scale}x", **tile_endpoint_params)
+        @self.router.get(
+            r"/tiles/{z}/{x}/{y}@{scale}x.{format}", **tile_endpoint_params
+        )
+        @self.router.get(
+            r"/tiles/{TileMatrixSetId}/{z}/{x}/{y}", **tile_endpoint_params
+        )
+        @self.router.get(
+            r"/tiles/{TileMatrixSetId}/{z}/{x}/{y}.{format}", **tile_endpoint_params
+        )
+        @self.router.get(
+            r"/tiles/{TileMatrixSetId}/{z}/{x}/{y}@{scale}x", **tile_endpoint_params
+        )
+        @self.router.get(
+            r"/tiles/{TileMatrixSetId}/{z}/{x}/{y}@{scale}x.{format}",
+            **tile_endpoint_params,
+        )
+        def tile(
+            z: int = Path(..., ge=0, le=30, description="Mercator tiles's zoom level"),
+            x: int = Path(..., description="Mercator tiles's column"),
+            y: int = Path(..., description="Mercator tiles's row"),
+            tms=Depends(self.tms_dependency),
+            scale: int = Query(
+                1, gt=0, lt=4, description="Tile size scale. 1=256x256, 2=512x512..."
+            ),
+            format: ImageType = Query(
+                None, description="Output image type. Default is auto."
+            ),
+            src_path=Depends(self.path_dependency),
+            params=Depends(self.tiles_dependency),
+            options=Depends(self.options),
+        ):
+            """Create map tile from a dataset."""
+            timings = []
+            headers: Dict[str, str] = {}
+
+            tilesize = scale * 256
+
+            with utils.Timer() as t:
+                reader = src_path.reader or self.reader
+                with reader(src_path.url, tms=tms, **self.reader_options) as src_dst:
+                    tile, mask = src_dst.tile(
+                        x,
+                        y,
+                        z,
+                        tilesize=tilesize,
+                        indexes=params.indexes,
+                        expression=params.expression,
+                        nodata=params.nodata,
+                        resampling_method=params.resampling_method.name,
+                        **options.kwargs,
+                    )
+                    colormap = params.colormap or getattr(src_dst, "colormap", None)
+
+            timings.append(("Read", t.elapsed))
+
+            if not format:
+                format = ImageType.jpg if mask.all() else ImageType.png
+
+            with utils.Timer() as t:
+                tile = utils.postprocess(
+                    tile,
+                    mask,
+                    rescale=params.rescale,
+                    color_formula=params.color_formula,
+                )
+            timings.append(("Post-process", t.elapsed))
+
+            bounds = tms.xy_bounds(x, y, z)
+            dst_transform = from_bounds(*bounds, tilesize, tilesize)
+            with utils.Timer() as t:
+                content = utils.reformat(
+                    tile,
+                    mask,
+                    format,
+                    colormap=colormap,
+                    transform=dst_transform,
+                    crs=tms.crs,
+                )
+            timings.append(("Format", t.elapsed))
+
+            if timings:
+                headers["X-Server-Timings"] = "; ".join(
+                    [
+                        "{} - {:0.2f}".format(name, time * 1000)
+                        for (name, time) in timings
+                    ]
+                )
+
+            return Response(
+                content, media_type=ImageMimeTypes[format.value].value, headers=headers,
+            )
+
+        @self.router.get(
+            "/tilejson.json",
+            response_model=TileJSON,
+            responses={200: {"description": "Return a tilejson"}},
+            response_model_exclude_none=True,
+            name=f"{self.router_prefix}tilejson",
+        )
+        @self.router.get(
+            "/{TileMatrixSetId}/tilejson.json",
+            response_model=TileJSON,
+            responses={200: {"description": "Return a tilejson"}},
+            response_model_exclude_none=True,
+            name=f"{self.router_prefix}tilejson",
+        )
+        def tilejson(
+            request: Request,
+            tms=Depends(self.tms_dependency),
+            src_path=Depends(self.path_dependency),
+            tile_format: Optional[ImageType] = Query(
+                None, description="Output image type. Default is auto."
+            ),
+            tile_scale: int = Query(
+                1, gt=0, lt=4, description="Tile size scale. 1=256x256, 2=512x512..."
+            ),
+            minzoom: Optional[int] = Query(
+                None, description="Overwrite default minzoom."
+            ),
+            maxzoom: Optional[int] = Query(
+                None, description="Overwrite default maxzoom."
+            ),
+        ):
+            """Return TileJSON document for a dataset."""
+            kwargs = {
+                "z": "{z}",
+                "x": "{x}",
+                "y": "{y}",
+                "scale": tile_scale,
+                "TileMatrixSetId": tms.identifier,
+            }
+            if tile_format:
+                kwargs["format"] = tile_format.value
+
+            q = dict(request.query_params)
+            q.pop("TileMatrixSetId", None)
+            q.pop("tile_format", None)
+            q.pop("tile_scale", None)
+            q.pop("minzoom", None)
+            q.pop("maxzoom", None)
+            qs = urlencode(list(q.items()))
+
+            tiles_url = request.url_for(f"{self.router_prefix}tile", **kwargs)
+            tiles_url += f"?{qs}"
+
+            reader = src_path.reader or self.reader
+            with reader(src_path.url, tms=tms, **self.reader_options) as src_dst:
+                center = list(src_dst.center)
+                if minzoom:
+                    center[-1] = minzoom
+                tjson = {
+                    "bounds": src_dst.bounds,
+                    "center": tuple(center),
+                    "minzoom": minzoom if minzoom is not None else src_dst.minzoom,
+                    "maxzoom": maxzoom if maxzoom is not None else src_dst.maxzoom,
+                    "name": os.path.basename(src_path.url),
+                    "tiles": [tiles_url],
+                }
+
+            return tjson
+
+        @self.router.get(
+            "/WMTSCapabilities.xml",
+            response_class=XMLResponse,
+            name=f"{self.router_prefix}wmts",
+        )
+        @self.router.get(
+            "/{TileMatrixSetId}/WMTSCapabilities.xml",
+            response_class=XMLResponse,
+            name=f"{self.router_prefix}wmts",
+        )
+        def wmts(
+            request: Request,
+            tms=Depends(self.tms_dependency),
+            src_path=Depends(self.path_dependency),
+            tile_format: ImageType = Query(
+                ImageType.png, description="Output image type. Default is png."
+            ),
+            tile_scale: int = Query(
+                1, gt=0, lt=4, description="Tile size scale. 1=256x256, 2=512x512..."
+            ),
+            minzoom: Optional[int] = Query(
+                None, description="Overwrite default minzoom."
+            ),
+            maxzoom: Optional[int] = Query(
+                None, description="Overwrite default maxzoom."
+            ),
+        ):
+            """OGC WMTS endpoint."""
+            kwargs = {
+                "z": "{TileMatrix}",
+                "x": "{TileCol}",
+                "y": "{TileRow}",
+                "scale": tile_scale,
+                "format": tile_format.value,
+                "TileMatrixSetId": tms.identifier,
+            }
+            tiles_endpoint = request.url_for(f"{self.router_prefix}tile", **kwargs)
+            q = dict(request.query_params)
+            q.pop("TileMatrixSetId", None)
+            q.pop("tile_format", None)
+            q.pop("tile_scale", None)
+            q.pop("minzoom", None)
+            q.pop("maxzoom", None)
+            q.pop("SERVICE", None)
+            q.pop("REQUEST", None)
+            qs = urlencode(list(q.items()))
+            tiles_endpoint += f"?{qs}"
+
+            reader = src_path.reader or self.reader
+            with reader(src_path.url, tms=tms, **self.reader_options) as src_dst:
+                bounds = src_dst.bounds
+                minzoom = minzoom if minzoom is not None else src_dst.minzoom
+                maxzoom = maxzoom if maxzoom is not None else src_dst.maxzoom
+
+            media_type = ImageMimeTypes[tile_format.value].value
+
+            tileMatrix = []
+            for zoom in range(minzoom, maxzoom + 1):
+                matrix = tms.matrix(zoom)
+                tm = f"""
+                        <TileMatrix>
+                            <ows:Identifier>{matrix.identifier}</ows:Identifier>
+                            <ScaleDenominator>{matrix.scaleDenominator}</ScaleDenominator>
+                            <TopLeftCorner>{matrix.topLeftCorner[0]} {matrix.topLeftCorner[1]}</TopLeftCorner>
+                            <TileWidth>{matrix.tileWidth}</TileWidth>
+                            <TileHeight>{matrix.tileHeight}</TileHeight>
+                            <MatrixWidth>{matrix.matrixWidth}</MatrixWidth>
+                            <MatrixHeight>{matrix.matrixHeight}</MatrixHeight>
+                        </TileMatrix>"""
+                tileMatrix.append(tm)
+
+            return templates.TemplateResponse(
+                "wmts.xml",
+                {
+                    "request": request,
+                    "tiles_endpoint": tiles_endpoint,
+                    "bounds": bounds,
+                    "tileMatrix": tileMatrix,
+                    "tms": tms,
+                    "title": "Cloud Optimized GeoTIFF",
+                    "layer_name": "cogeo",
+                    "media_type": media_type,
+                },
+                media_type=MimeTypes.xml.value,
+            )
+
+
+@dataclass
 class MosaicTilerFactory(BaseFactory):
     """
     MosaicTiler Factory.
@@ -888,14 +1133,6 @@ class MosaicTilerFactory(BaseFactory):
 
             with utils.Timer() as t:
                 reader = src_path.reader or self.dataset_reader
-                # Mosaic BaseBackend do not support TMS other than WebMercator
-                # so we suppose the dataset_reader is also using WebMercator as fallback
-                # reader_options = (
-                #   {**self.reader_options, "tms": tms}
-                #   if self.reader_supports_tms
-                #   else self.reader_options
-                # )
-
                 threads = int(os.getenv("MOSAIC_CONCURRENCY", MAX_THREADS))
 
                 with self.reader(

--- a/titiler/endpoints/factory.py
+++ b/titiler/endpoints/factory.py
@@ -155,7 +155,7 @@ class TilerFactory(BaseFactory):
 
         @self.router.get(
             "/info",
-            response_model=Union[List[str], Dict[str, cogInfo]],
+            response_model=Union[List[str], Dict[str, cogInfo], cogInfo],
             response_model_exclude={"minzoom", "maxzoom", "center"},
             response_model_exclude_none=True,
             responses={200: {"description": "Return dataset's basic info."}},
@@ -215,16 +215,18 @@ class TilerFactory(BaseFactory):
             """Return metadata."""
             reader = src_path.reader or self.reader
             with reader(src_path.url, **self.reader_options) as src_dst:
+                kwargs = options.kwargs.copy()
+                if params.nodata is not None:
+                    kwargs["nodata"] = params.nodata
                 info = src_dst.metadata(
                     params.pmin,
                     params.pmax,
-                    nodata=params.nodata,
                     indexes=params.indexes,
                     max_size=params.max_size,
                     hist_options=params.hist_options,
                     bounds=params.bounds,
                     resampling_method=params.resampling_method.name,
-                    **options.kwargs,
+                    **kwargs,
                 )
             return info
 
@@ -278,6 +280,9 @@ class TilerFactory(BaseFactory):
             with utils.Timer() as t:
                 reader = src_path.reader or self.reader
                 with reader(src_path.url, **self.reader_options) as src_dst:
+                    kwargs = options.kwargs.copy()
+                    if params.nodata is not None:
+                        kwargs["nodata"] = params.nodata
                     tile, mask = src_dst.tile(
                         x,
                         y,
@@ -285,9 +290,8 @@ class TilerFactory(BaseFactory):
                         tilesize=tilesize,
                         indexes=params.indexes,
                         expression=params.expression,
-                        nodata=params.nodata,
                         resampling_method=params.resampling_method.name,
-                        **options.kwargs,
+                        **kwargs,
                     )
                     colormap = params.colormap or getattr(src_dst, "colormap", None)
 
@@ -508,13 +512,15 @@ class TilerFactory(BaseFactory):
             with utils.Timer() as t:
                 reader = src_path.reader or self.reader
                 with reader(src_path.url, **self.reader_options) as src_dst:
+                    kwargs = options.kwargs.copy()
+                    if params.nodata is not None:
+                        kwargs["nodata"] = params.nodata
                     values = src_dst.point(
                         lon,
                         lat,
                         indexes=params.indexes,
                         expression=params.expression,
-                        nodata=params.nodata,
-                        **options.kwargs,
+                        **kwargs,
                     )
             timings.append(("Read", t.elapsed))
 
@@ -552,13 +558,15 @@ class TilerFactory(BaseFactory):
             with utils.Timer() as t:
                 reader = src_path.reader or self.reader
                 with reader(src_path.url, **self.reader_options) as src_dst:
+                    kwargs = options.kwargs.copy()
+                    if params.nodata is not None:
+                        kwargs["nodata"] = params.nodata
                     data, mask = src_dst.preview(
                         height=params.height,
                         width=params.width,
                         max_size=params.max_size,
                         indexes=params.indexes,
                         expression=params.expression,
-                        nodata=params.nodata,
                         resampling_method=params.resampling_method.name,
                         **options.kwargs,
                     )
@@ -621,6 +629,9 @@ class TilerFactory(BaseFactory):
             with utils.Timer() as t:
                 reader = src_path.reader or self.reader
                 with reader(src_path.url, **self.reader_options) as src_dst:
+                    kwargs = options.kwargs.copy()
+                    if params.nodata is not None:
+                        kwargs["nodata"] = params.nodata
                     data, mask = src_dst.part(
                         [minx, miny, maxx, maxy],
                         height=params.height,
@@ -628,9 +639,8 @@ class TilerFactory(BaseFactory):
                         max_size=params.max_size,
                         indexes=params.indexes,
                         expression=params.expression,
-                        nodata=params.nodata,
                         resampling_method=params.resampling_method.name,
-                        **options.kwargs,
+                        **kwargs,
                     )
                     colormap = params.colormap or getattr(src_dst, "colormap", None)
             timings.append(("Read", t.elapsed))
@@ -721,6 +731,9 @@ class TMSTilerFactory(TilerFactory):
             with utils.Timer() as t:
                 reader = src_path.reader or self.reader
                 with reader(src_path.url, tms=tms, **self.reader_options) as src_dst:
+                    kwargs = options.kwargs.copy()
+                    if params.nodata is not None:
+                        kwargs["nodata"] = params.nodata
                     tile, mask = src_dst.tile(
                         x,
                         y,
@@ -728,9 +741,8 @@ class TMSTilerFactory(TilerFactory):
                         tilesize=tilesize,
                         indexes=params.indexes,
                         expression=params.expression,
-                        nodata=params.nodata,
                         resampling_method=params.resampling_method.name,
-                        **options.kwargs,
+                        **kwargs,
                     )
                     colormap = params.colormap or getattr(src_dst, "colormap", None)
 
@@ -1138,6 +1150,9 @@ class MosaicTilerFactory(BaseFactory):
                 with self.reader(
                     src_path.url, reader=reader, reader_options=self.reader_options
                 ) as src_dst:
+                    kwargs = options.kwargs.copy()
+                    if params.nodata is not None:
+                        kwargs["nodata"] = params.nodata
                     (data, mask), assets_used = src_dst.tile(
                         x,
                         y,
@@ -1147,9 +1162,8 @@ class MosaicTilerFactory(BaseFactory):
                         tilesize=tilesize,
                         indexes=params.indexes,
                         expression=params.expression,
-                        nodata=params.nodata,
                         resampling_method=params.resampling_method.name,
-                        **options.kwargs,
+                        **kwargs,
                     )
 
             timings.append(("Read-tile", t.elapsed))
@@ -1376,14 +1390,16 @@ class MosaicTilerFactory(BaseFactory):
                 with self.reader(
                     src_path.url, reader=reader, reader_options=self.reader_options,
                 ) as src_dst:
+                    kwargs = options.kwargs.copy()
+                    if params.nodata is not None:
+                        kwargs["nodata"] = params.nodata
                     values = src_dst.point(
                         lon,
                         lat,
                         threads=threads,
                         indexes=params.indexes,
                         expression=params.expression,
-                        nodata=params.nodata,
-                        **options.kwargs,
+                        **kwargs,
                     )
             timings.append(("Read", t.elapsed))
 

--- a/titiler/endpoints/stac.py
+++ b/titiler/endpoints/stac.py
@@ -3,7 +3,7 @@
 import pkg_resources
 from rio_tiler_crs import STACReader
 
-from .factory import TilerFactory
+from .factory import TMSTilerFactory
 
 from starlette.requests import Request
 from starlette.responses import HTMLResponse
@@ -13,7 +13,7 @@ template_dir = pkg_resources.resource_filename("titiler", "templates")
 templates = Jinja2Templates(directory=template_dir)
 
 # Create Router using Tiler Factory
-stac = TilerFactory(reader=STACReader, add_asset_deps=True, router_prefix="stac")
+stac = TMSTilerFactory(reader=STACReader, add_asset_deps=True, router_prefix="stac")
 
 
 @stac.router.get("/viewer", response_class=HTMLResponse)


### PR DESCRIPTION
This PR is another approach for #87 and it does:

- removes morecantile.tms support from TilerFactory (only support WebMercator) and readers don't need TMS support (e.g rio-tiler.io.COGReader)
- adds TMSTilerFactory which support more TMS (needs a TMS friendly Reader like rio_tiler_crs.COGReader)

cc @geospatial-jeff 