### PR TITLE
more generic model (adapt for rio-tiler-pds)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@
   <a href="https://codecov.io/gh/developmentseed/titiler" target="_blank">
       <img src="https://codecov.io/gh/developmentseed/titiler/branch/master/graph/badge.svg" alt="Coverage">
   </a>
+  <a href="https://pypi.org/project/titiler" target="_blank">
+      <img src="https://img.shields.io/pypi/v/titiler?color=%2334D058&label=pypi%20package" alt="Package version">
+  </a>
   <a href="https://github.com/developmentseed/titiler/blob/master/LICENSE" target="_blank">
       <img src="https://img.shields.io/github/license/developmentseed/titiler.svg" alt="Downloads">
   </a>

--- a/titiler/endpoints/cog.py
+++ b/titiler/endpoints/cog.py
@@ -5,7 +5,7 @@ from rio_cogeo.cogeo import cog_info as rio_cogeo_info
 from rio_tiler_crs import COGReader
 
 from ..dependencies import PathParams
-from ..models.cog import RioCogeoInfo
+from ..models.dataset import RioCogeoInfo
 from .factory import TMSTilerFactory
 
 from fastapi import Depends, Query

--- a/titiler/endpoints/factory.py
+++ b/titiler/endpoints/factory.py
@@ -27,7 +27,7 @@ from ..dependencies import (
     WebMercatorTMSParams,
 )
 from ..errors import BadRequestError, TileNotFoundError
-from ..models.cog import cogBounds, cogInfo, cogMetadata
+from ..models.dataset import Bounds, Info, Metadata
 from ..models.mapbox import TileJSON
 from ..models.mosaic import CreateMosaicJSON, UpdateMosaicJSON, mosaicInfo
 from ..ressources.common import img_endpoint_params
@@ -134,7 +134,7 @@ class TilerFactory(BaseFactory):
 
         @self.router.get(
             "/bounds",
-            response_model=cogBounds,
+            response_model=Bounds,
             responses={200: {"description": "Return dataset's bounds."}},
             name=f"{self.router_prefix}bounds",
         )
@@ -152,7 +152,7 @@ class TilerFactory(BaseFactory):
 
         @self.router.get(
             "/info",
-            response_model=cogInfo,
+            response_model=Info,
             response_model_exclude={"minzoom", "maxzoom", "center"},
             response_model_exclude_none=True,
             responses={200: {"description": "Return dataset's basic info."}},
@@ -176,7 +176,7 @@ class TilerFactory(BaseFactory):
 
         @self.router.get(
             "/metadata",
-            response_model=cogMetadata,
+            response_model=Metadata,
             response_model_exclude={"minzoom", "maxzoom", "center"},
             response_model_exclude_none=True,
             responses={200: {"description": "Return dataset's metadata."}},
@@ -1047,7 +1047,7 @@ class MosaicTilerFactory(BaseFactory):
 
         @self.router.get(
             "/bounds",
-            response_model=cogBounds,
+            response_model=Bounds,
             responses={200: {"description": "Return the bounds of the MosaicJSON"}},
             name=f"{self.router_prefix}bounds",
         )

--- a/titiler/endpoints/stac.py
+++ b/titiler/endpoints/stac.py
@@ -7,7 +7,7 @@ import pkg_resources
 from rio_tiler_crs import STACReader
 
 from ..dependencies import AssetsParams
-from ..models.cog import cogInfo, cogMetadata
+from ..models.dataset import Info, Metadata
 from .factory import TMSTilerFactory
 
 from fastapi import Depends
@@ -33,7 +33,7 @@ class STACTiler(TMSTilerFactory):
 
         @self.router.get(
             "/info",
-            response_model=Union[List[str], Dict[str, cogInfo]],
+            response_model=Union[List[str], Dict[str, Info]],
             response_model_exclude={"minzoom", "maxzoom", "center"},
             response_model_exclude_none=True,
             responses={200: {"description": "Return dataset's basic info."}},
@@ -58,7 +58,7 @@ class STACTiler(TMSTilerFactory):
 
         @self.router.get(
             "/metadata",
-            response_model=Dict[str, cogMetadata],
+            response_model=Dict[str, Metadata],
             response_model_exclude={"minzoom", "maxzoom", "center"},
             response_model_exclude_none=True,
             responses={200: {"description": "Return dataset's metadata."}},

--- a/titiler/models/dataset.py
+++ b/titiler/models/dataset.py
@@ -10,18 +10,19 @@ from ..ressources.enums import NodataTypes
 NumType = Union[float, int]
 BBox = Tuple[NumType, NumType, NumType, NumType]
 ColorTuple = Tuple[int, int, int, int]
+BandIdxType = Union[str, int]
 
 
-class cogBounds(BaseModel):
-    """Bounding box"""
+class Bounds(BaseModel):
+    """Dataset Bounding box"""
 
     bounds: BBox
 
 
-class cogInfo(cogBounds):
-    """COG Info."""
+class Info(Bounds):
+    """Dataset Info."""
 
-    band_metadata: List[Tuple[int, Dict[int, Any]]]
+    band_metadata: List[Tuple[int, Dict]]
     band_descriptions: List[Tuple[int, str]]
     dtype: str
     colorinterp: List[str]
@@ -47,10 +48,10 @@ class ImageStatistics(BaseModel):
     histogram: List[List[NumType]]
 
 
-class cogMetadata(cogInfo):
-    """COG metadata and statistics."""
+class Metadata(Info):
+    """Dataset metadata and statistics."""
 
-    statistics: Dict[int, ImageStatistics]
+    statistics: Dict[BandIdxType, ImageStatistics]
 
 
 class CogeoInfoIFD(BaseModel):


### PR DESCRIPTION
This PR does:
- rename `titiler.models.cog.py` to `titiler.models.dataset.py`
- remove cog* prefix to Bounds, Info and Metadata models
- allow `Union[str, int]` for key in `Metadata.statistics` (as defined in rio-tiler-pds) 