### PR TITLE
add Custom Colormap querystring option

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # Release Notes
 
-## 0.2.0 (TBD)
+## 0.2.0 (2021-03-09)
 
 * adapt for cogeo-mosaic `3.0.0rc2` and add `backend_options` attribute in MosaicTilerFactory (https://github.com/developmentseed/titiler/pull/247)
 * update FastAPI requirements
@@ -15,6 +15,21 @@
 * renamed `MimeType` to `MediaType` (https://github.com/developmentseed/titiler/pull/258)
 * add `ColorMapParams` dependency to ease the creation of custom colormap dependency (https://github.com/developmentseed/titiler/pull/252)
 * renamed `PathParams` to `DatasetPathParams` and also made it a simple callable (https://github.com/developmentseed/titiler/pull/260)
+* renamed `colormap` query-parameter to `colormap_name` (https://github.com/developmentseed/titiler/pull/262)
+    ```
+    # before
+    /cog/preview.png?colormap=viridis
+
+    # now
+    /cog/preview.png?colormap_name=viridis
+    ```
+
+* use `colormap` query-parameter to pass custom colormap (https://github.com/developmentseed/titiler/pull/262)
+    ```
+    /cog/preview.png?colormap={"0": "#FFFF00FF", ...}
+    ```
+
+
 
 ## 0.1.0 (2021-02-17)
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ inst_reqs = [
     "python-dotenv",
     "rasterio",
     "rio-cogeo>=2.1,<2.2",
-    "rio-tiler>=2.0.1,<2.1",
+    "rio-tiler>=2.0.4,<2.1",
     "uvicorn[standard]>=0.12.0,<0.14.0",
     # Additional requirements for python 3.6
     "dataclasses;python_version<'3.7'",

--- a/tests/routes/test_cog.py
+++ b/tests/routes/test_cog.py
@@ -1,7 +1,10 @@
 """test /COG endpoints."""
+
+import json
 import os
 from io import BytesIO
 from unittest.mock import patch
+from urllib.parse import urlencode
 
 import numpy
 import pytest
@@ -202,19 +205,37 @@ def test_tile(rio, app):
     assert response.headers["content-type"] == "image/png"
 
     response = app.get(
-        "/cog/tiles/8/84/47?url=https://myurl.com/cog.tif&nodata=0&rescale=0,1000&color_map=viridis"
+        "/cog/tiles/8/84/47?url=https://myurl.com/cog.tif&nodata=0&rescale=0,1000&colormap_name=viridis"
     )
     assert response.status_code == 200
     assert response.headers["content-type"] == "image/png"
 
     response = app.get(
-        "/cog/tiles/8/53/50.png?url=https://myurl.com/above_cog.tif&bidx=1&color_map=above"
+        "/cog/tiles/8/53/50.png?url=https://myurl.com/above_cog.tif&bidx=1&colormap_name=above"
+    )
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "image/png"
+
+    cmap = urlencode(
+        {
+            "colormap": json.dumps(
+                {
+                    "1": [58, 102, 24, 255],
+                    "2": [100, 177, 41],
+                    "3": "#b1b129",
+                    "4": "#ddcb9aFF",
+                }
+            )
+        }
+    )
+    response = app.get(
+        f"/cog/tiles/8/53/50.png?url=https://myurl.com/above_cog.tif&bidx=1&{cmap}"
     )
     assert response.status_code == 200
     assert response.headers["content-type"] == "image/png"
 
     response = app.get(
-        "/cog/tiles/8/53/50.png?url=https://myurl.com/above_cog.tif&bidx=1&color_map=above&resampling_method=somethingwrong"
+        "/cog/tiles/8/53/50.png?url=https://myurl.com/above_cog.tif&bidx=1&colormap_name=above&resampling_method=somethingwrong"
     )
     assert response.status_code == 422
 

--- a/tests/routes/test_cog.py
+++ b/tests/routes/test_cog.py
@@ -262,6 +262,7 @@ def test_tilejson(rio, app):
     assert body["tilejson"] == "2.2.0"
     assert body["version"] == "1.0.0"
     assert body["scheme"] == "xyz"
+    assert body["name"] == "cog.tif"
     assert len(body["tiles"]) == 1
     assert body["tiles"][0].startswith(
         "http://testserver/cog/tiles/WebMercatorQuad/{z}/{x}/{y}@1x?url=https"

--- a/tests/routes/test_mosaic.py
+++ b/tests/routes/test_mosaic.py
@@ -161,7 +161,7 @@ def test_tile(app):
             params={
                 "url": MOSAICJSON_FILE,
                 "rescale": "0,1000",
-                "color_map": "viridis",
+                "colormap_name": "viridis",
                 "bidx": 1,
             },
         )

--- a/tests/test_CustomCmap.py
+++ b/tests/test_CustomCmap.py
@@ -19,17 +19,18 @@ cmap_values = {
     "cmap1": {6: (4, 5, 6, 255)},
 }
 cmap = ColorMaps(data=cmap_values)
-ColorMapNames = Enum(  # type: ignore
-    "ColorMapNames", [(a, a) for a in sorted(cmap.list())]
+ColorMapName = Enum(  # type: ignore
+    "ColorMapName", [(a, a) for a in sorted(cmap.list())]
 )
 
 
 def ColorMapParams(
-    color_map: ColorMapNames = Query(None, description="Colormap name",)
+    colormap_name: ColorMapName = Query(None, description="Colormap name"),
 ) -> Optional[Dict]:
     """Colormap Dependency."""
-    if color_map:
-        return cmap.get(color_map.value)
+    if colormap_name:
+        return cmap.get(colormap_name.value)
+
     return None
 
 
@@ -41,7 +42,7 @@ def test_CustomCmap():
     client = TestClient(app)
 
     response = client.get(
-        f"/preview.npy?url={DATA_DIR}/above_cog.tif&bidx=1&color_map=cmap1"
+        f"/preview.npy?url={DATA_DIR}/above_cog.tif&bidx=1&colormap_name=cmap1"
     )
     assert response.status_code == 200
     assert response.headers["content-type"] == "application/x-binary"
@@ -51,6 +52,6 @@ def test_CustomCmap():
     assert 6 in data[2]
 
     response = client.get(
-        f"/preview.npy?url={DATA_DIR}/above_cog.tif&bidx=1&color_map=another_cmap"
+        f"/preview.npy?url={DATA_DIR}/above_cog.tif&bidx=1&colormap_name=another_cmap"
     )
     assert response.status_code == 422

--- a/titiler/dependencies.py
+++ b/titiler/dependencies.py
@@ -10,7 +10,7 @@ import numpy
 from morecantile import tms
 from morecantile.models import TileMatrixSet
 from rasterio.enums import Resampling
-from rio_tiler.colormap import cmap
+from rio_tiler.colormap import cmap, parse_color
 from rio_tiler.errors import MissingAssets, MissingBands
 
 from .custom import cmap as custom_colormap
@@ -67,53 +67,6 @@ def TMSParams(
 ) -> TileMatrixSet:
     """TileMatrixSet Dependency."""
     return tms.get(TileMatrixSetId.name)
-
-
-def parse_color(value: Union[List[int], str]) -> List[int]:
-    """Parse RGB/RGBA color and return valid rio-tiler compatible RGBA colormap entry.
-
-    Args:
-        value (str or list of int): HEX encoded or list RGB or RGBA colors.
-
-    Returns:
-        list: RGBA values.
-
-    Examples:
-        >>> parse_color("#FFF")
-        [255, 255, 255, 255]
-
-        >>> parse_color("#FF0000FF")
-        [255, 0, 0, 255]
-
-        >>> parse_color("#FF0000")
-        [255, 0, 0, 255]
-
-        >>> parse_color([255, 255, 255])
-        [255, 255, 255, 255]
-
-    """
-    if isinstance(value, str):
-        hex_pattern = (
-            r"^#"
-            r"(?P<red>[a-fA-F0-9]{1,2})"
-            r"(?P<green>[a-fA-F0-9]{1,2})"
-            r"(?P<blue>[a-fA-F0-9]{1,2})"
-            r"(?P<alpha>[a-fA-F0-9]{1,2})?"
-            r"$"
-        )
-        match = re.match(hex_pattern, value)
-        if match:
-            factor = 1 if len(match.groups()[0]) == 2 else 2
-            value = [
-                int(n * factor, 16) for n in match.groupdict().values() if n is not None
-            ]
-        else:
-            raise Exception(f"Invalid color {value}")
-
-    if len(value) == 3:
-        value += [255]
-
-    return value
 
 
 def ColorMapParams(

--- a/titiler/dependencies.py
+++ b/titiler/dependencies.py
@@ -1,5 +1,6 @@
 """Common dependency."""
 
+import json
 import re
 from dataclasses import dataclass, field
 from enum import Enum
@@ -68,12 +69,67 @@ def TMSParams(
     return tms.get(TileMatrixSetId.name)
 
 
+def parse_color(value: Union[List[int], str]) -> List[int]:
+    """Parse RGB/RGBA color and return valid rio-tiler compatible RGBA colormap entry.
+
+    Args:
+        value (str or list of int): HEX encoded or list RGB or RGBA colors.
+
+    Returns:
+        list: RGBA values.
+
+    Examples:
+        >>> parse_color("#FFF")
+        [255, 255, 255, 255]
+
+        >>> parse_color("#FF0000FF")
+        [255, 0, 0, 255]
+
+        >>> parse_color("#FF0000")
+        [255, 0, 0, 255]
+
+        >>> parse_color([255, 255, 255])
+        [255, 255, 255, 255]
+
+    """
+    if isinstance(value, str):
+        hex_pattern = (
+            r"^#"
+            r"(?P<red>[a-fA-F0-9]{1,2})"
+            r"(?P<green>[a-fA-F0-9]{1,2})"
+            r"(?P<blue>[a-fA-F0-9]{1,2})"
+            r"(?P<alpha>[a-fA-F0-9]{1,2})?"
+            r"$"
+        )
+        match = re.match(hex_pattern, value)
+        if match:
+            factor = 1 if len(match.groups()[0]) == 2 else 2
+            value = [
+                int(n * factor, 16) for n in match.groupdict().values() if n is not None
+            ]
+        else:
+            raise Exception(f"Invalid color {value}")
+
+    if len(value) == 3:
+        value += [255]
+
+    return value
+
+
 def ColorMapParams(
-    color_map: ColorMapName = Query(None, description="Colormap name",)
+    colormap_name: ColorMapName = Query(None, description="Colormap name"),
+    colormap: str = Query(None, description="JSON encoded custom Colormap"),
 ) -> Optional[Dict]:
     """Colormap Dependency."""
-    if color_map:
-        return cmap.get(color_map.value)
+    if colormap_name:
+        return cmap.get(colormap_name.value)
+
+    if colormap:
+        return json.loads(
+            colormap,
+            object_hook=lambda x: {int(k): parse_color(v) for k, v in x.items()},
+        )
+
     return None
 
 

--- a/titiler/endpoints/factory.py
+++ b/titiler/endpoints/factory.py
@@ -4,7 +4,7 @@ import abc
 import os
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional, Type
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urlparse
 
 import rasterio
 from cogeo_mosaic.backends import BaseBackend, MosaicBackend
@@ -325,7 +325,6 @@ class TilerFactory(BaseTilerFactory):
                             **kwargs,
                         )
                         dst_colormap = getattr(src_dst, "colormap", None)
-
             timings.append(("dataread", round(t.elapsed * 1000, 2)))
 
             if not format:
@@ -423,7 +422,7 @@ class TilerFactory(BaseTilerFactory):
                         "center": tuple(center),
                         "minzoom": minzoom if minzoom is not None else src_dst.minzoom,
                         "maxzoom": maxzoom if maxzoom is not None else src_dst.maxzoom,
-                        "name": os.path.basename(src_path),
+                        "name": urlparse(src_path).path.lstrip("/") or "cogeotif",
                         "tiles": [tiles_url],
                     }
 
@@ -590,7 +589,7 @@ class TilerFactory(BaseTilerFactory):
                             **dataset_params.kwargs,
                             **kwargs,
                         )
-                        colormap = colormap or getattr(src_dst, "colormap", None)
+                        dst_colormap = getattr(src_dst, "colormap", None)
             timings.append(("dataread", round(t.elapsed * 1000, 2)))
 
             if not format:
@@ -607,7 +606,7 @@ class TilerFactory(BaseTilerFactory):
                 content = image.render(
                     add_mask=render_params.return_mask,
                     img_format=format.driver,
-                    colormap=colormap,
+                    colormap=colormap or dst_colormap,
                     **format.profile,
                     **render_params.kwargs,
                 )
@@ -661,7 +660,7 @@ class TilerFactory(BaseTilerFactory):
                             **dataset_params.kwargs,
                             **kwargs,
                         )
-                        colormap = colormap or getattr(src_dst, "colormap", None)
+                        dst_colormap = getattr(src_dst, "colormap", None)
             timings.append(("dataread", round(t.elapsed * 1000, 2)))
 
             with utils.Timer() as t:
@@ -675,7 +674,7 @@ class TilerFactory(BaseTilerFactory):
                 content = image.render(
                     add_mask=render_params.return_mask,
                     img_format=format.driver,
-                    colormap=colormap,
+                    colormap=colormap or dst_colormap,
                     **format.profile,
                     **render_params.kwargs,
                 )
@@ -1219,7 +1218,7 @@ class MosaicTilerFactory(BaseTilerFactory):
                     "center": tuple(center),
                     "minzoom": minzoom if minzoom is not None else src_dst.minzoom,
                     "maxzoom": maxzoom if maxzoom is not None else src_dst.maxzoom,
-                    "name": os.path.basename(src_path),
+                    "name": urlparse(src_path).path.lstrip("/") or "mosaic",
                     "tiles": [tiles_url],
                 }
 

--- a/titiler/templates/cog_index.html
+++ b/titiler/templates/cog_index.html
@@ -412,7 +412,7 @@
                 params.rescale = `${minV},${maxV}`
             }
             const cmap = document.getElementById('colormap-selector')[document.getElementById('colormap-selector').selectedIndex]
-            if (cmap.value !== 'b&w') params.color_map = cmap.value
+            if (cmap.value !== 'b&w') params.colormap_name = cmap.value
 
             const url_params = Object.keys(params).map(i => `${i}=${params[i]}`).join('&')
             let url = `${tilejson_endpoint}?${url_params}`

--- a/titiler/templates/stac_index.html
+++ b/titiler/templates/stac_index.html
@@ -408,7 +408,7 @@
             }
 
             const cmap = document.getElementById('colormap-selector')[document.getElementById('colormap-selector').selectedIndex]
-            if (cmap.value !== 'b&w') params.color_map = cmap.value
+            if (cmap.value !== 'b&w') params.colormap_name = cmap.value
 
             const url_params = Object.keys(params).map(i => `${i}=${params[i]}`).join('&')
             let url = `${tilejson_endpoint}?${url_params}`


### PR DESCRIPTION
closes #153  

This PR does:
- rename `color_map` query parameter to `colormap_name` 
- add `colormap` option.

The `colormap` option accepts JSON encoded object in form of:

```
{
    "1": {RGB(A)}
}
```

the `{RBG(A)}` value can either be a list of R,G,B (and Alpha) values or an hex color representation


cc @kylebarron @blazetopher
 