### PR TITLE
CD to publish to dockerhub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,3 +73,31 @@ jobs:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: tox
+
+  publish-docker:
+    needs: [tests]
+    runs-on: ubuntu-latest
+    if: contains(github.ref, 'tags')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfiles/ecs/Dockerfile
+          push: true
+          tags: titiler:latest


### PR DESCRIPTION
Closes #45

This is derived from the example provided at https://github.com/docker/build-push-action. It should build a Dockerfile using the ECS image.

- For this to work you'll need to include `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` as secrets
- Should there be two docker images created? One for ECS and another for Lambda?