### PR TITLE
[k8s] Changed probe url from ping to healthz

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 * update FastAPI requirements
 * update minimal python version to 3.6
 * add `**render_params.kwargs` to pass custom render params in `image.render` method (https://github.com/developmentseed/titiler/pull/259)
+* Changed probe url from `/ping` to `/healthz` in k8s deployment
 
 **breaking change**
 

--- a/deployment/k8s/titiler/templates/deployment.yaml
+++ b/deployment/k8s/titiler/templates/deployment.yaml
@@ -34,11 +34,11 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /ping
+              path: /healthz
               port: http
           readinessProbe:
             httpGet:
-              path: /ping
+              path: /healthz
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}


### PR DESCRIPTION
**Proposed Changes:**

Changed probe url from ping to healthz

**PR Checklist:**

- [X] This PR has **no** breaking changes.
- [X] I have added my changes to the [CHANGELOG](https://github.com/developmentseed/titiler/blob/master/CHANGES.md)