### PR TITLE
Set `rm=True` for building docker containers

### DIFF
--- a/stack/app.py
+++ b/stack/app.py
@@ -112,13 +112,13 @@ class titilerLambdaStack(core.Stack):
         client.images.build(
             path=code_dir,
             dockerfile="Dockerfiles/lambda/Dockerfile",
-            tag="lambda:latest",
+            tag="titiler-lambda:latest",
             rm=True,
         )
 
         print("Copying package.zip ...")
         client.containers.run(
-            image="lambda:latest",
+            image="titiler-lambda:latest",
             command="/bin/sh -c 'cp /tmp/package.zip /local/package.zip'",
             remove=True,
             volumes={os.path.abspath(code_dir): {"bind": "/local/", "mode": "rw"}},

--- a/stack/app.py
+++ b/stack/app.py
@@ -113,6 +113,7 @@ class titilerLambdaStack(core.Stack):
             path=code_dir,
             dockerfile="Dockerfiles/lambda/Dockerfile",
             tag="lambda:latest",
+            rm=True,
         )
 
         print("Copying package.zip ...")


### PR DESCRIPTION
From the docstring of `client.images.build`:

```
        rm (bool): Remove intermediate containers. The ``docker build``
            command now defaults to ``--rm=true``, but we have kept the old
            default of `False` to preserve backward compatibility
```

I think when `False`, it doesn't clean up intermediate containers, thus taking up more disk space?