### PR TITLE
Assets for tile

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 
 ### titiler.mosaic
 
-* add `/{quadkey}/assets`, `/{lon},{lat}/assets`, `/{minx},{miny},{maxx},{maxy}/assets` GET endpoints to return a list of assets that intersect a given geometry (author @mackdelany, https://github.com/developmentseed/titiler/pull/351)
+* add `/{z}/{x}/{y}/assets`, `/{lon},{lat}/assets`, `/{minx},{miny},{maxx},{maxy}/assets` GET endpoints to return a list of assets that intersect a given geometry (author @mackdelany, https://github.com/developmentseed/titiler/pull/351)
 
 ## 0.3.4 (2021-08-02)
 

--- a/docs/advanced/tiler_factories.md
+++ b/docs/advanced/tiler_factories.md
@@ -107,7 +107,7 @@ app.include_router(cog.router, tags=["Landsat"])
 | `GET`  | `/[{TileMatrixSetId}]/tilejson.json`                            | JSON      | return a Mapbox TileJSON document
 | `GET`  | `/{TileMatrixSetId}/WMTSCapabilities.xml`                       | XML       | return OGC WMTS Get Capabilities
 | `GET`  | `/point/{lon},{lat}`                                            | JSON      | return pixel value from a MosaicJSON dataset
-| `GET`  | `/{quadkey}/assets`                                             | JSON      | return list of assets intersecting a quadkey
+| `GET`  | `/{z}/{x}/{y}/assets`                                           | JSON      | return list of assets intersecting a XYZ tile
 | `GET`  | `/{lon},{lat}/assets`                                           | JSON      | return list of assets intersecting a point
 | `GET`  | `/{minx},{miny},{maxx},{maxy}/assets`                           | JSON      | return list of assets intersecting a bounding box
 

--- a/docs/endpoints/mosaic.md
+++ b/docs/endpoints/mosaic.md
@@ -17,7 +17,7 @@ Read Mosaic Info/Metadata and create Web map Tiles from a multiple COG. The `mos
 | `GET`  | `/mosaicjson/[{TileMatrixSetId}]/tilejson.json`                            | JSON      | return a Mapbox TileJSON document
 | `GET`  | `/mosaicjson/{TileMatrixSetId}/WMTSCapabilities.xml`                       | XML       | return OGC WMTS Get Capabilities
 | `GET`  | `/mosaicjson/point/{lon},{lat}`                                            | JSON      | return pixel value from a MosaicJSON dataset
-| `GET`  | `/mosaicjson/{quadkey}/assets`                                             | JSON      | return list of assets intersecting a quadkey
+| `GET`  | `/mosaicjson/{z}/{x}/{y}/assets`                                             | JSON      | return list of assets intersecting a XYZ tile
 | `GET`  | `/mosaicjson/{lon},{lat}/assets`                                           | JSON      | return list of assets intersecting a point
 | `GET`  | `/mosaicjson/{minx},{miny},{maxx},{maxy}/assets`                           | JSON      | return list of assets intersecting a bounding box
 

--- a/src/titiler/mosaic/tests/test_factory.py
+++ b/src/titiler/mosaic/tests/test_factory.py
@@ -143,7 +143,7 @@ def test_MosaicTilerFactory():
         )
         assert response.status_code == 200
 
-        response = client.get("/mosaic/0302302/assets", params={"url": mosaic_file},)
+        response = client.get("/mosaic/7/36/45/assets", params={"url": mosaic_file},)
         assert response.status_code == 200
         assert all(
             filepath.split("/")[-1] in ["cog1.tif"] for filepath in response.json()

--- a/src/titiler/mosaic/titiler/mosaic/factory.py
+++ b/src/titiler/mosaic/titiler/mosaic/factory.py
@@ -494,7 +494,7 @@ class MosaicTilerFactory(BaseTilerFactory):
             r"/{minx},{miny},{maxx},{maxy}/assets",
             responses={200: {"description": "Return list of COGs in bounding box"}},
         )
-        def bbox(
+        def assets_for_bbox(
             src_path=Depends(self.path_dependency),
             minx: float = Query(None, description="Left side of bounding box"),
             miny: float = Query(None, description="Bottom of bounding box"),
@@ -524,7 +524,7 @@ class MosaicTilerFactory(BaseTilerFactory):
             r"/{lng},{lat}/assets",
             responses={200: {"description": "Return list of COGs"}},
         )
-        def lonlat(
+        def assets_for_lon_lat(
             src_path=Depends(self.path_dependency),
             lng: float = Query(None, description="Longitude"),
             lat: float = Query(None, description="Latitude"),
@@ -536,15 +536,17 @@ class MosaicTilerFactory(BaseTilerFactory):
             return assets
 
         @self.router.get(
-            r"/{quadkey}/assets",
+            r"/{z}/{x}/{y}/assets",
             responses={200: {"description": "Return list of COGs"}},
         )
-        def quadkey(
+        def assets_for_tile(
+            z: int = Path(..., ge=0, le=30, description="Mercator tiles's zoom level"),
+            x: int = Path(..., description="Mercator tiles's column"),
+            y: int = Path(..., description="Mercator tiles's row"),
             src_path=Depends(self.path_dependency),
-            quadkey: str = Query(None, description="Quadkey to return COGS for."),
         ):
-            """Return a list of assets which overlap a given quadkey"""
+            """Return a list of assets which overlap a given tile"""
             with self.reader(src_path, **self.backend_options) as mosaic:
-                assets = mosaic.assets_for_tile(*mercantile.quadkey_to_tile(quadkey))
+                assets = mosaic.assets_for_tile(x, y, z)
 
             return assets


### PR DESCRIPTION
ref https://github.com/developmentseed/titiler/discussions/350#discussioncomment-1138576

IMO it's better to use `tile` instead of quadkey, then we could in theory support tile in different TMS (which might not support quadkeys)

cc @mackdelany 