### PR TITLE
add exclude_path to CacheControlMiddleware

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## Next (TBD)
+
+* add `exclude_path` options in `titiler.application.middleware.CacheControlMiddleware` to avoid adding cache-control headers to specific paths.
+
 ## 0.3.0 (2021-04-19)
 
 * add support for `.jpg` and `.jpeg` extensions (https://github.com/developmentseed/titiler/pull/271)

--- a/titiler/application/tests/test_cache_middleware.py
+++ b/titiler/application/tests/test_cache_middleware.py
@@ -1,0 +1,60 @@
+"""Test titiler.middleware.CacheControlMiddleware."""
+
+
+from titiler.application.middleware import CacheControlMiddleware
+
+from fastapi import FastAPI, Path
+
+from starlette.testclient import TestClient
+
+
+def test_cachecontrol_middleware_exclude():
+    """Create App."""
+    app = FastAPI()
+
+    @app.get("/route1")
+    async def route1():
+        """route1."""
+        return "yo"
+
+    @app.get("/route2")
+    async def route2():
+        """route2."""
+        return "yeah"
+
+    @app.get("/route3")
+    async def route3():
+        """route3."""
+        return "yeah"
+
+    @app.get("/tiles/{z}/{x}/{y}")
+    async def tiles(
+        z: int = Path(..., ge=0, le=30, description="Mercator tiles's zoom level"),
+        x: int = Path(..., description="Mercator tiles's column"),
+        y: int = Path(..., description="Mercator tiles's row"),
+    ):
+        """tiles."""
+        return "yeah"
+
+    app.add_middleware(
+        CacheControlMiddleware,
+        cachecontrol="public",
+        exclude_path={r"/route1", r"/route2", r"/tiles/[0-1]/.+"},
+    )
+
+    client = TestClient(app)
+
+    response = client.get("/route1")
+    assert not response.headers.get("Cache-Control")
+
+    response = client.get("/route2")
+    assert not response.headers.get("Cache-Control")
+
+    response = client.get("/route3")
+    assert response.headers["Cache-Control"] == "public"
+
+    response = client.get("/tiles/0/1/1")
+    assert not response.headers.get("Cache-Control")
+
+    response = client.get("/tiles/3/1/1")
+    assert response.headers["Cache-Control"] == "public"

--- a/titiler/application/titiler/application/main.py
+++ b/titiler/application/titiler/application/main.py
@@ -61,7 +61,12 @@ if api_settings.cors_origins:
     )
 
 app.add_middleware(BrotliMiddleware, minimum_size=0, gzip_fallback=True)
-app.add_middleware(CacheControlMiddleware, cachecontrol=api_settings.cachecontrol)
+app.add_middleware(
+    CacheControlMiddleware,
+    cachecontrol=api_settings.cachecontrol,
+    exclude_path={r"/healthz"},
+)
+
 if api_settings.debug:
     app.add_middleware(TotalTimeMiddleware)
     app.add_middleware(LoggerMiddleware, headers=True, querystrings=True)

--- a/titiler/application/titiler/application/middleware.py
+++ b/titiler/application/titiler/application/middleware.py
@@ -1,8 +1,9 @@
 """Titiler middlewares."""
 
 import logging
+import re
 import time
-from typing import Optional
+from typing import Optional, Set
 
 from fastapi.logger import logger
 
@@ -14,21 +15,35 @@ from starlette.types import ASGIApp
 class CacheControlMiddleware(BaseHTTPMiddleware):
     """MiddleWare to add CacheControl in response headers."""
 
-    def __init__(self, app: ASGIApp, cachecontrol: Optional[str] = None) -> None:
-        """Init Middleware."""
+    def __init__(
+        self,
+        app: ASGIApp,
+        cachecontrol: Optional[str] = None,
+        exclude_path: Optional[Set] = None,
+    ) -> None:
+        """Init Middleware.
+
+        Args:
+            app (ASGIApp): starlette/FastAPI application.
+            cachecontrol (str): Cache-Control string to add to the response.
+            exclude_path (set): Set of regex expression to use to filter the path.
+
+        """
         super().__init__(app)
         self.cachecontrol = cachecontrol
+        self.exclude_path = exclude_path or set()
 
     async def dispatch(self, request: Request, call_next):
         """Add cache-control."""
         response = await call_next(request)
-        if (
-            not response.headers.get("Cache-Control")
-            and self.cachecontrol
-            and request.method in ["HEAD", "GET"]
-            and response.status_code < 500
-        ):
-            response.headers["Cache-Control"] = self.cachecontrol
+        if self.cachecontrol and not response.headers.get("Cache-Control"):
+            for path in self.exclude_path:
+                if re.match(path, request.url.path):
+                    return response
+
+            if request.method in ["HEAD", "GET"] and response.status_code < 500:
+                response.headers["Cache-Control"] = self.cachecontrol
+
         return response
 
 

--- a/titiler/application/titiler/application/middleware.py
+++ b/titiler/application/titiler/application/middleware.py
@@ -19,7 +19,7 @@ class CacheControlMiddleware(BaseHTTPMiddleware):
         self,
         app: ASGIApp,
         cachecontrol: Optional[str] = None,
-        exclude_path: Optional[Set] = None,
+        exclude_path: Optional[Set[str]] = None,
     ) -> None:
         """Init Middleware.
 


### PR DESCRIPTION
closes #277 

This PR adds a `exclude_path` option for the CacheControlMiddleware