### PR TITLE
make colormap an independent dependency

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@
 
 * renamed `OptionalHeaders`, `MimeTypes` and `ImageDrivers` enums to the singular form. (https://github.com/developmentseed/titiler/pull/258)
 * renamed `MimeType` to `MediaType` (https://github.com/developmentseed/titiler/pull/258)
+* add `ColorMapParams` dependency to ease the creation of custom colormap dependency (https://github.com/developmentseed/titiler/pull/252)
 
 ## 0.1.0 (2021-02-17)
 

--- a/docs/concepts/dependencies.md
+++ b/docs/concepts/dependencies.md
@@ -162,15 +162,27 @@ The `factories` allow users to set multiple default dependencies. Here is the li
             title="Color Formula",
             description="rio-color formula (info: https://github.com/mapbox/rio-color)",
         )
-        color_map: Optional[ColorMapNames] = Query(
-            None, description="rio-tiler's colormap name"
-        )
         return_mask: bool = Query(True, description="Add mask to the output data.")
-        colormap: Optional[Dict[int, Tuple[int, int, int, int]]] = field(init=False)
+
+        rescale_range: Optional[List[Union[float, int]]] = field(init=False)
 
         def __post_init__(self):
             """Post Init."""
-            self.colormap = cmap.get(self.color_map.value) if self.color_map else None
+            self.rescale_range = (
+                list(map(float, self.rescale.split(","))) if self.rescale else None
+            )
+    ```
+
+* **colormap_dependency**: colormap options.
+
+    ```python
+    def ColorMapParams(
+        color_map: ColorMapNames = Query(None, description="Colormap name",)
+    ) -> Optional[Dict]:
+        """Colormap Dependency."""
+        if color_map:
+            return cmap.get(color_map.value)
+        return None
     ```
 
 * **additional_dependency**: Default dependency, will be passed as `**kwargs` to all endpoints.

--- a/tests/test_CustomCmap.py
+++ b/tests/test_CustomCmap.py
@@ -1,0 +1,56 @@
+# """Test TiTiler Custom Colormap Params."""
+
+from enum import Enum
+from io import BytesIO
+from typing import Dict, Optional
+
+import numpy
+from rio_tiler.colormap import ColorMaps
+
+from titiler.endpoints import factory
+
+from .conftest import DATA_DIR
+
+from fastapi import FastAPI, Query
+
+from starlette.testclient import TestClient
+
+cmap_values = {
+    "cmap1": {6: (4, 5, 6, 255)},
+}
+cmap = ColorMaps(data=cmap_values)
+ColorMapNames = Enum(  # type: ignore
+    "ColorMapNames", [(a, a) for a in sorted(cmap.list())]
+)
+
+
+def ColorMapParams(
+    color_map: ColorMapNames = Query(None, description="Colormap name",)
+) -> Optional[Dict]:
+    """Colormap Dependency."""
+    if color_map:
+        return cmap.get(color_map.value)
+    return None
+
+
+def test_CustomCmap():
+    """Test Custom Render Params dependency."""
+    app = FastAPI()
+    cog = factory.TilerFactory(colormap_dependency=ColorMapParams)
+    app.include_router(cog.router)
+    client = TestClient(app)
+
+    response = client.get(
+        f"/preview.npy?url={DATA_DIR}/above_cog.tif&bidx=1&color_map=cmap1"
+    )
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/x-binary"
+    data = numpy.load(BytesIO(response.content))
+    assert 4 in data[0]
+    assert 5 in data[1]
+    assert 6 in data[2]
+
+    response = client.get(
+        f"/preview.npy?url={DATA_DIR}/above_cog.tif&bidx=1&color_map=another_cmap"
+    )
+    assert response.status_code == 422

--- a/titiler/dependencies.py
+++ b/titiler/dependencies.py
@@ -3,7 +3,7 @@
 import re
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Union
 
 import numpy
 from morecantile import tms
@@ -66,6 +66,15 @@ def TMSParams(
 ) -> TileMatrixSet:
     """TileMatrixSet Dependency."""
     return tms.get(TileMatrixSetId.name)
+
+
+def ColorMapParams(
+    color_map: ColorMapNames = Query(None, description="Colormap name",)
+) -> Optional[Dict]:
+    """Colormap Dependency."""
+    if color_map:
+        return cmap.get(color_map.value)
+    return None
 
 
 @dataclass
@@ -332,12 +341,10 @@ class RenderParams(DefaultDependency):
     )
     return_mask: bool = Query(True, description="Add mask to the output data.")
 
-    colormap: Optional[Dict[int, Tuple[int, int, int, int]]] = field(init=False)
     rescale_range: Optional[List[Union[float, int]]] = field(init=False)
 
     def __post_init__(self):
         """Post Init."""
-        self.colormap = cmap.get(self.color_map.value) if self.color_map else None
         self.rescale_range = (
             list(map(float, self.rescale.split(","))) if self.rescale else None
         )

--- a/titiler/dependencies.py
+++ b/titiler/dependencies.py
@@ -336,9 +336,6 @@ class RenderParams(DefaultDependency):
         title="Color Formula",
         description="rio-color formula (info: https://github.com/mapbox/rio-color)",
     )
-    color_map: Optional[ColorMapNames] = Query(
-        None, description="rio-tiler's colormap name"
-    )
     return_mask: bool = Query(True, description="Add mask to the output data.")
 
     rescale_range: Optional[List[Union[float, int]]] = field(init=False)

--- a/titiler/endpoints/factory.py
+++ b/titiler/endpoints/factory.py
@@ -24,6 +24,7 @@ from ..dependencies import (
     BandsParams,
     BidxExprParams,
     BidxParams,
+    ColorMapParams,
     DatasetParams,
     DefaultDependency,
     ImageParams,
@@ -90,6 +91,8 @@ class BaseTilerFactory(metaclass=abc.ABCMeta):
 
     # Image rendering Dependencies
     render_dependency: Type[DefaultDependency] = RenderParams
+
+    colormap_dependency: Callable[..., Optional[Dict]] = ColorMapParams
 
     # TileMatrixSet dependency
     tms_dependency: Callable[..., TileMatrixSet] = WebMercatorTMSParams
@@ -303,6 +306,7 @@ class TilerFactory(BaseTilerFactory):
             layer_params=Depends(self.layer_dependency),
             dataset_params=Depends(self.dataset_dependency),
             render_params=Depends(self.render_dependency),
+            colormap=Depends(self.colormap_dependency),
             kwargs: Dict = Depends(self.additional_dependency),
         ):
             """Create map tile from a dataset."""
@@ -325,9 +329,7 @@ class TilerFactory(BaseTilerFactory):
                             **dataset_params.kwargs,
                             **kwargs,
                         )
-                        colormap = render_params.colormap or getattr(
-                            src_dst, "colormap", None
-                        )
+                        colormap = colormap or getattr(src_dst, "colormap", None)
             timings.append(("dataread", round(t.elapsed * 1000, 2)))
 
             if not format:
@@ -390,6 +392,7 @@ class TilerFactory(BaseTilerFactory):
             layer_params=Depends(self.layer_dependency),  # noqa
             dataset_params=Depends(self.dataset_dependency),  # noqa
             render_params=Depends(self.render_dependency),  # noqa
+            colormap=Depends(self.colormap_dependency),  # noqa
             kwargs: Dict = Depends(self.additional_dependency),  # noqa
         ):
             """Return TileJSON document for a dataset."""
@@ -457,6 +460,7 @@ class TilerFactory(BaseTilerFactory):
             layer_params=Depends(self.layer_dependency),  # noqa
             dataset_params=Depends(self.dataset_dependency),  # noqa
             render_params=Depends(self.render_dependency),  # noqa
+            colormap=Depends(self.colormap_dependency),  # noqa
             kwargs: Dict = Depends(self.additional_dependency),  # noqa
         ):
             """OGC WMTS endpoint."""
@@ -577,6 +581,7 @@ class TilerFactory(BaseTilerFactory):
             img_params=Depends(self.img_dependency),
             dataset_params=Depends(self.dataset_dependency),
             render_params=Depends(self.render_dependency),
+            colormap=Depends(self.colormap_dependency),
             kwargs: Dict = Depends(self.additional_dependency),
         ):
             """Create preview of a dataset."""
@@ -592,9 +597,7 @@ class TilerFactory(BaseTilerFactory):
                             **dataset_params.kwargs,
                             **kwargs,
                         )
-                        colormap = render_params.colormap or getattr(
-                            src_dst, "colormap", None
-                        )
+                        colormap = colormap or getattr(src_dst, "colormap", None)
             timings.append(("dataread", round(t.elapsed * 1000, 2)))
 
             if not format:
@@ -647,6 +650,7 @@ class TilerFactory(BaseTilerFactory):
             image_params=Depends(self.img_dependency),
             dataset_params=Depends(self.dataset_dependency),
             render_params=Depends(self.render_dependency),
+            colormap=Depends(self.colormap_dependency),
             kwargs: Dict = Depends(self.additional_dependency),
         ):
             """Create image from part of a dataset."""
@@ -663,9 +667,7 @@ class TilerFactory(BaseTilerFactory):
                             **dataset_params.kwargs,
                             **kwargs,
                         )
-                        colormap = render_params.colormap or getattr(
-                            src_dst, "colormap", None
-                        )
+                        colormap = colormap or getattr(src_dst, "colormap", None)
             timings.append(("dataread", round(t.elapsed * 1000, 2)))
 
             with utils.Timer() as t:
@@ -1085,6 +1087,7 @@ class MosaicTilerFactory(BaseTilerFactory):
             layer_params=Depends(self.layer_dependency),
             dataset_params=Depends(self.dataset_dependency),
             render_params=Depends(self.render_dependency),
+            colormap=Depends(self.colormap_dependency),
             pixel_selection: PixelSelectionMethod = Query(
                 PixelSelectionMethod.first, description="Pixel selection method."
             ),
@@ -1135,7 +1138,7 @@ class MosaicTilerFactory(BaseTilerFactory):
                 content = image.render(
                     add_mask=render_params.return_mask,
                     img_format=format.driver,
-                    colormap=render_params.colormap,
+                    colormap=colormap,
                     **format.profile,
                 )
             timings.append(("format", round(t.elapsed * 1000, 2)))
@@ -1184,6 +1187,7 @@ class MosaicTilerFactory(BaseTilerFactory):
             layer_params=Depends(self.layer_dependency),  # noqa
             dataset_params=Depends(self.dataset_dependency),  # noqa
             render_params=Depends(self.render_dependency),  # noqa
+            colormap=Depends(self.colormap_dependency),  # noqa
             pixel_selection: PixelSelectionMethod = Query(
                 PixelSelectionMethod.first, description="Pixel selection method."
             ),  # noqa
@@ -1249,6 +1253,7 @@ class MosaicTilerFactory(BaseTilerFactory):
             layer_params=Depends(self.layer_dependency),  # noqa
             dataset_params=Depends(self.dataset_dependency),  # noqa
             render_params=Depends(self.render_dependency),  # noqa
+            colormap=Depends(self.colormap_dependency),  # noqa
             pixel_selection: PixelSelectionMethod = Query(
                 PixelSelectionMethod.first, description="Pixel selection method."
             ),  # noqa


### PR DESCRIPTION
closes #251 

This PR tries to simplify how we can register colormaps 

```python
from rio_tiler.colormap import cmap

# register new cmap if you want 
# cmap = cmap.register({"above": custom_colormap.above_cmap})

# define a enums with the available cmaps
ColorMapNames = Enum(  # type: ignore
    "ColorMapNames", [(a, a) for a in sorted(cmap.list())]
)

# create a cmap dependency
def ColorMapParams(
    color_map: ColorMapNames = Query(None, description="Colormap name",)
) -> Optional[Dict]:
    """Colormap Dependency."""
    if color_map:
        return cmap.get(color_map.value)
    return None


tiler = TilerFactory(colormap_dependency=ColorMapParams)
``` 



### To Do 
- [x] write doc