### PR TITLE
add backend options to the MosaicTilerFactory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,9 @@ jobs:
       - name: Run Tox
         run: tox -e py
 
-      # Run pre-commit (only for python-3.7)
+      # Run pre-commit (only for python-3.8)
       - name: run pre-commit
-        if: matrix.python-version == 3.7
+        if: matrix.python-version == 3.8
         run: pre-commit run --all-files
 
       - name: Upload Results

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,20 +3,20 @@ repos:
     rev: 19.10b0
     hooks:
       - id: black
-        language_version: python3.7
+        language_version: python3.8
         args: ["--safe"]
 
   - repo: https://github.com/PyCQA/isort
     rev: 5.4.2
     hooks:
       - id: isort
-        language_version: python3.7
+        language_version: python3.8
 
   - repo: https://github.com/PyCQA/flake8
     rev: 3.8.3
     hooks:
       - id: flake8
-        language_version: python3.7
+        language_version: python3.8
         args: [
             # E501 let black handle all line length decisions
             # W503 black conflicts with "line break before operator" rule
@@ -28,7 +28,7 @@ repos:
     rev: 5.1.1
     hooks:
       - id: pydocstyle
-        language_version: python3.7
+        language_version: python3.8
         args: [
             # Check for docstring presence only
             "--select=D1",
@@ -40,5 +40,5 @@ repos:
     rev: v0.770
     hooks:
       - id: mypy
-        language_version: python3.7
+        language_version: python3.8
         args: ["--no-strict-optional", "--ignore-missing-imports"]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 0.2.0 (TBD)
+
+* adapt for cogeo-mosaic `3.0.0rc2` and add `backend_options` attribute in MosaicTilerFactory (https://github.com/developmentseed/titiler/pull/247)
+
 ## 0.1.0 (2021-02-17)
 
 * update FastAPI requirements

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ inst_reqs = [
     "morecantile",
     "rio-cogeo>=2.1,<2.2",
     "rio-tiler>=2.0.1,<2.1",
-    "cogeo-mosaic>=3.0.0rc1,<3.1",
+    "cogeo-mosaic>=3.0.0rc2,<3.1",
     "rasterio",
     "pydantic",
     "numpy",

--- a/titiler/endpoints/factory.py
+++ b/titiler/endpoints/factory.py
@@ -986,9 +986,7 @@ class MosaicTilerFactory(BaseTilerFactory):
         )
         def read(src_path=Depends(self.path_dependency),):
             """Read a MosaicJSON"""
-            with self.reader(
-                src_path.url, backend_options=self.backend_options
-            ) as mosaic:
+            with self.reader(src_path.url, **self.backend_options) as mosaic:
                 return mosaic.mosaic_def
 
     ############################################################################
@@ -1005,9 +1003,7 @@ class MosaicTilerFactory(BaseTilerFactory):
         def bounds(src_path=Depends(self.path_dependency)):
             """Return the bounds of the COG."""
             with rasterio.Env(**self.gdal_config):
-                with self.reader(
-                    src_path.url, backend_options=self.backend_options
-                ) as src_dst:
+                with self.reader(src_path.url, **self.backend_options) as src_dst:
                     return {"bounds": src_dst.bounds}
 
     ############################################################################
@@ -1023,9 +1019,7 @@ class MosaicTilerFactory(BaseTilerFactory):
         )
         def info(src_path=Depends(self.path_dependency)):
             """Return basic info."""
-            with self.reader(
-                src_path.url, backend_options=self.backend_options
-            ) as src_dst:
+            with self.reader(src_path.url, **self.backend_options) as src_dst:
                 return src_dst.info()
 
         @self.router.get(
@@ -1046,9 +1040,7 @@ class MosaicTilerFactory(BaseTilerFactory):
         ):
             """Return mosaic's basic info as a GeoJSON feature."""
             with rasterio.Env(**self.gdal_config):
-                with self.reader(
-                    src_path.url, backend_options=self.backend_options
-                ) as src_dst:
+                with self.reader(src_path.url, **self.backend_options) as src_dst:
                     info = src_dst.info(**kwargs).dict(exclude_none=True)
                     bounds = info.pop("bounds", None)
                     info.pop("center", None)
@@ -1111,7 +1103,7 @@ class MosaicTilerFactory(BaseTilerFactory):
                         src_path.url,
                         reader=self.dataset_reader,
                         reader_options=self.reader_options,
-                        backend_options=self.backend_options,
+                        **self.backend_options,
                     ) as src_dst:
                         mosaic_read = t.from_start
                         timings.append(("mosaicread", round(mosaic_read * 1000, 2)))
@@ -1121,8 +1113,8 @@ class MosaicTilerFactory(BaseTilerFactory):
                             y,
                             z,
                             pixel_selection=pixel_selection.method(),
-                            threads=threads,
                             tilesize=tilesize,
+                            threads=threads,
                             **layer_params.kwargs,
                             **dataset_params.kwargs,
                             **kwargs,
@@ -1218,13 +1210,11 @@ class MosaicTilerFactory(BaseTilerFactory):
             qs = urlencode(list(q.items()))
             tiles_url += f"?{qs}"
 
-            with self.reader(
-                src_path.url, backend_options=self.backend_options
-            ) as src_dst:
+            with self.reader(src_path.url, **self.backend_options) as src_dst:
                 center = list(src_dst.center)
                 if minzoom:
                     center[-1] = minzoom
-                tjson = {
+                return {
                     "bounds": src_dst.bounds,
                     "center": tuple(center),
                     "minzoom": minzoom if minzoom is not None else src_dst.minzoom,
@@ -1232,8 +1222,6 @@ class MosaicTilerFactory(BaseTilerFactory):
                     "name": os.path.basename(src_path.url),
                     "tiles": [tiles_url],
                 }
-
-            return tjson
 
     def wmts(self):  # noqa: C901
         """Add wmts endpoint."""
@@ -1288,9 +1276,7 @@ class MosaicTilerFactory(BaseTilerFactory):
             qs = urlencode(list(q.items()))
             tiles_url += f"?{qs}"
 
-            with self.reader(
-                src_path.url, backend_options=self.backend_options
-            ) as src_dst:
+            with self.reader(src_path.url, **self.backend_options) as src_dst:
                 bounds = src_dst.bounds
                 minzoom = minzoom if minzoom is not None else src_dst.minzoom
                 maxzoom = maxzoom if maxzoom is not None else src_dst.maxzoom
@@ -1354,7 +1340,7 @@ class MosaicTilerFactory(BaseTilerFactory):
                         src_path.url,
                         reader=self.dataset_reader,
                         reader_options=self.reader_options,
-                        backend_options=self.backend_options,
+                        **self.backend_options,
                     ) as src_dst:
                         mosaic_read = t.from_start
                         timings.append(("mosaicread", round(mosaic_read * 1000, 2)))

--- a/titiler/endpoints/factory.py
+++ b/titiler/endpoints/factory.py
@@ -944,6 +944,8 @@ class MosaicTilerFactory(BaseTilerFactory):
     # BaseBackend does not support other TMS than WebMercator
     tms_dependency: Callable[..., TileMatrixSet] = WebMercatorTMSParams
 
+    backend_options: Dict = field(default_factory=dict)
+
     def register_routes(self):
         """
         This Method register routes to the router.
@@ -984,7 +986,9 @@ class MosaicTilerFactory(BaseTilerFactory):
         )
         def read(src_path=Depends(self.path_dependency),):
             """Read a MosaicJSON"""
-            with self.reader(src_path.url) as mosaic:
+            with self.reader(
+                src_path.url, backend_options=self.backend_options
+            ) as mosaic:
                 return mosaic.mosaic_def
 
     ############################################################################
@@ -1001,7 +1005,9 @@ class MosaicTilerFactory(BaseTilerFactory):
         def bounds(src_path=Depends(self.path_dependency)):
             """Return the bounds of the COG."""
             with rasterio.Env(**self.gdal_config):
-                with self.reader(src_path.url) as src_dst:
+                with self.reader(
+                    src_path.url, backend_options=self.backend_options
+                ) as src_dst:
                     return {"bounds": src_dst.bounds}
 
     ############################################################################
@@ -1017,7 +1023,9 @@ class MosaicTilerFactory(BaseTilerFactory):
         )
         def info(src_path=Depends(self.path_dependency)):
             """Return basic info."""
-            with self.reader(src_path.url) as src_dst:
+            with self.reader(
+                src_path.url, backend_options=self.backend_options
+            ) as src_dst:
                 return src_dst.info()
 
         @self.router.get(
@@ -1038,7 +1046,9 @@ class MosaicTilerFactory(BaseTilerFactory):
         ):
             """Return mosaic's basic info as a GeoJSON feature."""
             with rasterio.Env(**self.gdal_config):
-                with self.reader(src_path.url, **self.reader_options) as src_dst:
+                with self.reader(
+                    src_path.url, backend_options=self.backend_options
+                ) as src_dst:
                     info = src_dst.info(**kwargs).dict(exclude_none=True)
                     bounds = info.pop("bounds", None)
                     info.pop("center", None)
@@ -1101,6 +1111,7 @@ class MosaicTilerFactory(BaseTilerFactory):
                         src_path.url,
                         reader=self.dataset_reader,
                         reader_options=self.reader_options,
+                        backend_options=self.backend_options,
                     ) as src_dst:
                         mosaic_read = t.from_start
                         timings.append(("mosaicread", round(mosaic_read * 1000, 2)))
@@ -1207,7 +1218,9 @@ class MosaicTilerFactory(BaseTilerFactory):
             qs = urlencode(list(q.items()))
             tiles_url += f"?{qs}"
 
-            with self.reader(src_path.url) as src_dst:
+            with self.reader(
+                src_path.url, backend_options=self.backend_options
+            ) as src_dst:
                 center = list(src_dst.center)
                 if minzoom:
                     center[-1] = minzoom
@@ -1275,7 +1288,9 @@ class MosaicTilerFactory(BaseTilerFactory):
             qs = urlencode(list(q.items()))
             tiles_url += f"?{qs}"
 
-            with self.reader(src_path.url) as src_dst:
+            with self.reader(
+                src_path.url, backend_options=self.backend_options
+            ) as src_dst:
                 bounds = src_dst.bounds
                 minzoom = minzoom if minzoom is not None else src_dst.minzoom
                 maxzoom = maxzoom if maxzoom is not None else src_dst.maxzoom
@@ -1339,6 +1354,7 @@ class MosaicTilerFactory(BaseTilerFactory):
                         src_path.url,
                         reader=self.dataset_reader,
                         reader_options=self.reader_options,
+                        backend_options=self.backend_options,
                     ) as src_dst:
                         mosaic_read = t.from_start
                         timings.append(("mosaicread", round(mosaic_read * 1000, 2)))


### PR DESCRIPTION
In cogeo-mosaic backend we are using `backend_options` to pass addition backend options (e.g client) 

cc @kylebarron 