### PR TITLE
Coerce env values to string

### DIFF
--- a/stack/app.py
+++ b/stack/app.py
@@ -159,11 +159,11 @@ class titilerECSStack(core.Stack):
 
         # GUNICORN configuration
         if settings.workers_per_core:
-            task_env.update({"WORKERS_PER_CORE": settings.workers_per_core})
+            task_env.update({"WORKERS_PER_CORE": str(settings.workers_per_core)})
         if settings.max_workers:
-            task_env.update({"MAX_WORKERS": settings.max_workers})
+            task_env.update({"MAX_WORKERS": str(settings.max_workers)})
         if settings.web_concurrency:
-            task_env.update({"WEB_CONCURRENCY": settings.web_concurrency})
+            task_env.update({"WEB_CONCURRENCY": str(settings.web_concurrency)})
 
         task_env.update(env)
 


### PR DESCRIPTION
CDK deploy currently errors because you can't use non-string values as env values.