### PR TITLE
Case insensitive query parameters

### DIFF
--- a/titiler/application/titiler/application/main.py
+++ b/titiler/application/titiler/application/main.py
@@ -9,6 +9,7 @@ from titiler.application.middleware import (
     CacheControlMiddleware,
     LoggerMiddleware,
     TotalTimeMiddleware,
+    CaseInsensitiveMiddleware
 )
 from titiler.application.routers import cog, mosaic, stac, tms
 from titiler.application.settings import ApiSettings
@@ -66,6 +67,8 @@ app.add_middleware(
     cachecontrol=api_settings.cachecontrol,
     exclude_path={r"/healthz"},
 )
+
+app.add_middleware(CaseInsensitiveMiddleware)
 
 if api_settings.debug:
     app.add_middleware(LoggerMiddleware, headers=True, querystrings=True)

--- a/titiler/application/titiler/application/middleware.py
+++ b/titiler/application/titiler/application/middleware.py
@@ -88,3 +88,21 @@ class LoggerMiddleware(BaseHTTPMiddleware):
 
         response = await call_next(request)
         return response
+
+
+class CaseInsensitiveMiddleware(BaseHTTPMiddleware):
+    """Middleware to make URL parameters case-insensitive.
+    taken from: https://github.com/tiangolo/fastapi/issues/826
+    """
+
+    async def dispatch(self, request: Request, call_next):
+        self.DECODE_FORMAT = "latin-1"
+
+        raw = request.scope["query_string"].decode(self.DECODE_FORMAT).lower()
+        request.scope["query_string"] = raw.encode(self.DECODE_FORMAT)
+
+        path = request.scope["path"].lower()
+        request.scope["path"] = path
+
+        response = await call_next(request)
+        return response

--- a/titiler/application/titiler/application/middleware.py
+++ b/titiler/application/titiler/application/middleware.py
@@ -101,8 +101,5 @@ class CaseInsensitiveMiddleware(BaseHTTPMiddleware):
         raw = request.scope["query_string"].decode(self.DECODE_FORMAT).lower()
         request.scope["query_string"] = raw.encode(self.DECODE_FORMAT)
 
-        path = request.scope["path"].lower()
-        request.scope["path"] = path
-
         response = await call_next(request)
         return response


### PR DESCRIPTION
Hi, thank you for this awesome tool! 

Some client applications require URL query parameters to be case-insensitive, so I have added a middleware to make all query parameters in the request lowercase following [an example from an issue in FastAPI](https://github.com/tiangolo/fastapi/issues/826). 

With this PR for example both `https://host/cog/WMTSCapabilities.xml?url=path/to/cog/...tif` and `https://host/cog/WMTSCapabilities.xml?URL=path/to/cog/...tif`
 will work.

I am not 100% the WMTS standard says anything about this so happy with any feedback.