### PR TITLE
Fixed binder broken links

### DIFF
--- a/docs/examples/notebooks/Working_with_CloudOptimizedGeoTIFF.ipynb
+++ b/docs/examples/notebooks/Working_with_CloudOptimizedGeoTIFF.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Working With COG - At Scale\n",
     "\n",
-    "[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/developmentseed/titiler/master?filepath=docs%2Fexamples%2FWorking_with_CloudOptimizedGeoTIFF.ipynb)\n",
+    "[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/developmentseed/titiler/master?filepath=docs%2Fexamples%2F%2Fnotebooks%2FWorking_with_CloudOptimizedGeoTIFF.ipynb)\n",
     "\n",
     "For this demo we will use the new `Ozone Monitoring Instrument (OMI) / Aura NO2 Tropospheric Column Density` dataset hosted on AWS PDS: https://registry.opendata.aws/omi-no2-nasa/\n",
     "\n",

--- a/docs/examples/notebooks/Working_with_CloudOptimizedGeoTIFF_simple.ipynb
+++ b/docs/examples/notebooks/Working_with_CloudOptimizedGeoTIFF_simple.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Working With COG\n",
     "\n",
-    "[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/developmentseed/titiler/master?filepath=docs%2Fexamples%2FWorking_with_CloudOptimizedGeoTIFF_simple.ipynb)\n",
+    "[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/developmentseed/titiler/master?filepath=docs%2Fexamples%2F%2Fnotebooks%2FWorking_with_CloudOptimizedGeoTIFF_simple.ipynb)\n",
     "\n",
     "For this demo we will use the new `DigitalGlobe OpenData` dataset https://www.digitalglobe.com/ecosystem/open-data\n",
     "\n",

--- a/docs/examples/notebooks/Working_with_MosaicJSON.ipynb
+++ b/docs/examples/notebooks/Working_with_MosaicJSON.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Working With MosaicJSON\n",
     "\n",
-    "[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/developmentseed/titiler/master?filepath=docs%2Fexamples%2FWorking_with_MosaicJSON.ipynb)\n",
+    "[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/developmentseed/titiler/master?filepath=docs%2Fexamples%2F%2Fnotebooks%2FWorking_with_MosaicJSON.ipynb)\n",
     "\n",
     "### MosaicJSON\n",
     "\n",

--- a/docs/examples/notebooks/Working_with_NumpyTile.ipynb
+++ b/docs/examples/notebooks/Working_with_NumpyTile.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "## NumpyTile\n",
     "\n",
-    "[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/developmentseed/titiler/master?filepath=docs%2Fexamples%2FWorking_with_NumpyTile.ipynb)\n",
+    "[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/developmentseed/titiler/master?filepath=docs%2Fexamples%2F%2Fnotebooks%2FWorking_with_NumpyTile.ipynb)\n",
     "\n",
     "\n",
     "Specification: https://github.com/planetlabs/numpytiles-spec"

--- a/docs/examples/notebooks/Working_with_STAC.ipynb
+++ b/docs/examples/notebooks/Working_with_STAC.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Working With STAC - At Scale\n",
     "\n",
-    "[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/developmentseed/titiler/master?filepath=docs%2Fexamples%2FWorking_with_STAC.ipynb)\n",
+    "[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/developmentseed/titiler/master?filepath=docs%2Fexamples%2F%2Fnotebooks%2FWorking_with_STAC.ipynb)\n",
     "\n",
     "### STAC: SpatioTemporal Asset Catalog\n",
     "\n",

--- a/docs/examples/notebooks/Working_with_STAC_simple.ipynb
+++ b/docs/examples/notebooks/Working_with_STAC_simple.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Working With STAC\n",
     "\n",
-    "[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/developmentseed/titiler/master?filepath=docs%2Fexamples%2FWorking_with_STAC_simple.ipynb)\n",
+    "[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/developmentseed/titiler/master?filepath=docs%2Fexamples%2F%2Fnotebooks%2FWorking_with_STAC_simple.ipynb)\n",
     "\n",
     "### STAC: SpatioTemporal Asset Catalog\n",
     "\n",

--- a/docs/examples/notebooks/Working_with_nonWebMercatorTMS.ipynb
+++ b/docs/examples/notebooks/Working_with_nonWebMercatorTMS.ipynb
@@ -7,7 +7,7 @@
     "# Working With TileMatrixSets (other than WebMercator)\n",
     "\n",
     "\n",
-    "[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/developmentseed/titiler/master?filepath=docs%2Fexamples%2FWorking_with_nonWebMercatorTMS.ipynb)\n",
+    "[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/developmentseed/titiler/master?filepath=docs%2Fexamples%2F%2Fnotebooks%2FWorking_with_nonWebMercatorTMS.ipynb)\n",
     "\n",
     "TiTiler has builtin support for serving tiles in multiple Projections by using [rio-tiler](https://github.com/cogeotiff/rio-tiler) and [morecantile](https://github.com/developmentseed/morecantile)."
    ]


### PR DESCRIPTION
All notebook binder links are broken, missing the word `notebooks` in the file path. This PR fixes the issue. 