### PR TITLE
Fix helm chart

### DIFF
--- a/deployment/k8s/titiler/templates/NOTES.txt
+++ b/deployment/k8s/titiler/templates/NOTES.txt
@@ -6,16 +6,16 @@
   {{- end }}
 {{- end }}
 {{- else if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "cpes.fullname" . }})
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "titiler.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT/docs
 {{- else if contains "LoadBalancer" .Values.service.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "cpes.fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "cpes.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "titiler.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "titiler.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
   echo http://$SERVICE_IP:{{ .Values.service.port }}
 {{- else if contains "ClusterIP" .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "cpes.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "titiler.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:8080/docs to use Titiler"
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:80
 {{- end }}


### PR DESCRIPTION
```
$ helm install --kube-context eks-development  --dry-run --debug --generate-name ./titiler
WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /home/denis/.kube/config
WARNING: Kubernetes configuration file is world-readable. This is insecure. Location: /home/denis/.kube/config
install.go:173: [debug] Original chart version: ""
install.go:190: [debug] CHART PATH: /home/denis/git/titiler/deployment/k8s/titiler

Error: template: titiler/templates/NOTES.txt:18:104: executing "titiler/templates/NOTES.txt" at <include "cpes.name" .>: error calling include: template: no template "cpes.name" associated with template "gotpl"
helm.go:81: [debug] template: titiler/templates/NOTES.txt:18:104: executing "titiler/templates/NOTES.txt" at <include "cpes.name" .>: error calling include: template: no template "cpes.name" associated with template "gotpl"
```