### PR TITLE
Add missing dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,11 @@ inst_reqs = [
     "rio-cogeo~=2.0",
     "rio-tiler>=2.0.0rc2,<2.1",
     "cogeo-mosaic>=3.0.0a17,<3.1",
+    "rasterio",
+    "pydantic",
+    "numpy",
+    "morecantile",
+    "dataclasses;python_version<'3.7'",
 ]
 extra_reqs = {
     "dev": ["pytest", "pytest-cov", "pytest-asyncio", "pre-commit", "requests"],


### PR DESCRIPTION
In my opinion, if a dependency is explicitly imported, it should be declared in `setup.py`'s `install_requires`. This adds missing dependencies to that list.