### PR TITLE
limit rio-cogeo version to 2.x

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 0.3.11 (2021-10-07)
+
+### titiler.application
+
+- Update rio-cogeo requirement to stay under `3.0`
+
 ## 0.3.10 (2021-09-23)
 
 ### titiler.core

--- a/src/titiler/application/setup.py
+++ b/src/titiler/application/setup.py
@@ -6,7 +6,7 @@ with open("README.md") as f:
     long_description = f.read()
 
 inst_reqs = [
-    "rio-cogeo>=2.2",
+    "rio-cogeo>=2.2,<3.0",
     "titiler.core",
     "titiler.mosaic",
     "starlette-cramjam>=0.1.0,<0.2",


### PR DESCRIPTION
rio-cogeo 3.0 needs morecantile 3.0 which is imcompatible with cogeo-mosaic and rio-tiler. Pip should be smart but it's ok to be safer. 