### PR TITLE
Make http error cache control behavior configurable.

### DIFF
--- a/src/titiler/core/tests/test_cache_middleware.py
+++ b/src/titiler/core/tests/test_cache_middleware.py
@@ -49,7 +49,7 @@ def test_cachecontrol_middleware_exclude():
     app.add_middleware(
         CacheControlMiddleware,
         cachecontrol="public",
-        cachecontrol_http_code_range=400,
+        cachecontrol_max_http_code=400,
         exclude_path={r"/route1", r"/route2", r"/tiles/[0-1]/.+"},
     )
 

--- a/src/titiler/core/tests/test_cache_middleware.py
+++ b/src/titiler/core/tests/test_cache_middleware.py
@@ -5,6 +5,7 @@ from titiler.core.middleware import CacheControlMiddleware
 
 from fastapi import FastAPI, Path
 
+from starlette.responses import Response
 from starlette.testclient import TestClient
 
 
@@ -36,9 +37,19 @@ def test_cachecontrol_middleware_exclude():
         """tiles."""
         return "yeah"
 
+    @app.get("/emptytiles/{z}/{x}/{y}")
+    async def emptytiles(
+        z: int = Path(..., ge=0, le=30, description="Mercator tiles's zoom level"),
+        x: int = Path(..., description="Mercator tiles's column"),
+        y: int = Path(..., description="Mercator tiles's row"),
+    ):
+        """tiles."""
+        return Response(status_code=404)
+
     app.add_middleware(
         CacheControlMiddleware,
         cachecontrol="public",
+        cachecontrol_http_code_range=400,
         exclude_path={r"/route1", r"/route2", r"/tiles/[0-1]/.+"},
     )
 
@@ -58,3 +69,6 @@ def test_cachecontrol_middleware_exclude():
 
     response = client.get("/tiles/3/1/1")
     assert response.headers["Cache-Control"] == "public"
+
+    response = client.get("/emptytiles/3/1/1")
+    assert not response.headers.get("Cache-Control")

--- a/src/titiler/core/titiler/core/middleware.py
+++ b/src/titiler/core/titiler/core/middleware.py
@@ -19,6 +19,7 @@ class CacheControlMiddleware(BaseHTTPMiddleware):
         self,
         app: ASGIApp,
         cachecontrol: Optional[str] = None,
+        cachecontrol_http_code_range: Optional[int] = 500,
         exclude_path: Optional[Set[str]] = None,
     ) -> None:
         """Init Middleware.
@@ -31,6 +32,7 @@ class CacheControlMiddleware(BaseHTTPMiddleware):
         """
         super().__init__(app)
         self.cachecontrol = cachecontrol
+        self.cachecontrol_http_code_range = cachecontrol_http_code_range
         self.exclude_path = exclude_path or set()
 
     async def dispatch(self, request: Request, call_next):
@@ -41,7 +43,10 @@ class CacheControlMiddleware(BaseHTTPMiddleware):
                 if re.match(path, request.url.path):
                     return response
 
-            if request.method in ["HEAD", "GET"] and response.status_code < 500:
+            if (
+                request.method in ["HEAD", "GET"]
+                and response.status_code < self.cachecontrol_http_code_range
+            ):
                 response.headers["Cache-Control"] = self.cachecontrol
 
         return response

--- a/src/titiler/core/titiler/core/middleware.py
+++ b/src/titiler/core/titiler/core/middleware.py
@@ -19,7 +19,7 @@ class CacheControlMiddleware(BaseHTTPMiddleware):
         self,
         app: ASGIApp,
         cachecontrol: Optional[str] = None,
-        cachecontrol_http_code_range: Optional[int] = 500,
+        cachecontrol_max_http_code: Optional[int] = 500,
         exclude_path: Optional[Set[str]] = None,
     ) -> None:
         """Init Middleware.
@@ -32,7 +32,7 @@ class CacheControlMiddleware(BaseHTTPMiddleware):
         """
         super().__init__(app)
         self.cachecontrol = cachecontrol
-        self.cachecontrol_http_code_range = cachecontrol_http_code_range
+        self.cachecontrol_max_http_code = cachecontrol_max_http_code
         self.exclude_path = exclude_path or set()
 
     async def dispatch(self, request: Request, call_next):
@@ -45,7 +45,7 @@ class CacheControlMiddleware(BaseHTTPMiddleware):
 
             if (
                 request.method in ["HEAD", "GET"]
-                and response.status_code < self.cachecontrol_http_code_range
+                and response.status_code < self.cachecontrol_max_http_code
             ):
                 response.headers["Cache-Control"] = self.cachecontrol
 


### PR DESCRIPTION
## What I am changing
While implementing edge caching for a titiler deployment we have a case where underlying source COGs are continually added in real time.  Currently a request that results in `404` `No assets found for tile` has the same `Cache-Control` header as a `200` response and is maintained by the edge cache for the same duration.  In our case we would prefer `404` responses to have a shorter duration in the edge cache so that requests are passed to the origin (where new assets may now be available).  This PR makes the upper range or http codes which include a `Cache-Control` header configurable so that edge caches can exert finer control on error response cache duration.

## How I did it
Extended `core/middleware` to support a configurable upper bound for response codes which include a `Cache-Control` header rather than the hardcoded `500` value.

## How you can test it
Via the project's `tox` testing entrypoint.
