### PR TITLE
add tilebuffer option in tiles endpoint

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 0.4.3 (TBD)
+
+* add tile `buffer` option to match rio-tiler tile options (https://github.com/developmentseed/titiler/pull/427)
+
 ## 0.4.2 (2022-01-25)
 
 ## titiler.core

--- a/docs/endpoints/cog.md
+++ b/docs/endpoints/cog.md
@@ -58,6 +58,7 @@ app.include_router(cog.router, prefix="/cog", tags=["Cloud Optimized GeoTIFF"])
     - **colormap** (str): JSON encoded custom Colormap.
     - **colormap_name** (str): rio-tiler color map name.
     - **return_mask** (bool): Add mask to the output data. Default is True.
+    - **buffer** (float): Add buffer on each side of the tile (e.g 0.5 = 257x257, 1.0 = 258x258).
 
 Example:
 
@@ -210,6 +211,7 @@ Example:
     - **colormap** (str): JSON encoded custom Colormap.
     - **colormap_name** (str): rio-tiler color map name.
     - **return_mask** (bool): Add mask to the output data. Default is True.
+    - **buffer** (float): Add buffer on each side of the tile (e.g 0.5 = 257x257, 1.0 = 258x258).
 
 Example:
 

--- a/docs/endpoints/stac.md
+++ b/docs/endpoints/stac.md
@@ -60,6 +60,7 @@ app.include_router(stac.router, prefix="/stac", tags=["SpatioTemporal Asset Cata
     - **colormap** (str): JSON encoded custom Colormap.
     - **colormap_name** (str): rio-tiler color map name.
     - **return_mask** (bool): Add mask to the output data. Default is True.
+    - **buffer** (float): Add buffer on each side of the tile (e.g 0.5 = 257x257, 1.0 = 258x258).
 
 !!! important
     **assets** OR **expression** is required
@@ -230,6 +231,7 @@ Example:
     - **colormap** (str): JSON encoded custom Colormap.
     - **colormap_name** (str): rio-tiler color map name.
     - **return_mask** (bool): Add mask to the output data. Default is True.
+    - **buffer** (float): Add buffer on each side of the tile (e.g 0.5 = 257x257, 1.0 = 258x258).
 
 !!! important
     **assets** OR **expression** is required

--- a/src/titiler/core/titiler/core/factory.py
+++ b/src/titiler/core/titiler/core/factory.py
@@ -465,6 +465,13 @@ class TilerFactory(BaseTilerFactory):
             postprocess_params=Depends(self.process_dependency),
             colormap=Depends(self.colormap_dependency),
             render_params=Depends(self.render_dependency),
+            tile_buffer: Optional[float] = Query(
+                None,
+                gt=0,
+                alias="buffer",
+                title="Tile buffer.",
+                description="Buffer on each side of the given tile. It must be a multiple of `0.5`. Output **tilesize** will be expanded to `tilesize + 2 * tile_buffer` (e.g 0.5 = 257x257, 1.0 = 258x258).",
+            ),
         ):
             """Create map tile from a dataset."""
             timings = []
@@ -480,6 +487,7 @@ class TilerFactory(BaseTilerFactory):
                             y,
                             z,
                             tilesize=tilesize,
+                            tile_buffer=tile_buffer,
                             **layer_params,
                             **dataset_params,
                         )
@@ -545,6 +553,13 @@ class TilerFactory(BaseTilerFactory):
             postprocess_params=Depends(self.process_dependency),  # noqa
             colormap=Depends(self.colormap_dependency),  # noqa
             render_params=Depends(self.render_dependency),  # noqa
+            tile_buffer: Optional[float] = Query(  # noqa
+                None,
+                gt=0,
+                alias="buffer",
+                title="Tile buffer.",
+                description="Buffer on each side of the given tile. It must be a multiple of `0.5`. Output **tilesize** will be expanded to `tilesize + 2 * tile_buffer` (e.g 0.5 = 257x257, 1.0 = 258x258).",
+            ),
         ):
             """Return TileJSON document for a dataset."""
             route_params = {

--- a/src/titiler/mosaic/titiler/mosaic/factory.py
+++ b/src/titiler/mosaic/titiler/mosaic/factory.py
@@ -209,6 +209,13 @@ class MosaicTilerFactory(BaseTilerFactory):
             postprocess_params=Depends(self.process_dependency),
             colormap=Depends(self.colormap_dependency),
             render_params=Depends(self.render_dependency),
+            tile_buffer: Optional[float] = Query(
+                None,
+                gt=0,
+                alias="buffer",
+                title="Tile buffer.",
+                description="Buffer on each side of the given tile. It must be a multiple of `0.5`. Output **tilesize** will be expanded to `tilesize + 2 * tile_buffer` (e.g 0.5 = 257x257, 1.0 = 258x258).",
+            ),
         ):
             """Create map tile from a COG."""
             timings = []
@@ -234,6 +241,7 @@ class MosaicTilerFactory(BaseTilerFactory):
                             pixel_selection=pixel_selection.method(),
                             tilesize=tilesize,
                             threads=threads,
+                            tile_buffer=tile_buffer,
                             **layer_params,
                             **dataset_params,
                         )
@@ -304,6 +312,13 @@ class MosaicTilerFactory(BaseTilerFactory):
             postprocess_params=Depends(self.process_dependency),  # noqa
             colormap=Depends(self.colormap_dependency),  # noqa
             render_params=Depends(self.render_dependency),  # noqa
+            tile_buffer: Optional[float] = Query(  # noqa
+                None,
+                gt=0,
+                alias="buffer",
+                title="Tile buffer.",
+                description="Buffer on each side of the given tile. It must be a multiple of `0.5`. Output **tilesize** will be expanded to `tilesize + 2 * tile_buffer` (e.g 0.5 = 257x257, 1.0 = 258x258).",
+            ),
         ):
             """Return TileJSON document for a COG."""
             route_params = {


### PR DESCRIPTION
we added `tile_buffer` in rio-tiler a while back https://github.com/cogeotiff/rio-tiler/issues/365 but wasn't part of the titiler tile endpoint option 🤷‍♂️ 