### PR TITLE
Add edit and site links

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,8 @@ site_description: A lightweight service for creating map tiles from Cloud-Optimi
 
 repo_name: "developmentseed/titiler"
 repo_url: "https://github.com/developmentseed/titiler"
+edit_uri: "blob/master/docs/"
+site_url: "https://developmentseed.org/titiler/"
 
 extra:
   social:


### PR DESCRIPTION
Adding the [`site_url`](https://www.mkdocs.org/user-guide/configuration/#site_url):

> This will add a link tag with the canonical URL to the generated HTML header.

The edit link isn't strictly necessary. As you can tell, there's already an edit link on titiler pages. The main difference is that the default edit link goes _straight to the editing mode_ on Github. That means that a user who isn't logged in would be immediately greeted with an auth wall. When I was writing docs with mkdocs for my first project, most users wouldn't be on Github, so I wanted them to see the Github docs page before needing to sign in. But here that's probably personal preference.