### PR TITLE
Valid stack name in documentation; including example for requester pays

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,11 @@
 API_NAME="titiler"
 API_CACHECONTROL="public, max-age=3600"
 
-STACK_NAME="my_tiler"
+STACK_NAME="my-tiler"
 STACK_STAGE="dev"
 STACK_BUCKETS='["my-bucket*", "*"]'
 STACK_MEMORY=3008
+
+# Uncomment to allow lambda to access content on requester-payer
+# buckets
+#STACK_ADDITIONAL_ENV='{"AWS_REQUEST_PAYER":"requester"}'

--- a/docs/deployment/settings.md
+++ b/docs/deployment/settings.md
@@ -6,13 +6,17 @@ Variables in `.env` or in environment variable need to be prefixed with `STACK_`
 
 
 ```bash
-STACK_NAME="my_tiler"
+STACK_NAME="my-tiler"
 STACK_STAGE="dev"
 
 STACK_BUCKETS='["my-bucket*", "*"]'
 STACK_MOSAIC_HOST="my-bucket/mosaics"
 
 STACK_MEMORY=3008
+
+# Uncomment to allow lambda to access content on requester-payer
+# buckets
+#STACK_ADDITIONAL_ENV='{"AWS_REQUEST_PAYER":"requester"}'
 ```
 
 Default values from [stack.config.py](https://github.com/developmentseed/titiler/blob/master/stack/config.py):


### PR DESCRIPTION
Minor documentation updates suggestions based on my deploy experience. The STACK_NAME example contains an invalid character. I'm also including an example on how to define extra ENV vars for lambda, I needed to include that to work with CBERS' requester pays buckets.