### PR TITLE
Add binder links

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@
   <a href="https://github.com/developmentseed/titiler/blob/master/LICENSE" target="_blank">
       <img src="https://img.shields.io/github/license/developmentseed/titiler.svg" alt="Downloads">
   </a>
+  <a href="https://mybinder.org/v2/gh/developmentseed/titiler/master" target="_blank">
+      <img src="https://mybinder.org/badge_logo.svg" alt="Downloads">
+  </a>
 </p>
 
 ---

--- a/docs/examples/Working_with_CloudOptimizedGeoTIFF.ipynb
+++ b/docs/examples/Working_with_CloudOptimizedGeoTIFF.ipynb
@@ -6,6 +6,8 @@
    "source": [
     "# Working With COG - At Scale\n",
     "\n",
+    "[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/developmentseed/titiler/master?filepath=docs%2Fexamples%2FWorking_with_CloudOptimizedGeoTIFF.ipynb)\n",
+    "\n",
     "For this demo we will use the new `Ozone Monitoring Instrument (OMI) / Aura NO2 Tropospheric Column Density` dataset hosted on AWS PDS: https://registry.opendata.aws/omi-no2-nasa/\n",
     "\n",
     "\n",
@@ -114,9 +116,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "Map(\n",
@@ -166,7 +166,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "scrolled": false,
     "tags": []
    },
    "outputs": [],
@@ -265,9 +264,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "r = requests.get(\n",
@@ -432,9 +429,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/docs/examples/Working_with_CloudOptimizedGeoTIFF_simple.ipynb
+++ b/docs/examples/Working_with_CloudOptimizedGeoTIFF_simple.ipynb
@@ -6,6 +6,8 @@
    "source": [
     "# Working With COG\n",
     "\n",
+    "[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/developmentseed/titiler/master?filepath=docs%2Fexamples%2FWorking_with_CloudOptimizedGeoTIFF_simple.ipynb)\n",
+    "\n",
     "For this demo we will use the new `DigitalGlobe OpenData` dataset https://www.digitalglobe.com/ecosystem/open-data\n",
     "\n",
     "\n",
@@ -92,9 +94,7 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -278,9 +278,7 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -342,9 +340,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/docs/examples/Working_with_MosaicJSON.ipynb
+++ b/docs/examples/Working_with_MosaicJSON.ipynb
@@ -6,6 +6,8 @@
    "source": [
     "# Working With MosaicJSON\n",
     "\n",
+    "[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/developmentseed/titiler/master?filepath=docs%2Fexamples%2FWorking_with_MosaicJSON.ipynb)\n",
+    "\n",
     "### MosaicJSON\n",
     "\n",
     "MosaicJSON is a specification created by DevelopmentSeed which aims to be an open standard for representing metadata about a mosaic of Cloud-Optimized GeoTIFF (COG) files.\n",
@@ -113,9 +115,11 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Number of GeoTIFF: 52\n"
+     "output_type": "stream",
+     "text": [
+      "Number of GeoTIFF: 52\n"
+     ]
     }
    ],
    "source": [
@@ -153,9 +157,12 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Number of Pre Event COG: 37\nNumber of Post Event COG: 15\n"
+     "output_type": "stream",
+     "text": [
+      "Number of Pre Event COG: 37\n",
+      "Number of Post Event COG: 15\n"
+     ]
     }
    ],
    "source": [
@@ -215,16 +222,18 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "display_data",
      "data": {
-      "text/plain": "Map(center=[38.45337291724532, -114.37367751387771], controls=(ZoomControl(options=['position', 'zoom_in_text'…",
       "application/vnd.jupyter.widget-view+json": {
+       "model_id": "81862f4fc239412d8eb878a42cc776dd",
        "version_major": 2,
-       "version_minor": 0,
-       "model_id": "81862f4fc239412d8eb878a42cc776dd"
-      }
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map(center=[38.45337291724532, -114.37367751387771], controls=(ZoomControl(options=['position', 'zoom_in_text'…"
+      ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -285,9 +294,11 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJhbm9ueW1vdXMiLCJzY29wZSI6WyJtb3NhaWM6cmVhZCIsIm1vc2FpYzpjcmVhdGUiXSwiaWF0IjoxNTk5NTc1NTQxLCJleHAiOjE1OTk1NzkxNDF9.e7PfiNoiBEomGwrXPWwjZKPISsJJoBXweeEZCcDkdmE\n"
+     "output_type": "stream",
+     "text": [
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJhbm9ueW1vdXMiLCJzY29wZSI6WyJtb3NhaWM6cmVhZCIsIm1vc2FpYzpjcmVhdGUiXSwiaWF0IjoxNTk5NTc1NTQxLCJleHAiOjE1OTk1NzkxNDF9.e7PfiNoiBEomGwrXPWwjZKPISsJJoBXweeEZCcDkdmE\n"
+     ]
     }
    ],
    "source": [
@@ -319,9 +330,11 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "{'username': 'anonymous', 'layername': 'dgopendata_CAfire_2020_post', 'mosaic': 'anonymous.dgopendata_CAfire_2020_post'}\n"
+     "output_type": "stream",
+     "text": [
+      "{'username': 'anonymous', 'layername': 'dgopendata_CAfire_2020_post', 'mosaic': 'anonymous.dgopendata_CAfire_2020_post'}\n"
+     ]
     }
    ],
    "source": [
@@ -388,21 +401,25 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "{'tilejson': '2.2.0', 'name': 'anonymous.dgopendata_CAfire_2020_post', 'version': '1.0.0', 'scheme': 'xyz', 'tiles': ['https://api.cogeo.xyz/mosaicjson/anonymous.dgopendata_CAfire_2020_post/tiles/{z}/{x}/{y}@1x?'], 'minzoom': 10, 'maxzoom': 18, 'bounds': [-123.00645857801385, 36.254745572560125, -105.74089644974157, 40.65200026193052], 'center': [-114.37367751387771, 38.45337291724532, 10]}\n"
+     "output_type": "stream",
+     "text": [
+      "{'tilejson': '2.2.0', 'name': 'anonymous.dgopendata_CAfire_2020_post', 'version': '1.0.0', 'scheme': 'xyz', 'tiles': ['https://api.cogeo.xyz/mosaicjson/anonymous.dgopendata_CAfire_2020_post/tiles/{z}/{x}/{y}@1x?'], 'minzoom': 10, 'maxzoom': 18, 'bounds': [-123.00645857801385, 36.254745572560125, -105.74089644974157, 40.65200026193052], 'center': [-114.37367751387771, 38.45337291724532, 10]}\n"
+     ]
     },
     {
-     "output_type": "display_data",
      "data": {
-      "text/plain": "Map(center=[38.45337291724532, -114.37367751387771], controls=(ZoomControl(options=['position', 'zoom_in_text'…",
       "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3f58e1f2d1ed4771a675add725d68972",
        "version_major": 2,
-       "version_minor": 0,
-       "model_id": "3f58e1f2d1ed4771a675add725d68972"
-      }
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map(center=[38.45337291724532, -114.37367751387771], controls=(ZoomControl(options=['position', 'zoom_in_text'…"
+      ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -451,9 +468,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4-final"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/docs/examples/Working_with_STAC_simple.ipynb
+++ b/docs/examples/Working_with_STAC_simple.ipynb
@@ -6,6 +6,8 @@
    "source": [
     "# Working With STAC\n",
     "\n",
+    "[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/developmentseed/titiler/master?filepath=docs%2Fexamples%2FWorking_with_STAC_simple.ipynb)\n",
+    "\n",
     "### STAC: SpatioTemporal Asset Catalog\n",
     "\n",
     "> The SpatioTemporal Asset Catalog (STAC) specification aims to standardize the way geospatial assets are exposed online and queried. A 'spatiotemporal asset' is any file that represents information about the earth captured in a certain space and time. The initial focus is primarily remotely-sensed imagery (from satellites, but also planes, drones, balloons, etc), but the core is designed to be extensible to SAR, full motion video, point clouds, hyperspectral, LiDAR and derived data like NDVI, Digital Elevation Models, mosaics, etc.\n",
@@ -40,9 +42,11 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Populating the interactive namespace from numpy and matplotlib\n"
+     "output_type": "stream",
+     "text": [
+      "Populating the interactive namespace from numpy and matplotlib\n"
+     ]
     }
    ],
    "source": [
@@ -74,9 +78,11 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "{'type': 'Feature', 'stac_version': '0.8.1', 'id': 'S5_11055_6057_20070622', 'properties': {'eo:gsd': 20, 'eo:bands': [{'name': 'Panchromatic', 'common_name': 'panchromatic', 'description': 'Panchromatic: 480-710 nm'}, {'name': 'Green', 'common_name': 'green', 'description': 'Green: 500-590 nm'}, {'name': 'Red', 'common_name': 'red', 'description': 'Red: 610-680 nm'}, {'name': 'Near Infrared', 'common_name': 'nir', 'description': 'Near Infrared: 780-890 nm'}, {'name': 'ShortWave Infrared', 'common_name': 'swir', 'description': 'ShortWave Infrared: 1580-1750 nm'}], 'proj:epsg': 3979, 'datetime': '2007-06-22T00:00:00Z'}, 'geometry': {'type': 'Polygon', 'coordinates': [[[-111.6453245, 60.81065789999892], [-111.2296762, 61.30928879999903], [-110.1583693, 61.093875199999], [-110.5877877, 60.59892389999882], [-111.6453245, 60.81065789999892]]]}, 'bbox': [-111.6453245, 60.59892389999882, -110.1583693, 61.30928879999903], 'links': [{'rel': 'collection', 'href': 'https://canada-spot-ortho.s3.amazonaws.com/canada_spot_orthoimages/canada_spot5_orthoimages/collection.json', 'type': 'application/json'}, {'rel': 'self', 'href': 'https://canada-spot-ortho.s3.amazonaws.com/canada_spot_orthoimages/canada_spot5_orthoimages/S5_2007/S5_11055_6057_20070622/S5_11055_6057_20070622.json', 'type': 'application/json'}, {'rel': 'root', 'href': 'https://canada-spot-ortho.s3.amazonaws.com/catalog.json', 'type': 'application/json'}, {'rel': 'parent', 'href': 'https://canada-spot-ortho.s3.amazonaws.com/canada_spot_orthoimages/canada_spot5_orthoimages/S5_2007/catalog.json', 'type': 'application/json'}], 'assets': {'pan': {'href': 'https://canada-spot-ortho.s3.amazonaws.com/canada_spot_orthoimages/canada_spot5_orthoimages/S5_2007/S5_11055_6057_20070622/s5_11055_6057_20070622_p10_1_lcc00_cog.tif', 'type': 'image/tiff; application=geotiff; profile=cloud-optimized', 'title': 'pan'}, 'B1': {'href': 'https://canada-spot-ortho.s3.amazonaws.com/canada_spot_orthoimages/canada_spot5_orthoimages/S5_2007/S5_11055_6057_20070622/s5_11055_6057_20070622_m20_1_lcc00_cog.tif', 'type': 'image/tiff; application=geotiff; profile=cloud-optimized', 'title': 'B1'}, 'B2': {'href': 'https://canada-spot-ortho.s3.amazonaws.com/canada_spot_orthoimages/canada_spot5_orthoimages/S5_2007/S5_11055_6057_20070622/s5_11055_6057_20070622_m20_2_lcc00_cog.tif', 'type': 'image/tiff; application=geotiff; profile=cloud-optimized', 'title': 'B2'}, 'thumbnail': {'href': 'https://canada-spot-ortho.s3.amazonaws.com/canada_spot_orthoimages/canada_spot5_orthoimages/S5_2007/S5_11055_6057_20070622/s5_11055_6057_20070622_tn.jpg', 'type': 'image/jpeg', 'title': 'thumbnail'}, 'B3': {'href': 'https://canada-spot-ortho.s3.amazonaws.com/canada_spot_orthoimages/canada_spot5_orthoimages/S5_2007/S5_11055_6057_20070622/s5_11055_6057_20070622_m20_3_lcc00_cog.tif', 'type': 'image/tiff; application=geotiff; profile=cloud-optimized', 'title': 'B3'}, 'B4': {'href': 'https://canada-spot-ortho.s3.amazonaws.com/canada_spot_orthoimages/canada_spot5_orthoimages/S5_2007/S5_11055_6057_20070622/s5_11055_6057_20070622_m20_4_lcc00_cog.tif', 'type': 'image/tiff; application=geotiff; profile=cloud-optimized', 'title': 'B4'}}, 'collection': 'canada_spot5_orthoimages'}\n"
+     "output_type": "stream",
+     "text": [
+      "{'type': 'Feature', 'stac_version': '0.8.1', 'id': 'S5_11055_6057_20070622', 'properties': {'eo:gsd': 20, 'eo:bands': [{'name': 'Panchromatic', 'common_name': 'panchromatic', 'description': 'Panchromatic: 480-710 nm'}, {'name': 'Green', 'common_name': 'green', 'description': 'Green: 500-590 nm'}, {'name': 'Red', 'common_name': 'red', 'description': 'Red: 610-680 nm'}, {'name': 'Near Infrared', 'common_name': 'nir', 'description': 'Near Infrared: 780-890 nm'}, {'name': 'ShortWave Infrared', 'common_name': 'swir', 'description': 'ShortWave Infrared: 1580-1750 nm'}], 'proj:epsg': 3979, 'datetime': '2007-06-22T00:00:00Z'}, 'geometry': {'type': 'Polygon', 'coordinates': [[[-111.6453245, 60.81065789999892], [-111.2296762, 61.30928879999903], [-110.1583693, 61.093875199999], [-110.5877877, 60.59892389999882], [-111.6453245, 60.81065789999892]]]}, 'bbox': [-111.6453245, 60.59892389999882, -110.1583693, 61.30928879999903], 'links': [{'rel': 'collection', 'href': 'https://canada-spot-ortho.s3.amazonaws.com/canada_spot_orthoimages/canada_spot5_orthoimages/collection.json', 'type': 'application/json'}, {'rel': 'self', 'href': 'https://canada-spot-ortho.s3.amazonaws.com/canada_spot_orthoimages/canada_spot5_orthoimages/S5_2007/S5_11055_6057_20070622/S5_11055_6057_20070622.json', 'type': 'application/json'}, {'rel': 'root', 'href': 'https://canada-spot-ortho.s3.amazonaws.com/catalog.json', 'type': 'application/json'}, {'rel': 'parent', 'href': 'https://canada-spot-ortho.s3.amazonaws.com/canada_spot_orthoimages/canada_spot5_orthoimages/S5_2007/catalog.json', 'type': 'application/json'}], 'assets': {'pan': {'href': 'https://canada-spot-ortho.s3.amazonaws.com/canada_spot_orthoimages/canada_spot5_orthoimages/S5_2007/S5_11055_6057_20070622/s5_11055_6057_20070622_p10_1_lcc00_cog.tif', 'type': 'image/tiff; application=geotiff; profile=cloud-optimized', 'title': 'pan'}, 'B1': {'href': 'https://canada-spot-ortho.s3.amazonaws.com/canada_spot_orthoimages/canada_spot5_orthoimages/S5_2007/S5_11055_6057_20070622/s5_11055_6057_20070622_m20_1_lcc00_cog.tif', 'type': 'image/tiff; application=geotiff; profile=cloud-optimized', 'title': 'B1'}, 'B2': {'href': 'https://canada-spot-ortho.s3.amazonaws.com/canada_spot_orthoimages/canada_spot5_orthoimages/S5_2007/S5_11055_6057_20070622/s5_11055_6057_20070622_m20_2_lcc00_cog.tif', 'type': 'image/tiff; application=geotiff; profile=cloud-optimized', 'title': 'B2'}, 'thumbnail': {'href': 'https://canada-spot-ortho.s3.amazonaws.com/canada_spot_orthoimages/canada_spot5_orthoimages/S5_2007/S5_11055_6057_20070622/s5_11055_6057_20070622_tn.jpg', 'type': 'image/jpeg', 'title': 'thumbnail'}, 'B3': {'href': 'https://canada-spot-ortho.s3.amazonaws.com/canada_spot_orthoimages/canada_spot5_orthoimages/S5_2007/S5_11055_6057_20070622/s5_11055_6057_20070622_m20_3_lcc00_cog.tif', 'type': 'image/tiff; application=geotiff; profile=cloud-optimized', 'title': 'B3'}, 'B4': {'href': 'https://canada-spot-ortho.s3.amazonaws.com/canada_spot_orthoimages/canada_spot5_orthoimages/S5_2007/S5_11055_6057_20070622/s5_11055_6057_20070622_m20_4_lcc00_cog.tif', 'type': 'image/tiff; application=geotiff; profile=cloud-optimized', 'title': 'B4'}}, 'collection': 'canada_spot5_orthoimages'}\n"
+     ]
     }
    ],
    "source": [
@@ -92,9 +98,17 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "['pan', 'B1', 'B2', 'thumbnail', 'B3', 'B4']\nimage/tiff; application=geotiff; profile=cloud-optimized\nimage/tiff; application=geotiff; profile=cloud-optimized\nimage/tiff; application=geotiff; profile=cloud-optimized\nimage/jpeg\nimage/tiff; application=geotiff; profile=cloud-optimized\nimage/tiff; application=geotiff; profile=cloud-optimized\n"
+     "output_type": "stream",
+     "text": [
+      "['pan', 'B1', 'B2', 'thumbnail', 'B3', 'B4']\n",
+      "image/tiff; application=geotiff; profile=cloud-optimized\n",
+      "image/tiff; application=geotiff; profile=cloud-optimized\n",
+      "image/tiff; application=geotiff; profile=cloud-optimized\n",
+      "image/jpeg\n",
+      "image/tiff; application=geotiff; profile=cloud-optimized\n",
+      "image/tiff; application=geotiff; profile=cloud-optimized\n"
+     ]
     }
    ],
    "source": [
@@ -106,21 +120,21 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [
     {
-     "output_type": "display_data",
      "data": {
-      "text/plain": "Map(center=[60.95410634999892, -110.90184690000001], controls=(ZoomControl(options=['position', 'zoom_in_text'…",
       "application/vnd.jupyter.widget-view+json": {
+       "model_id": "da18375998e14dba895126755f4a1c67",
        "version_major": 2,
-       "version_minor": 0,
-       "model_id": "da18375998e14dba895126755f4a1c67"
-      }
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map(center=[60.95410634999892, -110.90184690000001], controls=(ZoomControl(options=['position', 'zoom_in_text'…"
+      ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -145,9 +159,11 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "['pan', 'B1', 'B2', 'B3', 'B4']\n"
+     "output_type": "stream",
+     "text": [
+      "['pan', 'B1', 'B2', 'B3', 'B4']\n"
+     ]
     }
    ],
    "source": [
@@ -171,21 +187,21 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [
     {
-     "output_type": "display_data",
      "data": {
-      "text/plain": "Map(center=[60.95410634999892, -110.90184690000001], controls=(ZoomControl(options=['position', 'zoom_in_text'…",
       "application/vnd.jupyter.widget-view+json": {
+       "model_id": "38d5e41e4d67476dbf1da4ad2f58a648",
        "version_major": 2,
-       "version_minor": 0,
-       "model_id": "38d5e41e4d67476dbf1da4ad2f58a648"
-      }
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map(center=[60.95410634999892, -110.90184690000001], controls=(ZoomControl(options=['position', 'zoom_in_text'…"
+      ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -224,21 +240,21 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [
     {
-     "output_type": "display_data",
      "data": {
-      "text/plain": "Map(center=[60.95410634999892, -110.90184690000001], controls=(ZoomControl(options=['position', 'zoom_in_text'…",
       "application/vnd.jupyter.widget-view+json": {
+       "model_id": "0201ed911c3341aca94dd8f5036fd726",
        "version_major": 2,
-       "version_minor": 0,
-       "model_id": "0201ed911c3341aca94dd8f5036fd726"
-      }
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map(center=[60.95410634999892, -110.90184690000001], controls=(ZoomControl(options=['position', 'zoom_in_text'…"
+      ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -285,9 +301,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4-final"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/docs/examples/Working_with_nonWebMercatorTMS.ipynb
+++ b/docs/examples/Working_with_nonWebMercatorTMS.ipynb
@@ -6,6 +6,8 @@
    "source": [
     "# Working With TileMatrixSets (other than WebMercator)\n",
     "\n",
+    "[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/developmentseed/titiler/master?filepath=docs%2Fexamples%2FWorking_with_nonWebMercatorTMS.ipynb)\n",
+    "\n",
     "#### Requirements\n",
     "- ipyleaflet\n",
     "- requests\n",
@@ -48,26 +50,29 @@
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {
-    "scrolled": false,
     "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "{'tilejson': '2.2.0', 'name': 'world.tif', 'version': '1.0.0', 'scheme': 'xyz', 'tiles': ['https://api.cogeo.xyz/cog/tiles/EPSG3413/{z}/{x}/{y}@1x?url=https%3A%2F%2Fs3.amazonaws.com%2Fopendata.remotepixel.ca%2Fcogs%2Fnatural_earth%2Fworld.tif'], 'minzoom': 0, 'maxzoom': 0, 'bounds': [-179.8333333333333, -89.8333333333693, 179.8333333334053, 89.83333333333331], 'center': [3.601030584832188e-11, -1.7990942069445737e-11, 0]}\n"
+     "output_type": "stream",
+     "text": [
+      "{'tilejson': '2.2.0', 'name': 'world.tif', 'version': '1.0.0', 'scheme': 'xyz', 'tiles': ['https://api.cogeo.xyz/cog/tiles/EPSG3413/{z}/{x}/{y}@1x?url=https%3A%2F%2Fs3.amazonaws.com%2Fopendata.remotepixel.ca%2Fcogs%2Fnatural_earth%2Fworld.tif'], 'minzoom': 0, 'maxzoom': 0, 'bounds': [-179.8333333333333, -89.8333333333693, 179.8333333334053, 89.83333333333331], 'center': [3.601030584832188e-11, -1.7990942069445737e-11, 0]}\n"
+     ]
     },
     {
-     "output_type": "display_data",
      "data": {
-      "text/plain": "Map(center=[90, 0], controls=(ZoomControl(options=['position', 'zoom_in_text', 'zoom_in_title', 'zoom_out_text…",
       "application/vnd.jupyter.widget-view+json": {
+       "model_id": "dfe7cd75905f422e81f5e52b639bc6eb",
        "version_major": 2,
-       "version_minor": 0,
-       "model_id": "dfe7cd75905f422e81f5e52b639bc6eb"
-      }
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map(center=[90, 0], controls=(ZoomControl(options=['position', 'zoom_in_text', 'zoom_in_title', 'zoom_out_text…"
+      ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -103,9 +108,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4-final"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
Adds binder links to the README (to browse the repo) and to each Jupyter Notebook other than the custom Sentinel 2 tiler one

In order to add badges to each Jupyter Notebook, I opened Jupyter Lab, added a badge to the first Markdown section, and saved. Notebooks just have horrible diffs 🤷‍♂️ 