### PR TITLE
fix: update instructions for local install to make all packages mutable

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,19 +61,26 @@ Starting with version `0.3.0`, the `TiTiler` python module has been split into a
 
 ## Installation
 
+To install from PyPI and run:
+
 ```bash
 $ pip install -U pip
-
-# From Pypi
+$ pip install uvicorn
 $ pip install titiler.{package}
-# e.g
+# e.g.,
 # pip install titiler.core
 # pip install titiler.mosaic
-# pip install titiler.application
+# pip install titiler.application (also installs core and mosaic)
+$ uvicorn titiler.application.main:app
+```
 
-# Or from sources
+To install from sources and run for development:
+
+```
 $ git clone https://github.com/developmentseed/titiler.git
-$ cd titiler && pip install -e titiler/core titiler/mosaic titiler/application
+$ cd titiler
+$ pip install uvicorn -e titiler/core -e titiler/mosaic -e titiler/application
+$ uvicorn titiler.application.main:app --reload
 ```
 
 ## Docker

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,18 +1,17 @@
 
 `TiTiler` is a set of python modules whose goal are to help users in creating a dynamic tile server. To learn more about `dynamic tiling` please refer to the [docs](dynamic_tiling.md).
 
-Users can choose to extend or use `Titiler` as it is.
+Users can choose to extend or use `TiTiler` as it is.
 
-## Defaults
+## Default Application
 
-`TiTiler` comes with a default (complete) application with support for COG, STAC and MosaicJSON. You can start the application locally by doing:
+`TiTiler` comes with a default (complete) application with support for COG, STAC, and MosaicJSON. You can install and start the application locally by doing:
 
 ```bash
-$ pip install titiler.application uvicorn
-$ uvicorn titiler.application.main:app --reload
+$ pip install uvicorn titiler.application
+$ uvicorn titiler.application.main:app
 
 > INFO: Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
-> INFO: Started reloader process [45592]
 ```
 
 See default endpoints documentation pages:
@@ -22,9 +21,33 @@ See default endpoints documentation pages:
 * [`/stac` - Spatio Temporal Asset Catalog](endpoints/stac.md)
 * [`/tms` - TileMatrixSets](endpoints/tms.md)
 
+## Development
+
+To install and run `Titiler` from sources and for developing the `Titiler` code itself:
+
+```
+$ git clone https://github.com/developmentseed/titiler.git
+$ cd titiler
+$ pip install uvicorn -e titiler/core -e titiler/mosaic -e titiler/application
+$ uvicorn titiler.application.main:app --reload
+
+> INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
+> INFO:     Started reloader process [66665] using statreload
+```
+
 ## Customized, minimal app
 
 `TiTiler` has been developed so users can build their own app using only the portions they need. Using [TilerFactories](advanced/tiler_factories.md), users can create a fully customized application with only the endpoints needed.
+
+When building a custom application, you may wish to only install the `core` and/or `mosaic` modules. To install these from PyPI:
+
+```bash
+$ pip install -U pip
+$ pip install titiler.core
+$ pip install titiler.mosaic
+```
+
+These can then be used like:
 
 ```python
 from titiler.core.factory import TilerFactory
@@ -51,7 +74,15 @@ add_exception_handlers(app, DEFAULT_STATUS_CODES)
 ## Extending TiTiler's app
 
 If you want to include all of Titiler's built-in endpoints, but also include
-customized endpoints, you can import and extend the app directly:
+customized endpoints, you can import and extend the app directly.
+
+```bash
+$ pip install -U pip
+$ pip install titiler.application # also installs titiler.core and titiler.mosaic
+```
+
+These can then be used like:
+
 
 ```py
 from titiler.application.main import app

--- a/titiler/mosaic/README.md
+++ b/titiler/mosaic/README.md
@@ -12,7 +12,7 @@ $ pip install titiler.mosaic
 
 # Or from sources
 $ git clone https://github.com/developmentseed/titiler.git
-$ cd titiler && pip install -e titiler/core titiler/mosaic
+$ cd titiler && pip install -e titiler/core -e titiler/mosaic
 ```
 
 ## How To


### PR DESCRIPTION
update instructions for local install to make all packages mutable (-e), general install documentation improvements

The existing directions for running locally with uvicorn only applied mutability `-e` on titiler/core and not application or mosaic, so only changes to core were picked up by reload, even through changes in application or mosaic still triggered a reload -- which was very confusing!