### PR TITLE
Pin rasterio in dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,9 @@ COPY README.md /app/README.md
 COPY titiler/ /app/titiler/
 COPY setup.py /app/setup.py
 
-RUN pip install -e /app/. --no-cache-dir
+# rasterio 1.2.0 wheels are built using GDAL 3.2 and PROJ 7 which we found having a
+# performance downgrade: https://github.com/developmentseed/titiler/discussions/216
+RUN pip install -e /app/. rasterio==1.1.8 --no-cache-dir
 
 ENV MODULE_NAME titiler.main
 ENV VARIABLE_NAME app

--- a/deployment/aws/lambda/Dockerfile
+++ b/deployment/aws/lambda/Dockerfile
@@ -2,7 +2,9 @@ FROM lambci/lambda:build-python3.8
 
 WORKDIR /tmp
 
-RUN pip install titiler mangum>=0.10.0 -t /var/task --no-binary numpy,pydantic
+# rasterio 1.2.0 wheels are built using GDAL 3.2 and PROJ 7 which we found having a
+# performance downgrade: https://github.com/developmentseed/titiler/discussions/216
+RUN pip install titiler mangum>=0.10.0 rasterio==1.1.8 -t /var/task --no-binary numpy,pydantic
 
 # Reduce package size and remove useless files
 RUN cd /var/task && find . -type f -name '*.pyc' | while read f; do n=$(echo $f | sed 's/__pycache__\///' | sed 's/.cpython-[2-3][0-9]//'); cp $f $n; done;


### PR DESCRIPTION
```
# rasterio 1.2.0 wheels are built using GDAL 3.2 and PROJ 7 which we found has a
# performance downgrade: https://github.com/developmentseed/titiler/discussions/216
```