### PR TITLE
Deploy docker image directly to lambda

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,4 @@ ENV/
 cdk.out/
 deployment/k8s/titiler/values-test.yaml
 docs/api
+package-lock.json

--- a/deployment/aws/cdk/app.py
+++ b/deployment/aws/cdk/app.py
@@ -31,7 +31,6 @@ class titilerLambdaStack(core.Stack):
         id: str,
         memory: int = 1024,
         timeout: int = 30,
-        runtime: aws_lambda.Runtime = aws_lambda.Runtime.PYTHON_3_8,
         concurrent: Optional[int] = None,
         permissions: Optional[List[iam.PolicyStatement]] = None,
         environment: Optional[Dict] = None,
@@ -44,20 +43,11 @@ class titilerLambdaStack(core.Stack):
         permissions = permissions or []
         environment = environment or {}
 
-        lambda_function = aws_lambda.Function(
+        lambda_function = aws_lambda.DockerImageFunction(
             self,
             f"{id}-lambda",
-            runtime=runtime,
-            code=aws_lambda.Code.from_asset(
-                path=os.path.abspath(code_dir),
-                bundling=core.BundlingOptions(
-                    image=core.BundlingDockerImage.from_asset(
-                        os.path.abspath(code_dir), file="lambda/Dockerfile",
-                    ),
-                    command=["bash", "-c", "cp -R /var/task/. /asset-output/."],
-                ),
-            ),
-            handler="handler.handler",
+            code=aws_lambda.DockerImageCode.from_image_asset(
+                os.path.abspath(os.path.join(code_dir, 'lambda'))),
             memory_size=memory,
             reserved_concurrent_executions=concurrent,
             timeout=core.Duration.seconds(timeout),

--- a/deployment/aws/lambda/Dockerfile
+++ b/deployment/aws/lambda/Dockerfile
@@ -1,15 +1,7 @@
-FROM lambci/lambda:build-python3.8
+FROM public.ecr.aws/lambda/python:3.8
 
-WORKDIR /tmp
+RUN pip install titiler.application mangum>=0.10.0
 
-RUN pip install titiler.application mangum>=0.10.0 -t /var/task --no-binary numpy,pydantic
+COPY lambda/handler.py ${LAMBDA_TASK_ROOT}/
 
-# Reduce package size and remove useless files
-RUN cd /var/task && find . -type f -name '*.pyc' | while read f; do n=$(echo $f | sed 's/__pycache__\///' | sed 's/.cpython-[2-3][0-9]//'); cp $f $n; done;
-RUN cd /var/task && find . -type d -a -name '__pycache__' -print0 | xargs -0 rm -rf
-RUN cd /var/task && find . -type f -a -name '*.py' -print0 | xargs -0 rm -f
-RUN find /var/task -type d -a -name 'tests' -print0 | xargs -0 rm -rf
-RUN rm -rdf /var/task/numpy/doc/
-RUN rm -rdf /var/task/uvicorn
-
-COPY lambda/handler.py /var/task/handler.py
+CMD ["handler.handler"]

--- a/deployment/aws/lambda/Dockerfile
+++ b/deployment/aws/lambda/Dockerfile
@@ -2,6 +2,6 @@ FROM public.ecr.aws/lambda/python:3.8
 
 RUN pip install titiler.application mangum>=0.10.0
 
-COPY lambda/handler.py ${LAMBDA_TASK_ROOT}/
+COPY handler.py ${LAMBDA_TASK_ROOT}/
 
 CMD ["handler.handler"]


### PR DESCRIPTION
I noticed that the existing code was causing CDK to build the docker image every time you invoke `cdk`, even for something like `cdk ls`. This PR changes the lambda to use the built docker image directly instead of the Python runtime, and that seems to be intelligent enough to only rebuild the Docker image when Dockerfile or handler.py changes, and only on `deploy`.