### PR TITLE
add /info.geojson routes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@
 * allow `API_DISABLE_{COG/STAC/MOSAIC}` environment variables to control default endpoints in titiler main app (ref: https://github.com/developmentseed/titiler/issues/156)
 * add `overwriting=False/True` on MosaicJSON creation (ref: https://github.com/developmentseed/titiler/issues/164)
 * add `gdal_config` option to Tiler factories to replace custom `APIRoute` class (ref: https://github.com/developmentseed/titiler/issues/168)
+* add `info.json` endpoint to return dataset info as a GeoJSON feature (ref: https://github.com/developmentseed/titiler/issues/166)
+
 
 ## 0.1.0a12 (2020-11-18)
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ titiler/                         - titiler python module.
  ├── models/                     - pydantic models for this application.
  ├── ressources/                 - application resources (enums, constants, etc.).
  ├── templates/                  - html/xml models.
+ ├── middleware.py               - Custom Starlette middlewares.
  ├── dependencies.py             - API dependencies.
  ├── errors.py                   - API custom error handling.
  ├── main.py                     - FastAPI application creation and configuration.
@@ -100,10 +101,9 @@ stack/
  ├── config.py                   - Optional parameters for the stack definition [EDIT THIS]
  │
 Dockerfiles/
- ├── ecs/
- │   └── Dockerfile              - Dockerfile to build the ECS service image.
- ├── lambda/
- │   └── Dockerfile              - Dockerfile to build the Lambda service image.
+ ├── Dockerfile                  - Dockerfile to build the ECS service image.
+ ├── lambda.package              - Dockerfile to build the Lambda service package.
+ ├── lambda.container            - Dockerfile to build the Lambda service container.
  │
 lambda/
  │   └── handler.py              - Mangum adaptor for AWS Lambda.

--- a/docs/concepts/tiler_factories.md
+++ b/docs/concepts/tiler_factories.md
@@ -7,6 +7,7 @@ Tiler factories (`titiler.endpoints.factory.TilerFactory|MosaicTilerFactory`) ar
 | ------ | --------------------------------------------------------------- |---------- |--------------
 | `GET`  | `/bounds`                                                       | JSON      | return bounds info for a dataset
 | `GET`  | `/info`                                                         | JSON      | return basic info for a dataset
+| `GET`  | `/info.geojson`                                                 | GeoJSON   | return basic info for a dataset as a GeoJSON feature
 | `GET`  | `/metadata`                                                     | JSON      | return info and statistics for a dataset
 | `GET`  | `/tiles/[{TileMatrixSetId}]/{z}/{x}/{y}[@{scale}x][.{format}]`  | image/bin | create a web map tile image from a dataset
 | `GET`  | `/[{TileMatrixSetId}]/tilejson.json`                            | JSON      | return a Mapbox TileJSON document
@@ -24,6 +25,7 @@ Tiler factories (`titiler.endpoints.factory.TilerFactory|MosaicTilerFactory`) ar
 | `PUT`  | `/`                                                             | JSON      | update a MosaicJSON from a list of files
 | `GET`  | `/bounds`                                                       | JSON      | return bounds info for a MosaicJSON
 | `GET`  | `/info`                                                         | JSON      | return basic info for a MosaicJSON
+| `GET`  | `/info.geojson`                                                 | GeoJSON   | return basic info for a MosaicJSON as a GeoJSON feature
 | `GET`  | `/tiles/[{TileMatrixSetId}]/{z}/{x}/{y}[@{scale}x][.{format}]`  | image/bin | create a web map tile image from a MosaicJSON
 | `GET`  | `/[{TileMatrixSetId}]/tilejson.json`                            | JSON      | return a Mapbox TileJSON document
 | `GET`  | `/{TileMatrixSetId}/WMTSCapabilities.xml`                       | XML       | return OGC WMTS Get Capabilities

--- a/docs/endpoints/cog.md
+++ b/docs/endpoints/cog.md
@@ -20,6 +20,7 @@ app.include_router(cog.router, prefix="/cog", tags=["Cloud Optimized GeoTIFF"])
 | ------ | ------------------------------------------------------------------- |---------- |--------------
 | `GET`  | `/cog/bounds`                                                       | JSON      | return bounds info for a dataset
 | `GET`  | `/cog/info`                                                         | JSON      | return basic info for a dataset
+| `GET`  | `/cog/info.geojson`                                                 | GeoJSON   | return basic info for a dataset as a GeoJSON feature
 | `GET`  | `/cog/metadata`                                                     | JSON      | return info and statistics for a dataset
 | `GET`  | `/cog/tiles/[{TileMatrixSetId}]/{z}/{x}/{y}[@{scale}x][.{format}]`  | image/bin | create a web map tile image from a dataset
 | `GET`  | `/cog/[{TileMatrixSetId}]/tilejson.json`                            | JSON      | return a Mapbox TileJSON document
@@ -177,6 +178,15 @@ Example:
 Example:
 
 - `https://myendpoint/cog/info?url=https://somewhere.com/mycog.tif`
+
+`:endpoint:/cog/info.geojson` general raster info as a GeoJSON feature
+- QueryParams:
+    - **url**: Cloud Optimized GeoTIFF URL. **REQUIRED**
+
+Example:
+
+- `https://myendpoint/cog/info.geojson?url=https://somewhere.com/mycog.tif`
+
 
 ### Metadata
 

--- a/docs/endpoints/mosaic.md
+++ b/docs/endpoints/mosaic.md
@@ -23,6 +23,7 @@ app.include_router(mosaic.router, prefix="/mosaicjson", tags=["MosaicJSON"])
 | `PUT`  | `/mosaicjson/`                                                             | JSON      | update a MosaicJSON from a list of files
 | `GET`  | `/mosaicjson/bounds`                                                       | JSON      | return bounds info for a MosaicJSON
 | `GET`  | `/mosaicjson/info`                                                         | JSON      | return basic info for a MosaicJSON
+| `GET`  | `/mosaicjson/info.geojson`                                                 | GeoJSON   | return basic info for a MosaicJSON as a GeoJSON feature
 | `GET`  | `/mosaicjson/tiles/[{TileMatrixSetId}]/{z}/{x}/{y}[@{scale}x][.{format}]`  | image/bin | create a web map tile image from a MosaicJSON
 | `GET`  | `/mosaicjson/[{TileMatrixSetId}]/tilejson.json`                            | JSON      | return a Mapbox TileJSON document
 | `GET`  | `/mosaicjson/{TileMatrixSetId}/WMTSCapabilities.xml`                       | XML       | return OGC WMTS Get Capabilities

--- a/docs/endpoints/stac.md
+++ b/docs/endpoints/stac.md
@@ -20,6 +20,7 @@ app.include_router(stac.router, prefix="/stac", tags=["SpatioTemporal Asset Cata
 | ------ | ------------------------------------------------------------------- |---------- |--------------
 | `GET`  | `/stac/bounds`                                                       | JSON      | return bounds info for a dataset
 | `GET`  | `/stac/info`                                                         | JSON      | return basic info for a dataset
+| `GET`  | `/stac/info.geojson`                                                 | GeoJSON   | return basic info for a dataset as a GeoJSON feature
 | `GET`  | `/stac/metadata`                                                     | JSON      | return info and statistics for a dataset
 | `GET`  | `/stac/tiles/[{TileMatrixSetId}]/{z}/{x}/{y}[@{scale}x][.{format}]`  | image/bin | create a web map tile image from a dataset
 | `GET`  | `/stac/[{TileMatrixSetId}]/tilejson.json`                            | JSON      | return a Mapbox TileJSON document
@@ -196,6 +197,19 @@ Note: If `assets` is not provided, `/stac/info` will return the list of assets.
 Example:
 
 - `https://myendpoint/stac/info?url=https://somewhere.com/item.json&assets=B01`
+
+`:endpoint:/stac/info.geojson` - Return basic info on STAC item's COG as a GeoJSON feature
+
+- QueryParams:
+    - **url**: STAC Item URL. **REQUIRED**
+    - **assets**: Comma (',') delimited asset names. OPTIONAL
+
+Note: If `assets` is not provided, `/stac/info.geojson` will return the list of assets in the properties.
+
+Example:
+
+- `https://myendpoint/stac/info.geojson?url=https://somewhere.com/item.json&assets=B01`
+
 
 ### Metadata
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -56,14 +56,14 @@ customized endpoints, you can import and extend the app directly:
 ```py
 from titiler.main import app
 
-from fastapi import FastAPI, APIRouter
-from titiler.custom.routing import apiroute_factory
 from titiler.endpoints.factory import TilerFactory
 
 # Create a custom Tiler (see: https://github.com/developmentseed/titiler-pds/blob/master/app/routes/naip.py)
-route_class = apiroute_factory({"AWS_REQUEST_PAYER": "requester"})
-router = APIRouter(route_class=route_class)
-tiler = TilerFactory(router=router, prefix="private/cog")
+tiler = TilerFactory(
+    router=router,
+    prefix="private/cog",
+    gdal_config={"AWS_REQUEST_PAYER": "requester"},
+)
 
 app.include_router(
     tiler.router,

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ inst_reqs = [
     "numpy",
     "morecantile",
     "dataclasses;python_version<'3.7'",
+    "geojson-pydantic",
 ]
 extra_reqs = {
     "dev": ["pytest", "pytest-cov", "pytest-asyncio", "pre-commit", "requests"],

--- a/tests/routes/test_cog.py
+++ b/tests/routes/test_cog.py
@@ -35,6 +35,16 @@ def test_info(rio, app):
     assert body["colorinterp"] == ["gray"]
     assert body["nodata_type"] == "None"
 
+    response = app.get("/cog/info.geojson?url=https://myurl.com/cog.tif")
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/geo+json"
+    body = response.json()
+    assert body["geometry"]
+    assert body["properties"]["band_descriptions"] == [["1", ""]]
+    assert body["properties"]["dtype"] == "uint16"
+    assert body["properties"]["colorinterp"] == ["gray"]
+    assert body["properties"]["nodata_type"] == "None"
+
 
 @patch("rio_tiler.io.cogeo.rasterio")
 def test_metadata(rio, app):

--- a/tests/routes/test_mosaic.py
+++ b/tests/routes/test_mosaic.py
@@ -100,6 +100,16 @@ def test_info(app):
     assert body["name"] == "mosaic"  # mosaic.name is not set
     assert body["quadkeys"] == []
 
+    response = app.get("/mosaicjson/info.geojson", params={"url": MOSAICJSON_FILE})
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/geo+json"
+    body = response.json()
+    assert body["geometry"]
+    assert body["properties"]["minzoom"] == 7
+    assert body["properties"]["maxzoom"] == 9
+    assert body["properties"]["name"] == "mosaic"  # mosaic.name is not set
+    assert body["properties"]["quadkeys"] == []
+
 
 def test_tilejson(app):
     """test GET /mosaicjson/tilejson.json endpoint"""

--- a/tests/routes/test_stac.py
+++ b/tests/routes/test_stac.py
@@ -43,6 +43,21 @@ def test_info(requests, rio, app):
     assert body["B01"]
     assert body["B09"]
 
+    response = app.get("/stac/info.geojson?url=https://myurl.com/item.json")
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/geo+json"
+    body = response.json()
+    assert body["geometry"]
+    assert len(body["properties"]["available_assets"]) == 17
+
+    response = app.get("/stac/info.geojson?url=https://myurl.com/item.json&assets=B01")
+    assert response.status_code == 200
+    body = response.json()
+    assert response.headers["content-type"] == "application/geo+json"
+    body = response.json()
+    assert body["geometry"]
+    assert body["properties"]["assets"]["B01"]
+
 
 @patch("rio_tiler.io.cogeo.rasterio")
 @patch("rio_tiler.io.stac.requests")

--- a/tests/test_factories.py
+++ b/tests/test_factories.py
@@ -9,11 +9,11 @@ def test_TilerFactory(set_env):
     from titiler.endpoints import factory
 
     app = factory.TilerFactory(reader=COGReader)
-    assert len(app.router.routes) == 20
+    assert len(app.router.routes) == 21
     assert app.tms_dependency == TMSParams
 
     app = factory.TilerFactory(reader=COGReader, add_preview=False, add_part=False)
-    assert len(app.router.routes) == 16
+    assert len(app.router.routes) == 17
 
 
 def test_MosaicTilerFactory(set_env):
@@ -22,8 +22,8 @@ def test_MosaicTilerFactory(set_env):
     from titiler.endpoints import factory
 
     app = factory.MosaicTilerFactory()
-    assert len(app.router.routes) == 18
+    assert len(app.router.routes) == 19
     assert app.tms_dependency == WebMercatorTMSParams
 
     app = factory.MosaicTilerFactory(add_create=False, add_update=False)
-    assert len(app.router.routes) == 16
+    assert len(app.router.routes) == 17

--- a/titiler/ressources/enums.py
+++ b/titiler/ressources/enums.py
@@ -19,6 +19,7 @@ class MimeTypes(str, Enum):
     npy = "application/x-binary"
     xml = "application/xml"
     json = "application/json"
+    geojson = "application/geo+json"
     html = "text/html"
     text = "text/plain"
 

--- a/titiler/ressources/responses.py
+++ b/titiler/ressources/responses.py
@@ -1,9 +1,15 @@
 """Common response models."""
 
-from starlette.responses import Response
+from starlette.responses import JSONResponse, Response
 
 
 class XMLResponse(Response):
     """XML Response"""
 
     media_type = "application/xml"
+
+
+class GeoJSONResponse(JSONResponse):
+    """GeoJSON Response"""
+
+    media_type = "application/geo+json"

--- a/titiler/utils.py
+++ b/titiler/utils.py
@@ -3,7 +3,9 @@
 import hashlib
 import json
 import time
-from typing import Any
+from typing import Any, Dict, Optional, Tuple
+
+from geojson_pydantic.features import Feature
 
 
 def get_hash(**kwargs: Any) -> str:
@@ -36,3 +38,27 @@ class Timer(object):
     def from_start(self):
         """Return time elapsed from start."""
         return time.time() - self.start
+
+
+def bbox_to_feature(
+    bbox: Tuple[float, float, float, float], properties: Optional[Dict] = None,
+) -> Feature:
+    """Create a GeoJSON feature polygon from a bounding box."""
+    return Feature(
+        **{
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [bbox[0], bbox[3]],
+                        [bbox[0], bbox[1]],
+                        [bbox[2], bbox[1]],
+                        [bbox[2], bbox[3]],
+                        [bbox[0], bbox[3]],
+                    ]
+                ],
+            },
+            "properties": {} or properties,
+            "type": "Feature",
+        }
+    )

--- a/tox.ini
+++ b/tox.ini
@@ -46,5 +46,5 @@ ignore_missing_imports = True
 profile=black
 known_first_party = titiler
 forced_separate = fastapi,starlette
-known_third_party = rasterio,morecantile,rio_tiler_crs,rio_tiler,cogeo_mosaic,brotli_asgi
+known_third_party = rasterio,morecantile,rio_tiler_crs,rio_tiler,cogeo_mosaic,brotli_asgi,geojson_pydantic
 default_section = THIRDPARTY


### PR DESCRIPTION
closes #166 

This PR adds a `/info.geojson` route to the Tiler Factories. 

Note: I didn't change the `/info` endpoints to `/info.json` (because this was leading to a 🕳️ , basically if we add info.json, then we should also have metadata.json, bounds.json...)

cc @geospatial-jeff 