### PR TITLE
netrc configmap

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,11 +1,5 @@
 # Release Notes
 
-## Unreleased
-
-### titiler.k8s
-
-- create a configmap attached to the titiler deployment for netrc config file (ref: https://github.com/developmentseed/titiler/pull/380)
-
 ## 0.3.10 (2021-09-23)
 
 ### titiler.core

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## Unreleased
+
+### titiler.k8s
+
+- create a configmap attached to the titiler deployment for netrc config file (ref: https://github.com/developmentseed/titiler/pull/380)
+
 ## 0.3.10 (2021-09-23)
 
 ### titiler.core

--- a/deployment/k8s/titiler/Chart.yaml
+++ b/deployment/k8s/titiler/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.0"
+appVersion: 0.3.10
 description: A dynamic Web Map tile server
 name: titiler
-version: 0.1.0
+version: 0.2.0

--- a/deployment/k8s/titiler/templates/configmap.yaml
+++ b/deployment/k8s/titiler/templates/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "titiler.fullname" . }}-configmap
+data:
+  {{- if .Values.netrc }}
+  netrc: {{ tpl (.Values.netrc) . | quote }}
+  {{- end }}
+    

--- a/deployment/k8s/titiler/templates/deployment.yaml
+++ b/deployment/k8s/titiler/templates/deployment.yaml
@@ -16,12 +16,20 @@ spec:
     spec:
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
           {{- range $key, $val := .Values.env }}
             - name: {{ $key }}
               value: {{ $val | quote }}
+          {{- end }}
+          {{- if .Values.netrc }}
+            - name: NETRC
+              value: /config/netrc
+            - name: CURLOPT_NETRC
+              value: CURL_NETRC_OPTIONAL
+            - name: CURLOPT_NETRC_FILE
+              value: /config/netrc
           {{- end }}
           ports:
             - name: http
@@ -37,6 +45,14 @@ spec:
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - mountPath: /config
+              name: config
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "titiler.fullname" . }}-configmap
       {{- with .Values.serviceAccountName }}
       serviceAccountName: {{ . | quote }}
       {{- end }}


### PR DESCRIPTION
**Related issue** :

In https://github.com/cogeotiff/rio-tiler/issues/397, I expressed the need to be able to authenticate to the STAC resource if needed.

**Proposed Changes:**

Implement netrc configuration to allow HTTP basic auth for STAC reader. A configmap is attached to the deployment and mount a netrc config file at `/config/netrc` that is then passed as various env var `NETRC`, `CURLOPT_NETRC`, `CURLOPT_NETRC_FILE` 

**PR Checklist:**

- [X] This PR has **no** breaking changes.

