### PR TITLE
use custom APIRoute to set GDAL env before endpoint calls

### DIFF
--- a/tests/test_customAPIRoute.py
+++ b/tests/test_customAPIRoute.py
@@ -1,0 +1,129 @@
+from concurrent import futures
+
+import rasterio
+from rasterio._env import get_gdal_config
+
+from titiler.endpoints.factory import apiroute_factory
+
+from fastapi import APIRouter, FastAPI
+
+from starlette.testclient import TestClient
+
+
+def test_withoutCustomRoute(set_env, monkeypatch):
+    """Create App."""
+    monkeypatch.setenv("GDAL_DISABLE_READDIR_ON_OPEN", "something")
+
+    app = FastAPI()
+    router = APIRouter()
+
+    def f(r):
+        return get_gdal_config("GDAL_DISABLE_READDIR_ON_OPEN")
+
+    @router.get("/simple")
+    def home():
+        """Works and should return FALSE."""
+        with rasterio.Env(GDAL_DISABLE_READDIR_ON_OPEN="FALSE"):
+            res = get_gdal_config("GDAL_DISABLE_READDIR_ON_OPEN")
+        return {"env": res}
+
+    @router.get("/asimple")
+    async def home1():
+        """Works and should return FALSE."""
+        with rasterio.Env(GDAL_DISABLE_READDIR_ON_OPEN="FALSE"):
+            res = get_gdal_config("GDAL_DISABLE_READDIR_ON_OPEN")
+        return {"env": res}
+
+    @router.get("/future")
+    def home2():
+        """Doesn't work and should return the value from env."""
+        with rasterio.Env(GDAL_DISABLE_READDIR_ON_OPEN="FALSE"):
+            with futures.ThreadPoolExecutor() as executor:
+                res = list(executor.map(f, range(1)))[0]
+        return {"env": res}
+
+    @router.get("/afuture")
+    async def home3():
+        """Works and should return FALSE."""
+        with rasterio.Env(GDAL_DISABLE_READDIR_ON_OPEN="FALSE"):
+            with futures.ThreadPoolExecutor() as executor:
+                res = list(executor.map(f, range(1)))[0]
+        return {"env": res}
+
+    app.include_router(router)
+
+    client = TestClient(app)
+    response = client.get("/simple")
+    assert response.json()["env"] == "FALSE"
+
+    client = TestClient(app)
+    response = client.get("/asimple")
+    assert response.json()["env"] == "FALSE"
+
+    # confirm the multi threads case doesn't work
+    client = TestClient(app)
+    response = client.get("/future")
+    assert response.json()["env"] == "something"
+
+    client = TestClient(app)
+    response = client.get("/afuture")
+    assert response.json()["env"] == "FALSE"
+
+
+def test_withCustomRoute(set_env, monkeypatch):
+    """Create App."""
+    monkeypatch.setenv("GDAL_DISABLE_READDIR_ON_OPEN", "something")
+
+    app = FastAPI()
+
+    env = dict(GDAL_DISABLE_READDIR_ON_OPEN="FALSE")
+    route_class = apiroute_factory(env)
+    router = APIRouter(route_class=route_class)
+
+    def f(r):
+        return get_gdal_config("GDAL_DISABLE_READDIR_ON_OPEN")
+
+    @router.get("/simple")
+    def home():
+        """Works and should return FALSE."""
+        res = get_gdal_config("GDAL_DISABLE_READDIR_ON_OPEN")
+        return {"env": res}
+
+    @router.get("/asimple")
+    async def home1():
+        """Works and should return FALSE."""
+        res = get_gdal_config("GDAL_DISABLE_READDIR_ON_OPEN")
+        return {"env": res}
+
+    @router.get("/future")
+    def home2():
+        """Doesn't work and should return the value from env."""
+        with futures.ThreadPoolExecutor() as executor:
+            res = list(executor.map(f, range(1)))[0]
+        return {"env": res}
+
+    @router.get("/afuture")
+    async def home3():
+        """Works and should return FALSE."""
+        with futures.ThreadPoolExecutor() as executor:
+            res = list(executor.map(f, range(1)))[0]
+        return {"env": res}
+
+    app.include_router(router)
+
+    client = TestClient(app)
+    response = client.get("/simple")
+    assert response.json()["env"] == "FALSE"
+
+    client = TestClient(app)
+    response = client.get("/asimple")
+    assert response.json()["env"] == "FALSE"
+
+    # confirm the Custom APIRoute class fix
+    client = TestClient(app)
+    response = client.get("/future")
+    assert response.json()["env"] == "FALSE"
+
+    client = TestClient(app)
+    response = client.get("/afuture")
+    assert response.json()["env"] == "FALSE"

--- a/tests/test_customAPIRoute.py
+++ b/tests/test_customAPIRoute.py
@@ -10,7 +10,7 @@ from fastapi import APIRouter, FastAPI
 from starlette.testclient import TestClient
 
 
-def test_withoutCustomRoute(set_env, monkeypatch):
+def test_withoutCustomRoute(monkeypatch):
     """Create App."""
     monkeypatch.setenv("GDAL_DISABLE_READDIR_ON_OPEN", "something")
 
@@ -51,26 +51,23 @@ def test_withoutCustomRoute(set_env, monkeypatch):
         return {"env": res}
 
     app.include_router(router)
-
     client = TestClient(app)
+
     response = client.get("/simple")
     assert response.json()["env"] == "FALSE"
 
-    client = TestClient(app)
     response = client.get("/asimple")
     assert response.json()["env"] == "FALSE"
 
     # confirm the multi threads case doesn't work
-    client = TestClient(app)
     response = client.get("/future")
-    assert response.json()["env"] == "something"
+    assert not response.json()["env"] == "FALSE"
 
-    client = TestClient(app)
     response = client.get("/afuture")
     assert response.json()["env"] == "FALSE"
 
 
-def test_withCustomRoute(set_env, monkeypatch):
+def test_withCustomRoute(monkeypatch):
     """Create App."""
     monkeypatch.setenv("GDAL_DISABLE_READDIR_ON_OPEN", "something")
 
@@ -110,20 +107,17 @@ def test_withCustomRoute(set_env, monkeypatch):
         return {"env": res}
 
     app.include_router(router)
-
     client = TestClient(app)
+
     response = client.get("/simple")
     assert response.json()["env"] == "FALSE"
 
-    client = TestClient(app)
     response = client.get("/asimple")
     assert response.json()["env"] == "FALSE"
 
     # confirm the Custom APIRoute class fix
-    client = TestClient(app)
     response = client.get("/future")
     assert response.json()["env"] == "FALSE"
 
-    client = TestClient(app)
     response = client.get("/afuture")
     assert response.json()["env"] == "FALSE"

--- a/titiler/endpoints/factory.py
+++ b/titiler/endpoints/factory.py
@@ -53,7 +53,7 @@ templates = Jinja2Templates(directory=template_dir)
 default_readers_type = Union[Type[BaseReader], Type[MultiBaseReader]]
 
 
-def apiroute_factory(env: Optional[Dict] = None):
+def apiroute_factory(env: Optional[Dict] = None) -> Type[APIRoute]:
     """
     Create Custom API Route class with custom Env.
 


### PR DESCRIPTION
this is another implementation of #106 but works with multithreaded Readers.

This PR does:
- create `apiroute_factory` function which create custom `fastapi.routing.APIRoute` which will set the GDAL env before the actual reader call) 
- remove `router` option from the Factory Init (**breaking change**), this is to make sure that the `env` options is used (if a user pass a `env` and use a outside router, it won't have any effect) - to be discussed
- add test to explain the behaviour