### PR TITLE
ingress template for k8s chart deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,4 @@ ENV/
 .mypy_cache/
 
 cdk.out/
+deployment/k8s/titiler/values-test.yaml

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 * add `rio_tiler.errors.MissingBands` in known errors.
 * add `titiler.endpoints.factory.TMSFactory` to enable custom TMS endpoints.
 * **breaking** rename `BaseFactory` to `BaseTilerFactory` in `titiler.endpoints.factory`
+* add `ingress` template in k8s deployment
 
 ## 0.1.0a13 (2020-12-20)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,6 @@
 * add `rio_tiler.errors.MissingBands` in known errors.
 * add `titiler.endpoints.factory.TMSFactory` to enable custom TMS endpoints.
 * **breaking** rename `BaseFactory` to `BaseTilerFactory` in `titiler.endpoints.factory`
-* add `ingress` template in k8s deployment
 
 ## 0.1.0a13 (2020-12-20)
 

--- a/deployment/k8s/titiler/templates/NOTES.txt
+++ b/deployment/k8s/titiler/templates/NOTES.txt
@@ -1,0 +1,21 @@
+1. Get the Titile docs deployed here:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}docs
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "cpes.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT/docs
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "cpes.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "cpes.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "cpes.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080/docs to use Titiler"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:80
+{{- end }}

--- a/deployment/k8s/titiler/templates/ingress.yaml
+++ b/deployment/k8s/titiler/templates/ingress.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "titiler.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+  {{- end }}

--- a/deployment/k8s/titiler/values.yaml
+++ b/deployment/k8s/titiler/values.yaml
@@ -13,6 +13,18 @@ service:
   type: ClusterIP
   port: 80
 
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: titiler.local
+      paths: ["/"]
+  tls: []
+  #  - secretName: titiler-tls
+  #    hosts:
+  #      - titiler.local
 
 env:
   PORT: 80


### PR DESCRIPTION
**Proposed Changes:**

***Add ingress template in k8s deployment***

In a production k8s cluster, the ingress resource in essential to route request from a public address to a service that loads balance towards several replicas of the deployment.
This PR adds a new template for the ingress following the helm charts conventions and allowing TLS termination

**PR Checklist:**

- [X] This PR has **no** breaking changes.
- [X] I have added my changes to the [CHANGELOG](https://github.com/developmentseed/titiler/blob/master/CHANGES.md)