### PR TITLE
avoid changing mutable TMS and Colormap list by using deepcopy.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## Next (TBD)
+
+* avoid changing mutable TMS and Colormap list by using deepcopy.
+
 ## 0.1.0a8 (2020-10-13)
 
 * update for rio-tiler 2.0.0b17, which now support TMS (morecantile) by default.

--- a/titiler/dependencies.py
+++ b/titiler/dependencies.py
@@ -29,7 +29,7 @@ tms.register(custom_tms.EPSG3413)
 tms.register(custom_tms.EPSG6933)
 # REGISTER CUSTOM TMS
 #
-# e.g DefaultTileMatrixSets.register(custom_tms.my_custom_tms)
+# e.g tms.register(custom_tms.my_custom_tms)
 
 cmap.register("above", custom_colormap.above_cmap)
 # REGISTER CUSTOM COLORMAP HERE
@@ -65,7 +65,7 @@ def WebMercatorTMSParams(
     )
 ) -> TileMatrixSet:
     """TileMatrixSet Dependency."""
-    return DefaultTileMatrixSets.get(TileMatrixSetId.name)
+    return tms.get(TileMatrixSetId.name)
 
 
 def TMSParams(
@@ -75,7 +75,7 @@ def TMSParams(
     )
 ) -> TileMatrixSet:
     """TileMatrixSet Dependency."""
-    return DefaultTileMatrixSets.get(TileMatrixSetId.name)
+    return tms.get(TileMatrixSetId.name)
 
 
 @dataclass

--- a/titiler/dependencies.py
+++ b/titiler/dependencies.py
@@ -1,5 +1,6 @@
 """Common dependency."""
 
+import copy
 import re
 from dataclasses import dataclass, field
 from enum import Enum
@@ -9,7 +10,7 @@ import numpy
 from morecantile import tms as DefaultTileMatrixSets
 from morecantile.models import TileMatrixSet
 from rasterio.enums import Resampling
-from rio_tiler.colormap import cmap
+from rio_tiler.colormap import cmap as DefaultColorMap
 
 from .custom import cmap as custom_colormap
 from .custom import tms as custom_tms
@@ -19,10 +20,13 @@ from fastapi import Query
 
 from starlette.requests import Request
 
+tms = copy.deepcopy(DefaultTileMatrixSets)
+cmap = copy.deepcopy(DefaultColorMap)
+
 ################################################################################
 #                       CMAP AND TMS Customization
-DefaultTileMatrixSets.register(custom_tms.EPSG3413)
-DefaultTileMatrixSets.register(custom_tms.EPSG6933)
+tms.register(custom_tms.EPSG3413)
+tms.register(custom_tms.EPSG6933)
 # REGISTER CUSTOM TMS
 #
 # e.g DefaultTileMatrixSets.register(custom_tms.my_custom_tms)
@@ -45,7 +49,7 @@ WebMercatorTileMatrixSetName = Enum(  # type: ignore
     "WebMercatorTileMatrixSetName", [("WebMercatorQuad", "WebMercatorQuad")]
 )
 TileMatrixSetNames = Enum(  # type: ignore
-    "TileMatrixSetNames", [(a, a) for a in sorted(DefaultTileMatrixSets.list())]
+    "TileMatrixSetNames", [(a, a) for a in sorted(tms.list())]
 )
 
 


### PR DESCRIPTION
What this PR does:

because titiler is meant to be used as a python module, I think we shouldn't modify the mutable object from rio-tiler and morecantile. 

### Before
```
In [1]: from morecantile import tms                                                                                                                                                                                                                                                                                             
In [2]: tms.list()                                                                                                                                                                                                                                                                                                              
Out[2]: 
['LINZAntarticaMapTilegrid',
 'EuropeanETRS89_LAEAQuad',
 'CanadianNAD83_LCC',
 'UPSArcticWGS84Quad',
 'NZTM2000',
 'UTM31WGS84Quad',
 'UPSAntarcticWGS84Quad',
 'WorldMercatorWGS84Quad',
 'WorldCRS84Quad',
 'WebMercatorQuad']

In [3]: from titiler import dependencies                                                                                                                                                                                                                                                                                        
In [4]: tms.list()                                                                                                                                                                                                                                                                                                              
Out[4]: 
['LINZAntarticaMapTilegrid',
 'EuropeanETRS89_LAEAQuad',
 'CanadianNAD83_LCC',
 'UPSArcticWGS84Quad',
 'NZTM2000',
 'UTM31WGS84Quad',
 'UPSAntarcticWGS84Quad',
 'WorldMercatorWGS84Quad',
 'WorldCRS84Quad',
 'WebMercatorQuad',
 'EPSG3413',
 'EPSG6933']
```

### After
```
In [1]: import morecantile                                                                                                                                                                                                                                                         

In [2]: morecantile.tms.list()                                                                                                                                                                                                                                                     
Out[2]: 
['LINZAntarticaMapTilegrid',
 'EuropeanETRS89_LAEAQuad',
 'CanadianNAD83_LCC',
 'UPSArcticWGS84Quad',
 'NZTM2000',
 'UTM31WGS84Quad',
 'UPSAntarcticWGS84Quad',
 'WorldMercatorWGS84Quad',
 'WorldCRS84Quad',
 'WebMercatorQuad']

In [3]: from titiler import dependencies                                                                                                                                                                                                                                           
In [4]: dependencies.tms.list()                                                                                                                                                                                                                                                    
Out[4]: 
['LINZAntarticaMapTilegrid',
 'EuropeanETRS89_LAEAQuad',
 'CanadianNAD83_LCC',
 'UPSArcticWGS84Quad',
 'NZTM2000',
 'UTM31WGS84Quad',
 'UPSAntarcticWGS84Quad',
 'WorldMercatorWGS84Quad',
 'WorldCRS84Quad',
 'WebMercatorQuad',
 'EPSG3413',
 'EPSG6933']

In [5]: morecantile.tms.list()                                                                                                                                                                                                                                                     
Out[5]: 
['LINZAntarticaMapTilegrid',
 'EuropeanETRS89_LAEAQuad',
 'CanadianNAD83_LCC',
 'UPSArcticWGS84Quad',
 'NZTM2000',
 'UTM31WGS84Quad',
 'UPSAntarcticWGS84Quad',
 'WorldMercatorWGS84Quad',
 'WorldCRS84Quad',
 'WebMercatorQuad']
```