### PR TITLE
Restore brotli middleware

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ with open("README.md") as f:
     long_description = f.read()
 
 inst_reqs = [
+    "brotli-asgi>=1.0.0",
     "email-validator",
     "fastapi==0.60.1",
     "jinja2",

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ inst_reqs = [
 extra_reqs = {
     "dev": ["pytest", "pytest-cov", "pytest-asyncio", "pre-commit", "requests"],
     "server": ["uvicorn", "click==7.0"],
-    "lambda": ["mangum>=0.9.0"],
+    "lambda": ["mangum>=0.10.0"],
     "deploy": [
         "docker",
         "python-dotenv",

--- a/tests/routes/test_cog.py
+++ b/tests/routes/test_cog.py
@@ -170,25 +170,23 @@ def test_tile(rio, app):
     data = numpy.load(BytesIO(response.content))
     assert data.shape == (1, 256, 256)
 
-    # We keep those tests for latter
-    # ref: https://github.com/developmentseed/titiler/issues/121
-    # # Test brotli compression
-    # headers = {"Accept-Encoding": "br, gzip"}
-    # response = app.get(
-    #     "/cog/tiles/8/87/48.npy?url=https://myurl.com/cog.tif&nodata=0&return_mask=false",
-    #     headers=headers,
-    # )
-    # assert response.status_code == 200
-    # assert response.headers["content-encoding"] == "br"
+    # Test brotli compression
+    headers = {"Accept-Encoding": "br, gzip"}
+    response = app.get(
+        "/cog/tiles/8/87/48.npy?url=https://myurl.com/cog.tif&nodata=0&return_mask=false",
+        headers=headers,
+    )
+    assert response.status_code == 200
+    assert response.headers["content-encoding"] == "br"
 
-    # # Test gzip fallback
-    # headers = {"Accept-Encoding": "gzip"}
-    # response = app.get(
-    #     "/cog/tiles/8/87/48.npy?url=https://myurl.com/cog.tif&nodata=0&return_mask=false",
-    #     headers=headers,
-    # )
-    # assert response.status_code == 200
-    # assert response.headers["content-encoding"] == "gzip"
+    # Test gzip fallback
+    headers = {"Accept-Encoding": "gzip"}
+    response = app.get(
+        "/cog/tiles/8/87/48.npy?url=https://myurl.com/cog.tif&nodata=0&return_mask=false",
+        headers=headers,
+    )
+    assert response.status_code == 200
+    assert response.headers["content-encoding"] == "gzip"
 
     # partial
     response = app.get(

--- a/titiler/main.py
+++ b/titiler/main.py
@@ -1,5 +1,7 @@
 """titiler app."""
 
+from brotli_asgi import BrotliMiddleware
+
 from . import settings, version
 from .endpoints import cog, mosaic, stac, tms
 from .errors import DEFAULT_STATUS_CODES, add_exception_handlers
@@ -8,7 +10,6 @@ from .middleware import CacheControlMiddleware, TotalTimeMiddleware
 from fastapi import FastAPI
 
 from starlette.middleware.cors import CORSMiddleware
-from starlette.middleware.gzip import GZipMiddleware
 
 api_settings = settings.ApiSettings()
 
@@ -35,7 +36,7 @@ if api_settings.cors_origins:
         allow_headers=["*"],
     )
 
-app.add_middleware(GZipMiddleware, minimum_size=0)
+app.add_middleware(BrotliMiddleware, minimum_size=0, gzip_fallback=True)
 app.add_middleware(CacheControlMiddleware, cachecontrol=api_settings.cachecontrol)
 app.add_middleware(TotalTimeMiddleware)
 

--- a/tox.ini
+++ b/tox.ini
@@ -46,5 +46,5 @@ ignore_missing_imports = True
 profile=black
 known_first_party = titiler
 forced_separate = fastapi,starlette
-known_third_party = rasterio,morecantile,rio_tiler_crs,rio_tiler,cogeo_mosaic
+known_third_party = rasterio,morecantile,rio_tiler_crs,rio_tiler,cogeo_mosaic,brotli_asgi
 default_section = THIRDPARTY


### PR DESCRIPTION
Now that mangum and brotli-asgi have new versions, we should restore brotli compression