### PR TITLE
add statistics endpoints

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ### titiler.core
 
 * add `/crop` POST endpoint to return an image from a GeoJSON feature (https://github.com/developmentseed/titiler/pull/339)
+* add `/statistics` (GET and POST) endpoints to return advanced images statistics (https://github.com/developmentseed/titiler/pull/347)
 
 ### titiler.application
 

--- a/docs/endpoints/cog.md
+++ b/docs/endpoints/cog.md
@@ -20,6 +20,8 @@ Read Info/Metadata and create Web map Tiles from a **single** COG. The `cog` rou
 | `GET`  | `/cog/preview[.{format}]`                                           | image/bin | create a preview image from a dataset
 | `GET`  | `/cog/crop/{minx},{miny},{maxx},{maxy}[/{width}x{height}].{format}` | image/bin | create an image from part of a dataset
 | `POST` | `/cog/crop[/{width}x{height}][].{format}]`                          | image/bin | create an image from a geojson covering a dataset
+| `GET`  | `/cog/statistics`                                                   | JSON      | Return advanced statistics from a dataset
+| `POST` | `/cog/statistics`                                                   | GeoJSON   | Return zonal statistics from a dataset for a geosjon Feature or FeatureCollection
 | `GET`  | `/cog/validate`                                                     | JSON      | validate a COG and return dataset info
 | `GET`  | `/cog/viewer`                                                       | HTML      | demo webpage
 
@@ -116,7 +118,7 @@ Example:
 `:endpoint:/cog/crop[/{width}x{height}][].{format}] - [POST]`
 
 - Body:
-    - **feature**: A valida GeoJSON feature (Polygon or MultiPolygon)
+    - **feature**: A valid GeoJSON feature (Polygon or MultiPolygon)
 
 - PathParams:
     - **height**: Force output image height. OPTIONAL
@@ -230,6 +232,33 @@ Example:
 Example:
 
 - `https://myendpoint/cog/metadata?url=https://somewhere.com/mycog.tif&bidx=1,2,3`
+
+### Statistics
+
+Advanced raster statistics
+
+`:endpoint:/cog/statistics - [GET|POST]`
+
+- QueryParams:
+    - **url**: Cloud Optimized GeoTIFF URL. **REQUIRED**
+    - **bidx**: Comma (',') delimited band indexes. OPTIONAL
+    - **expression**: rio-tiler's band math expression (e.g B1/B2). OPTIONAL
+    - **nodata**: Overwrite internal Nodata value. OPTIONAL
+    - **max_size**: Max image size from which to calculate statistics, default is 1024. OPTIONAL
+    - **height**: Force image height. OPTIONAL
+    - **width**: Force image width. OPTIONAL
+    - **unscale**: Apply internal Scale/Offset. OPTIONAL
+    - **resampling_method**: rasterio resampling method. Default is `nearest`.
+    - **categorical**: Return statistics for categorical dataset.
+    - **c** (multiple): Pixels values for categories.
+    - **p** (multiple): Percentile values.
+
+- Body (for POST endpoint):
+    - **features**: A valid GeoJSON feature or FeatureCollection (Polygon or MultiPolygon).
+
+Example:
+
+- `https://myendpoint/cog/statistics?url=https://somewhere.com/mycog.tif&bidx=1,2,3&categorical=true&c=1&c=2&c=3&p=2&p98`
 
 ### Demo
 

--- a/docs/endpoints/stac.md
+++ b/docs/endpoints/stac.md
@@ -261,7 +261,36 @@ Example:
 
 Example:
 
-- `https://myendpoint/stac/metadata?https://somewhere.com/item.json&assets=B01`
+- `https://myendpoint/stac/metadata?url=https://somewhere.com/item.json&assets=B01`
+
+
+### Statistics
+
+Advanced raster statistics
+
+`:endpoint:/stac/statistics - [GET|POST]`
+
+- QueryParams:
+    - **url**: STAC Item URL. **REQUIRED**
+    - **bidx**: Comma (',') delimited band indexes. OPTIONAL
+    - **assets**: Comma (',') delimited asset names. **REQUIRED**
+    - **expression**: rio-tiler's band math expression (e.g B1/B2). OPTIONAL
+    - **nodata**: Overwrite internal Nodata value. OPTIONAL
+    - **max_size**: Max image size from which to calculate statistics, default is 1024. OPTIONAL
+    - **height**: Force image height. OPTIONAL
+    - **width**: Force image width. OPTIONAL
+    - **unscale**: Apply internal Scale/Offset. OPTIONAL
+    - **resampling_method**: rasterio resampling method. Default is `nearest`.
+    - **categorical**: Return statistics for categorical dataset.
+    - **c** (multiple): Pixels values for categories.
+    - **p** (multiple): Percentile values.
+
+- Body (for POST endpoint):
+    - **features**: A valid GeoJSON feature or FeatureCollection (Polygon or MultiPolygon).
+
+Example:
+
+- `https://myendpoint/cog/statistics?url=https://somewhere.com/item.json&assets=B01&categorical=true&c=1&c=2&c=3&p=2&p98`
 
 ### Demo
 

--- a/src/titiler/core/tests/test_factories.py
+++ b/src/titiler/core/tests/test_factories.py
@@ -327,8 +327,13 @@ def test_TilerFactory():
         "sum",
         "std",
         "median",
+        "majority",
+        "minority",
+        "unique",
         "percentile_2",
         "percentile_98",
+        "valid_pixels",
+        "masked_pixels",
         "valid_percent",
     ]
 
@@ -345,7 +350,12 @@ def test_TilerFactory():
         "sum",
         "std",
         "median",
+        "majority",
+        "minority",
+        "unique",
         "percentile_4",
+        "valid_pixels",
+        "masked_pixels",
         "valid_percent",
     ]
 
@@ -354,7 +364,12 @@ def test_TilerFactory():
     assert response.headers["content-type"] == "application/json"
     resp = response.json()
     assert len(resp) == 1
-    assert list(resp[0]) == ["categories", "valid_percent"]
+    assert list(resp[0]) == [
+        "categories",
+        "valid_pixels",
+        "masked_pixels",
+        "valid_percent",
+    ]
     assert len(resp[0]["categories"]) == 15
 
     response = client.get(
@@ -364,7 +379,12 @@ def test_TilerFactory():
     assert response.headers["content-type"] == "application/json"
     resp = response.json()
     assert len(resp) == 1
-    assert list(resp[0]) == ["categories", "valid_percent"]
+    assert list(resp[0]) == [
+        "categories",
+        "valid_pixels",
+        "masked_pixels",
+        "valid_percent",
+    ]
     assert len(resp[0]["categories"]) == 4
     assert resp[0]["categories"]["4"] == 0
 
@@ -384,8 +404,13 @@ def test_TilerFactory():
         "sum",
         "std",
         "median",
+        "majority",
+        "minority",
+        "unique",
         "percentile_2",
         "percentile_98",
+        "valid_pixels",
+        "masked_pixels",
         "valid_percent",
     ]
 
@@ -396,8 +421,13 @@ def test_TilerFactory():
     assert response.headers["content-type"] == "application/json"
     resp = response.json()
     assert len(resp) == 1
-    assert list(resp[0]) == ["categories", "valid_percent"]
-    assert len(resp[0]["categories"]) == 13
+    assert list(resp[0]) == [
+        "categories",
+        "valid_pixels",
+        "masked_pixels",
+        "valid_percent",
+    ]
+    assert len(resp[0]["categories"]) == 12
 
     response = client.post(
         f"/statistics?url={DATA_DIR}/cog.tif&categorical=true&c=1&c=2&c=3&c=4",
@@ -407,7 +437,12 @@ def test_TilerFactory():
     assert response.headers["content-type"] == "application/json"
     resp = response.json()
     assert len(resp) == 1
-    assert list(resp[0]) == ["categories", "valid_percent"]
+    assert list(resp[0]) == [
+        "categories",
+        "valid_pixels",
+        "masked_pixels",
+        "valid_percent",
+    ]
     assert len(resp[0]["categories"]) == 4
     assert resp[0]["categories"]["4"] == 0
 
@@ -483,8 +518,13 @@ def test_MultiBaseTilerFactory(rio):
         "sum",
         "std",
         "median",
+        "majority",
+        "minority",
+        "unique",
         "percentile_2",
         "percentile_98",
+        "valid_pixels",
+        "masked_pixels",
         "valid_percent",
     ]
 
@@ -577,8 +617,13 @@ def test_MultiBandTilerFactory():
         "sum",
         "std",
         "median",
+        "majority",
+        "minority",
+        "unique",
         "percentile_2",
         "percentile_98",
+        "valid_pixels",
+        "masked_pixels",
         "valid_percent",
     ]
 

--- a/src/titiler/core/tests/test_factories.py
+++ b/src/titiler/core/tests/test_factories.py
@@ -272,41 +272,41 @@ def test_TilerFactory():
     assert meta["dtype"] == "int16"
     assert meta["count"] == 1
 
-    feature = json.dumps(
-        {
-            "type": "Feature",
-            "properties": {},
-            "geometry": {
-                "type": "Polygon",
-                "coordinates": [
-                    [
-                        [-59.23828124999999, 74.16408546675687],
-                        [-59.83154296874999, 73.15680773175981],
-                        [-58.73291015624999, 72.88087095711504],
-                        [-56.62353515625, 73.06104462497655],
-                        [-55.17333984375, 73.41588526207096],
-                        [-55.2392578125, 74.09799577518739],
-                        [-56.88720703125, 74.2895142503942],
-                        [-57.23876953124999, 74.30735341486248],
-                        [-59.23828124999999, 74.16408546675687],
-                    ]
-                ],
-            },
-        }
-    )
+    feature = {
+        "type": "Feature",
+        "properties": {},
+        "geometry": {
+            "type": "Polygon",
+            "coordinates": [
+                [
+                    [-59.23828124999999, 74.16408546675687],
+                    [-59.83154296874999, 73.15680773175981],
+                    [-58.73291015624999, 72.88087095711504],
+                    [-56.62353515625, 73.06104462497655],
+                    [-55.17333984375, 73.41588526207096],
+                    [-55.2392578125, 74.09799577518739],
+                    [-56.88720703125, 74.2895142503942],
+                    [-57.23876953124999, 74.30735341486248],
+                    [-59.23828124999999, 74.16408546675687],
+                ]
+            ],
+        },
+    }
 
-    response = client.post(f"/crop?url={DATA_DIR}/cog.tif", data=feature)
+    feature_collection = {"type": "FeatureCollection", "features": [feature]}
+
+    response = client.post(f"/crop?url={DATA_DIR}/cog.tif", json=feature)
     assert response.status_code == 200
     assert response.headers["content-type"] == "image/png"
 
-    response = client.post(f"/crop.tif?url={DATA_DIR}/cog.tif", data=feature)
+    response = client.post(f"/crop.tif?url={DATA_DIR}/cog.tif", json=feature)
     assert response.status_code == 200
     assert response.headers["content-type"] == "image/tiff; application=geotiff"
     meta = parse_img(response.content)
     assert meta["dtype"] == "uint16"
     assert meta["count"] == 2
 
-    response = client.post(f"/crop/100x100.jpeg?url={DATA_DIR}/cog.tif", data=feature)
+    response = client.post(f"/crop/100x100.jpeg?url={DATA_DIR}/cog.tif", json=feature)
     assert response.status_code == 200
     assert response.headers["content-type"] == "image/jpeg"
     meta = parse_img(response.content)
@@ -390,13 +390,14 @@ def test_TilerFactory():
 
     # POST - statistics
     response = client.post(
-        f"/statistics?url={DATA_DIR}/cog.tif&bidx=1,1,1", data=feature
+        f"/statistics?url={DATA_DIR}/cog.tif&bidx=1,1,1", json=feature
     )
     assert response.status_code == 200
-    assert response.headers["content-type"] == "application/json"
+    assert response.headers["content-type"] == "application/geo+json"
     resp = response.json()
-    assert len(resp) == 3
-    assert list(resp[0]) == [
+    assert resp["type"] == "Feature"
+    assert len(resp["properties"]["statistics"]) == 3
+    assert list(resp["properties"]["statistics"][0]) == [
         "min",
         "max",
         "mean",
@@ -415,36 +416,64 @@ def test_TilerFactory():
     ]
 
     response = client.post(
-        f"/statistics?url={DATA_DIR}/cog.tif&categorical=true", data=feature
+        f"/statistics?url={DATA_DIR}/cog.tif&bidx=1,1,1", json=feature_collection
     )
     assert response.status_code == 200
-    assert response.headers["content-type"] == "application/json"
+    assert response.headers["content-type"] == "application/geo+json"
     resp = response.json()
-    assert len(resp) == 1
-    assert list(resp[0]) == [
+    assert resp["type"] == "FeatureCollection"
+    assert len(resp["features"][0]["properties"]["statistics"]) == 3
+    assert list(resp["features"][0]["properties"]["statistics"][0]) == [
+        "min",
+        "max",
+        "mean",
+        "count",
+        "sum",
+        "std",
+        "median",
+        "majority",
+        "minority",
+        "unique",
+        "percentile_2",
+        "percentile_98",
+        "valid_pixels",
+        "masked_pixels",
+        "valid_percent",
+    ]
+
+    response = client.post(
+        f"/statistics?url={DATA_DIR}/cog.tif&categorical=true", json=feature
+    )
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/geo+json"
+    resp = response.json()
+    assert resp["type"] == "Feature"
+    assert len(resp["properties"]["statistics"]) == 1
+    assert list(resp["properties"]["statistics"][0]) == [
         "categories",
         "valid_pixels",
         "masked_pixels",
         "valid_percent",
     ]
-    assert len(resp[0]["categories"]) == 12
+    assert len(resp["properties"]["statistics"][0]["categories"]) == 12
 
     response = client.post(
         f"/statistics?url={DATA_DIR}/cog.tif&categorical=true&c=1&c=2&c=3&c=4",
-        data=feature,
+        json=feature,
     )
     assert response.status_code == 200
-    assert response.headers["content-type"] == "application/json"
+    assert response.headers["content-type"] == "application/geo+json"
     resp = response.json()
-    assert len(resp) == 1
-    assert list(resp[0]) == [
+    assert resp["type"] == "Feature"
+    assert len(resp["properties"]["statistics"]) == 1
+    assert list(resp["properties"]["statistics"][0]) == [
         "categories",
         "valid_pixels",
         "masked_pixels",
         "valid_percent",
     ]
-    assert len(resp[0]["categories"]) == 4
-    assert resp[0]["categories"]["4"] == 0
+    assert len(resp["properties"]["statistics"][0]["categories"]) == 4
+    assert resp["properties"]["statistics"][0]["categories"]["4"] == 0
 
 
 @patch("rio_tiler.io.cogeo.rasterio")

--- a/src/titiler/core/titiler/core/factory.py
+++ b/src/titiler/core/titiler/core/factory.py
@@ -791,7 +791,7 @@ class TilerFactory(BaseTilerFactory):
                 }
             },
         )
-        def get_statistics(
+        def statistics(
             src_path=Depends(self.path_dependency),
             layer_params=Depends(self.layer_dependency),
             image_params=Depends(self.img_dependency),
@@ -828,7 +828,7 @@ class TilerFactory(BaseTilerFactory):
                 }
             },
         )
-        def post_statistics(
+        def geojson_statistics(
             feature: Feature = Body(..., descriptiom="GeoJSON Feature."),
             src_path=Depends(self.path_dependency),
             layer_params=Depends(self.layer_dependency),

--- a/src/titiler/core/titiler/core/factory.py
+++ b/src/titiler/core/titiler/core/factory.py
@@ -802,7 +802,7 @@ class TilerFactory(BaseTilerFactory):
             c: List[Union[float, int]] = Query(
                 None, description="Pixels values for categories."
             ),
-            p: List[int] = Query([2, 98], description="Percentiles values."),
+            p: List[int] = Query([2, 98], description="Percentile values."),
             kwargs: Dict = Depends(self.additional_dependency),
         ):
             """Create image from a geojson feature."""
@@ -845,7 +845,7 @@ class TilerFactory(BaseTilerFactory):
             c: List[Union[float, int]] = Query(
                 None, description="Pixels values for categories."
             ),
-            p: List[int] = Query([2, 98], description="Percentiles values."),
+            p: List[int] = Query([2, 98], description="Percentile values."),
             kwargs: Dict = Depends(self.additional_dependency),
         ):
             """Create image from a geojson feature."""


### PR DESCRIPTION
closes #340 

This PR adds 2 new endpoints per TilerFactories
`GET - /statistics`: get stats from a preview of a dataset
`POST - /statistics`: get stats from a feature covering a dataset

### To Be Discussed

Per the HTML specification, `list` must be passed using multiple parameter (e.g `p=1&p=2`) and is also supported in openapi. When we started titiler we (I) didn't knew about this and used `comma delimited string` (e.g `bidx=1,2,3`) to allow list input. In the PR the statistics endpoints have 2 `list` inputs: **c** (categories) and **p** (percentiles). I've choose to keep the name small because those will be repeated in the query_param (e.g `p=1&p=2` to define `percentiles=[1, 2]`).

I'm open to discuss either we should follow the spec or use `comma delimited values`. I've already raised this over https://github.com/developmentseed/titiler/pull/262#issuecomment-792863831

IMO we should switch every `list` input to this, but as it's a breaking change I'll think starting to implement this for new QueryParameters is the safest way 🤷 


Here is example of `statistics` result
```
$ curl http://127.0.0.1:8000/cog/statistics\?url\=https://rio-tiler-dev.s3.amazonaws.com/data/eu_webAligned_256px.tif&bidx=1
[
  {
    "min": 38,
    "max": 255,
    "mean": 125.75282900811122,
    "count": 262106,
    "sum": 32960571,
    "std": 36.320596765212024,
    "median": 102,
    "percentile_2": 0,
    "percentile_98": 178,
    "valid_percent": 25
  }
]

$ curl http://127.0.0.1:8000/cog/statistics\?url\=https://rio-tiler-dev.s3.amazonaws.com/data/eu_webAligned_256px.tif&bidx=1&categorical=true&c=1&c=2&c=3
[
  {
    "categories": {
      "1": 0,
      "2": 0,
      "3": 0
    },
    "valid_percent": 25
  }
]
```
