### PR TITLE
update defaultDependency and QueryParameter format

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,16 @@
 * update `statistics` endpoint responses **breaking API**
 * remove `band_expression` in `BandsExprParams` dependency **breaking API**
 * remove `morecantile` requirement definition in setup.py and defers to rio-tiler supported version
+* update `titiler.core.dependencies.DefaultDependency` (allows dict unpacking and remove `.kwargs`) **breaking API**
+* use standard for List in QueryParameter (e.g `bidx=1&bidx=2&bidx` instead of `bidx=1,2,3`) **breaking API**
+* add `asset_bidx` query parameter in replacement of `bidx` in MultiBaseFactory dependencies and switch to new format: `{asset name}|{bidx,bidx,bidx}` **breaking API**
+* update `asset_expression` to the new format: `{asset name}|{expression}` (e.g `data|b1+b2`) **breaking API**
+* update `assets` QueryParameter to List (e.g `assets=COG&assets=Data`) **breaking API**
+* update `bands` QueryParameter to List (e.g `bands=B01&bands=B02`) **breaking API**
+* split `RenderParams` dependency into:
+    * `PostProcessParams`: `rescale` and `color_formula` parameters
+    * `ImageRenderingParams`: `return_mask`
+* add `process_dependency` attribute in `BaseTilerFactory` (defaults to `PostProcessParams`)
 
 ### titiler.mosaic
 

--- a/src/titiler/application/tests/routes/test_stac.py
+++ b/src/titiler/application/tests/routes/test_stac.py
@@ -37,7 +37,9 @@ def test_info(httpx, rio, app):
     body = response.json()
     assert body["B01"]
 
-    response = app.get("/stac/info?url=https://myurl.com/item.json&assets=B01,B09")
+    response = app.get(
+        "/stac/info?url=https://myurl.com/item.json&assets=B01&assets=B09"
+    )
     assert response.status_code == 200
     body = response.json()
     assert body["B01"]
@@ -226,13 +228,13 @@ def test_point(httpx, rio, app):
     assert body["coordinates"] == [23.878, 32.063]
     assert body["values"] == [[3565]]
 
-    # response = app.get(
-    #     "/stac/point/23.878,32.063?url=https://myurl.com/item.json&assets=B01&asset_expression=b1*2"
-    # )
-    # assert response.status_code == 200
-    # body = response.json()
-    # assert body["coordinates"] == [23.878, 32.063]
-    # assert body["values"] == [[7130]]
+    response = app.get(
+        "/stac/point/23.878,32.063?url=https://myurl.com/item.json&assets=B01&asset_expression=B01|b1*2"
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["coordinates"] == [23.878, 32.063]
+    assert body["values"] == [[7130]]
 
     response = app.get(
         "/stac/point/23.878,32.063?url=https://myurl.com/item.json&expression=B01/B09"

--- a/src/titiler/core/tests/test_CustomRender.py
+++ b/src/titiler/core/tests/test_CustomRender.py
@@ -5,7 +5,7 @@ from typing import Optional, Union
 
 import numpy
 
-from titiler.core.dependencies import RenderParams
+from titiler.core.dependencies import ImageRenderingParams
 from titiler.core.factory import TilerFactory
 
 from .conftest import DATA_DIR, parse_img
@@ -16,25 +16,20 @@ from starlette.testclient import TestClient
 
 
 @dataclass
-class CustomRenderParams(RenderParams):
+class CustomRenderParams(ImageRenderingParams):
     """Custom renderparams class."""
 
-    output_nodata: Optional[Union[str, int, float]] = Query(
-        None, title="Tiff Ouptut Nodata value",
+    nodata: Optional[Union[str, int, float]] = Query(
+        None, title="Tiff Ouptut Nodata value", alias="output_nodata",
     )
-    output_compression: Optional[str] = Query(
-        None, title="Tiff compression schema",
+    compress: Optional[str] = Query(
+        None, title="Tiff compression schema", alias="output_compression",
     )
 
     def __post_init__(self):
         """post init."""
-        super().__post_init__()
-        if self.output_nodata is not None:
-            self.kwargs["nodata"] = (
-                numpy.nan if self.output_nodata == "nan" else float(self.output_nodata)
-            )
-        if self.output_compression is not None:
-            self.kwargs["compress"] = self.output_compression
+        if self.nodata is not None:
+            self.nodata = numpy.nan if self.nodata == "nan" else float(self.nodata)
 
 
 def test_CustomRender():

--- a/src/titiler/core/titiler/core/dependencies.py
+++ b/src/titiler/core/titiler/core/dependencies.py
@@ -1,17 +1,15 @@
 """Common dependency."""
 
 import json
-import re
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from enum import Enum
-from typing import Dict, List, Optional, Sequence, Tuple, Union
+from typing import Dict, List, Optional, Sequence, Union
 
 import numpy
 from morecantile import tms
 from morecantile.models import TileMatrixSet
 from rasterio.enums import Resampling
 from rio_tiler.colormap import cmap, parse_color
-from rio_tiler.constants import NumType
 from rio_tiler.errors import MissingAssets, MissingBands
 
 from fastapi import HTTPException, Query
@@ -79,9 +77,15 @@ def DatasetPathParams(url: str = Query(..., description="Dataset URL")) -> str:
 
 @dataclass
 class DefaultDependency:
-    """Dependency Base Class"""
+    """Dataclass with dict unpacking"""
 
-    kwargs: Dict = field(init=False, default_factory=dict)
+    def keys(self):
+        """Return Keys."""
+        return self.__dict__.keys()
+
+    def __getitem__(self, key):
+        """Return value."""
+        return self.__dict__[key]
 
 
 # Dependencies for simple BaseReader (e.g COGReader)
@@ -89,40 +93,31 @@ class DefaultDependency:
 class BidxParams(DefaultDependency):
     """Band Indexes parameters."""
 
-    bidx: Optional[str] = Query(
-        None, title="Band indexes", description="comma (',') delimited band indexes",
+    indexes: Optional[List[int]] = Query(
+        None,
+        title="Band indexes",
+        alias="bidx",
+        description="Dataset band indexes",
+        examples={"one-band": {"value": [1]}, "multi-bands": {"value": [1, 2, 3]}},
     )
-
-    def __post_init__(self):
-        """Post Init."""
-        if self.bidx is not None:
-            self.kwargs["indexes"] = tuple(
-                int(s) for s in re.findall(r"\d+", self.bidx)
-            )
 
 
 @dataclass
-class BidxExprParams(DefaultDependency):
+class BidxExprParams(BidxParams):
     """Band Indexes and Expression parameters."""
 
-    bidx: Optional[str] = Query(
-        None, title="Band indexes", description="comma (',') delimited band indexes",
-    )
     expression: Optional[str] = Query(
         None,
         title="Band Math expression",
-        description="rio-tiler's band math expression (e.g B1/B2)",
+        description="rio-tiler's band math expression",
+        examples={
+            "simple": {"description": "Simple band math.", "value": "b1/b2"},
+            "multi-bands": {
+                "description": "Coma (,) delimited expressions (band1: b1/b2, band2: b2+b3).",
+                "value": "b1/b2,b2+b3",
+            },
+        },
     )
-
-    def __post_init__(self):
-        """Post Init."""
-        if self.bidx is not None:
-            self.kwargs["indexes"] = tuple(
-                int(s) for s in re.findall(r"\d+", self.bidx)
-            )
-
-        if self.expression is not None:
-            self.kwargs["expression"] = self.expression
 
 
 # Dependencies for  MultiBaseReader (e.g STACReader)
@@ -130,59 +125,85 @@ class BidxExprParams(DefaultDependency):
 class AssetsParams(DefaultDependency):
     """Assets parameters."""
 
-    assets: str = Query(
-        ..., title="Asset indexes", description="comma (',') delimited asset names.",
+    assets: List[str] = Query(
+        ...,
+        title="Asset names",
+        description="Asset's names.",
+        examples={
+            "one-asset": {
+                "description": "Return results for asset `data`.",
+                "value": ["data"],
+            },
+            "multi-assets": {
+                "description": "Return results for assets `data` and `cog`.",
+                "value": ["data", "cog"],
+            },
+        },
     )
-
-    def __post_init__(self):
-        """Post Init."""
-        if self.assets is not None:
-            self.kwargs["assets"] = self.assets.split(",")
-
-
-@dataclass
-class AssetsBidxParams(DefaultDependency):
-    """Asset and Band indexes parameters."""
-
-    assets: str = Query(
-        ..., title="Asset indexes", description="comma (',') delimited asset names.",
-    )
-    # TODO: Update to asset_indexes and new format
-    bidx: Optional[str] = Query(
-        None, title="Band indexes", description="comma (',') delimited band indexes",
-    )
-    # TODO: add asset_expression
-
-    def __post_init__(self):
-        """Post Init."""
-        self.kwargs["assets"] = self.assets.split(",")
-        if self.bidx is not None:
-            self.kwargs["indexes"] = tuple(
-                int(s) for s in re.findall(r"\d+", self.bidx)
-            )
 
 
 @dataclass
 class AssetsBidxExprParams(DefaultDependency):
     """Assets, Band Indexes and Expression parameters."""
 
-    assets: Optional[str] = Query(
-        None, title="Asset indexes", description="comma (',') delimited asset names.",
+    assets: Optional[List[str]] = Query(
+        None,
+        title="Asset names",
+        description="Asset's names.",
+        examples={
+            "one-asset": {
+                "description": "Return results for asset `data`.",
+                "value": ["data"],
+            },
+            "multi-assets": {
+                "description": "Return results for assets `data` and `cog`.",
+                "value": ["data", "cog"],
+            },
+        },
     )
     expression: Optional[str] = Query(
         None,
         title="Band Math expression",
-        description="rio-tiler's band math expression between assets (e.g asset1/asset2)",
+        description="Band math expression between assets",
+        examples={
+            "simple": {
+                "description": "Return results of expression between assets.",
+                "value": "asset1 + asset2 / asset3",
+            },
+        },
     )
-    # TODO: Update to asset_indexes and new format
-    bidx: Optional[str] = Query(
-        None, title="Band indexes", description="comma (',') delimited band indexes",
-    )
-    # TODO: Update to new format
-    asset_expression: Optional[str] = Query(
+
+    asset_indexes: Optional[Sequence[str]] = Query(
         None,
-        title="Band Math expression to apply to each asset",
-        description="rio-tiler's band math expression (e.g b1/b2)",
+        title="Per asset band indexes",
+        description="Per asset band indexes",
+        alias="asset_bidx",
+        examples={
+            "one-asset": {
+                "description": "Return indexes 1,2,3 of asset `data`.",
+                "value": ["data|1,2,3"],
+            },
+            "multi-assets": {
+                "description": "Return indexes 1,2,3 of asset `data` and indexes 1 of asset `cog`",
+                "value": ["data|1,2,3", "cog|1"],
+            },
+        },
+    )
+
+    asset_expression: Optional[Sequence[str]] = Query(
+        None,
+        title="Per asset band expression",
+        description="Per asset band expression",
+        examples={
+            "one-asset": {
+                "description": "Return results for expression `b1*b2+b3` of asset `data`.",
+                "value": ["data|b1*b2+b3"],
+            },
+            "multi-assets": {
+                "description": "Return results for expressions `b1*b2+b3` for asset `data` and `b1+b3` for asset `cog`.",
+                "value": ["data|b1*b2+b3", "cog|b1+b3"],
+            },
+        },
     )
 
     def __post_init__(self):
@@ -192,16 +213,67 @@ class AssetsBidxExprParams(DefaultDependency):
                 "assets must be defined either via expression or assets options."
             )
 
-        if self.assets is not None:
-            self.kwargs["assets"] = self.assets.split(",")
-        if self.expression is not None:
-            self.kwargs["expression"] = self.expression
-        if self.asset_expression is not None:
-            self.kwargs["asset_expression"] = self.asset_expression
-        if self.bidx is not None:
-            self.kwargs["indexes"] = tuple(
-                int(s) for s in re.findall(r"\d+", self.bidx)
-            )
+        if self.asset_indexes:
+            self.asset_indexes: Dict[str, Sequence[int]] = {  # type: ignore
+                idx.split("|")[0]: list(map(int, idx.split("|")[1].split(",")))
+                for idx in self.asset_indexes
+            }
+
+        if self.asset_expression:
+            self.asset_expression: Dict[str, str] = {  # type: ignore
+                idx.split("|")[0]: idx.split("|")[1] for idx in self.asset_expression
+            }
+
+
+@dataclass
+class AssetsBidxParams(AssetsParams):
+    """asset and extra."""
+
+    asset_indexes: Optional[Sequence[str]] = Query(
+        None,
+        title="Per asset band indexes",
+        description="Per asset band indexes",
+        alias="asset_bidx",
+        examples={
+            "one-asset": {
+                "description": "Return indexes 1,2,3 of asset `data`.",
+                "value": ["data|1,2,3"],
+            },
+            "multi-assets": {
+                "description": "Return indexes 1,2,3 of asset `data` and indexes 1 of asset `cog`",
+                "value": ["data|1,2,3", "cog|1"],
+            },
+        },
+    )
+
+    asset_expression: Optional[Sequence[str]] = Query(
+        None,
+        title="Per asset band expression",
+        description="Per asset band expression",
+        examples={
+            "one-asset": {
+                "description": "Return results for expression `b1*b2+b3` of asset `data`.",
+                "value": ["data|b1*b2+b3"],
+            },
+            "multi-assets": {
+                "description": "Return results for expressions `b1*b2+b3` for asset `data` and `b1+b3` for asset `cog`.",
+                "value": ["data|b1*b2+b3", "cog|b1+b3"],
+            },
+        },
+    )
+
+    def __post_init__(self):
+        """Post Init."""
+        if self.asset_indexes:
+            self.asset_indexes: Dict[str, Sequence[int]] = {  # type: ignore
+                idx.split("|")[0]: list(map(int, idx.split("|")[1].split(",")))
+                for idx in self.asset_indexes
+            }
+
+        if self.asset_expression:
+            self.asset_expression: Dict[str, str] = {  # type: ignore
+                idx.split("|")[0]: idx.split("|")[1] for idx in self.asset_expression
+            }
 
 
 # Dependencies for  MultiBandReader
@@ -209,26 +281,54 @@ class AssetsBidxExprParams(DefaultDependency):
 class BandsParams(DefaultDependency):
     """Band names parameters."""
 
-    bands: str = Query(
-        ..., title="bands names", description="comma (',') delimited bands names.",
+    bands: List[str] = Query(
+        ...,
+        title="Band names",
+        description="Band's names.",
+        examples={
+            "one-band": {
+                "description": "Return results for band `B01`.",
+                "value": ["B01"],
+            },
+            "multi-bands": {
+                "description": "Return results for bands `B01` and `B02`.",
+                "value": ["B01", "B02"],
+            },
+        },
     )
-
-    def __post_init__(self):
-        """Post Init."""
-        self.kwargs["bands"] = self.bands.split(",")
 
 
 @dataclass
 class BandsExprParams(DefaultDependency):
     """Band names and Expression parameters."""
 
-    bands: Optional[str] = Query(
-        None, title="bands names", description="comma (',') delimited bands names.",
+    bands: Optional[List[str]] = Query(
+        None,
+        title="Band names",
+        description="Band's names.",
+        examples={
+            "one-band": {
+                "description": "Return results for band `B01`.",
+                "value": ["B01"],
+            },
+            "multi-bands": {
+                "description": "Return results for bands `B01` and `B02`.",
+                "value": ["B01", "B02"],
+            },
+        },
     )
+
     expression: Optional[str] = Query(
         None,
         title="Band Math expression",
-        description="rio-tiler's band math expression between Band asset.",
+        description="rio-tiler's band math expression",
+        examples={
+            "simple": {"description": "Simple band math.", "value": "B01/B02"},
+            "multi-bands": {
+                "description": "Coma (,) delimited expressions (band1: B01/B02, band2: B02+B03).",
+                "value": "B01/B02,B02+B03",
+            },
+        },
     )
 
     def __post_init__(self):
@@ -237,11 +337,6 @@ class BandsExprParams(DefaultDependency):
             raise MissingBands(
                 "bands must be defined either via expression or bands options."
             )
-
-        if self.bands is not None:
-            self.kwargs["bands"] = self.bands.split(",")
-        if self.expression is not None:
-            self.kwargs["expression"] = self.expression
 
 
 @dataclass
@@ -259,15 +354,6 @@ class ImageParams(DefaultDependency):
         if self.width and self.height:
             self.max_size = None
 
-        if self.width is not None:
-            self.kwargs["width"] = self.width
-
-        if self.height is not None:
-            self.kwargs["height"] = self.height
-
-        if self.max_size is not None:
-            self.kwargs["max_size"] = self.max_size
-
 
 @dataclass
 class DatasetParams(DefaultDependency):
@@ -277,50 +363,51 @@ class DatasetParams(DefaultDependency):
         None, title="Nodata value", description="Overwrite internal Nodata value"
     )
     unscale: Optional[bool] = Query(
-        None,
+        False,
         title="Apply internal Scale/Offset",
         description="Apply internal Scale/Offset",
     )
     resampling_method: ResamplingName = Query(
-        ResamplingName.nearest, description="Resampling method."  # type: ignore
+        ResamplingName.nearest,  # type: ignore
+        description="Resampling method.",
     )
 
     def __post_init__(self):
         """Post Init."""
         if self.nodata is not None:
-            self.kwargs["nodata"] = (
-                numpy.nan if self.nodata == "nan" else float(self.nodata)
-            )
-
-        if self.unscale is not None:
-            self.kwargs["unscale"] = self.unscale
-
-        if self.resampling_method is not None:
-            self.kwargs["resampling_method"] = self.resampling_method.name
+            self.nodata = numpy.nan if self.nodata == "nan" else float(self.nodata)
+        self.resampling_method = self.resampling_method.value  # type: ignore
 
 
 @dataclass
-class RenderParams(DefaultDependency):
+class ImageRenderingParams(DefaultDependency):
     """Image Rendering options."""
 
-    rescale: Optional[List[str]] = Query(
+    add_mask: bool = Query(
+        True, alias="return_mask", description="Add mask to the output data."
+    )
+
+
+@dataclass
+class PostProcessParams(DefaultDependency):
+    """Data Post-Processing options."""
+
+    in_range: Optional[List[str]] = Query(
         None,
+        alias="rescale",
         title="Min/Max data Rescaling",
-        description="comma (',') delimited Min,Max bounds. Can set multiple time for multiple bands.",
+        description="comma (',') delimited Min,Max range. Can set multiple time for multiple bands.",
+        example=["0,2000", "0,1000", "0,10000"],  # band 1  # band 2  # band 3
     )
     color_formula: Optional[str] = Query(
         None,
         title="Color Formula",
         description="rio-color formula (info: https://github.com/mapbox/rio-color)",
     )
-    return_mask: bool = Query(True, description="Add mask to the output data.")
-
-    rescale_range: Optional[Sequence[Tuple[NumType, NumType]]] = field(init=False)
 
     def __post_init__(self):
         """Post Init."""
-        self.rescale_range = (
-            [tuple(map(float, r.replace(" ", "").split(","))) for r in self.rescale]
-            if self.rescale
-            else None
-        )
+        if self.in_range:
+            self.in_range = [  # type: ignore
+                tuple(map(float, r.replace(" ", "").split(","))) for r in self.in_range
+            ]

--- a/src/titiler/mosaic/titiler/mosaic/factory.py
+++ b/src/titiler/mosaic/titiler/mosaic/factory.py
@@ -187,6 +187,7 @@ class MosaicTilerFactory(BaseTilerFactory):
             layer_params=Depends(self.layer_dependency),
             dataset_params=Depends(self.dataset_dependency),
             render_params=Depends(self.render_dependency),
+            postprocess_params=Depends(self.process_dependency),
             colormap=Depends(self.colormap_dependency),
             pixel_selection: PixelSelectionMethod = Query(
                 PixelSelectionMethod.first, description="Pixel selection method."
@@ -220,8 +221,8 @@ class MosaicTilerFactory(BaseTilerFactory):
                             pixel_selection=pixel_selection.method(),
                             tilesize=tilesize,
                             threads=threads,
-                            **layer_params.kwargs,
-                            **dataset_params.kwargs,
+                            **layer_params,
+                            **dataset_params,
                             **kwargs,
                         )
             timings.append(("dataread", round((t.elapsed - mosaic_read) * 1000, 2)))
@@ -230,19 +231,15 @@ class MosaicTilerFactory(BaseTilerFactory):
                 format = ImageType.jpeg if data.mask.all() else ImageType.png
 
             with Timer() as t:
-                image = data.post_process(
-                    in_range=render_params.rescale_range,
-                    color_formula=render_params.color_formula,
-                )
+                image = data.post_process(**postprocess_params)
             timings.append(("postprocess", round(t.elapsed * 1000, 2)))
 
             with Timer() as t:
                 content = image.render(
-                    add_mask=render_params.return_mask,
                     img_format=format.driver,
                     colormap=colormap,
                     **format.profile,
-                    **render_params.kwargs,
+                    **render_params,
                 )
             timings.append(("format", round(t.elapsed * 1000, 2)))
 
@@ -290,6 +287,7 @@ class MosaicTilerFactory(BaseTilerFactory):
             layer_params=Depends(self.layer_dependency),  # noqa
             dataset_params=Depends(self.dataset_dependency),  # noqa
             render_params=Depends(self.render_dependency),  # noqa
+            postprocess_params=Depends(self.process_dependency),  # noqa
             colormap=Depends(self.colormap_dependency),  # noqa
             pixel_selection: PixelSelectionMethod = Query(
                 PixelSelectionMethod.first, description="Pixel selection method."
@@ -362,6 +360,7 @@ class MosaicTilerFactory(BaseTilerFactory):
             layer_params=Depends(self.layer_dependency),  # noqa
             dataset_params=Depends(self.dataset_dependency),  # noqa
             render_params=Depends(self.render_dependency),  # noqa
+            postprocess_params=Depends(self.process_dependency),  # noqa
             colormap=Depends(self.colormap_dependency),  # noqa
             pixel_selection: PixelSelectionMethod = Query(
                 PixelSelectionMethod.first, description="Pixel selection method."
@@ -470,8 +469,8 @@ class MosaicTilerFactory(BaseTilerFactory):
                             lon,
                             lat,
                             threads=threads,
-                            **layer_params.kwargs,
-                            **dataset_params.kwargs,
+                            **layer_params,
+                            **dataset_params,
                             **kwargs,
                         )
             timings.append(("dataread", round((t.elapsed - mosaic_read) * 1000, 2)))


### PR DESCRIPTION
This PR do 
- update the `DefaultDependency` as mentioned in https://github.com/developmentseed/titiler/discussions/349#discussioncomment-1090558

```python
#before
from dataclasses import dataclass, field
from titiler.core.dependencies import DefaultDependency

@dataclass
class a(DefaultDependency):

    v: int = field(default=1)

    def __post_init__(self):
        """Post Init."""
        if self.v is not None:
            self.kwargs["v"] = self.v

with self.reader(src_path) as src_dst:
    data = src_dst.tile(**a().kwargs)

#now
@dataclass
class a(DefaultDependency):

    v: int = field(default=1)

with self.reader(src_path) as src_dst:
    data = src_dst.tile(**a())
```

- Follow HTML standard for QueryString List 
- add `asset_bidx` and `asset_expression` parameter using the `dict` format `{param}={key}|{value}`
- split the `RenderParams` to `PostProcessParams` and `ImageRenderingParams`
- `process_dependency` attribute in the TileFactory (defaults to `PostProcessParams`) 