### PR TITLE
Include all values for a query param in LowerCaseQueryStringMiddleware

### DIFF
--- a/src/titiler/core/tests/test_case_middleware.py
+++ b/src/titiler/core/tests/test_case_middleware.py
@@ -1,5 +1,6 @@
 """Test titiler.core.middleware.LowerCaseQueryStringMiddleware."""
 
+from typing import List
 
 from titiler.core.middleware import LowerCaseQueryStringMiddleware
 
@@ -26,3 +27,23 @@ def test_lowercase_middleware():
 
     response = client.get("/route1?VALUE=lorenzori")
     assert response.json() == {"value": "lorenzori"}
+
+
+def test_lowercase_middleware_multiple_values():
+    """Make sure all values are available for lists."""
+    app = FastAPI()
+
+    @app.get("/route1")
+    async def route1(value: List[str] = Query(...)):
+        """route1."""
+        return {"value": value}
+
+    app.add_middleware(LowerCaseQueryStringMiddleware)
+
+    client = TestClient(app)
+
+    response = client.get("/route1?value=lorenzori&value=dogs")
+    assert response.json() == {"value": ["lorenzori", "dogs"]}
+
+    response = client.get("/route1?VALUE=lorenzori&VALUE=dogs&value=trucks")
+    assert response.json() == {"value": ["lorenzori", "dogs", "trucks"]}

--- a/src/titiler/core/titiler/core/middleware.py
+++ b/src/titiler/core/titiler/core/middleware.py
@@ -109,8 +109,8 @@ class LowerCaseQueryStringMiddleware(BaseHTTPMiddleware):
         self.DECODE_FORMAT = "latin-1"
 
         query_string = ""
-        for k in request.query_params:
-            query_string += k.lower() + "=" + request.query_params[k] + "&"
+        for k, v in request.query_params.multi_items():
+            query_string += k.lower() + "=" + v + "&"
 
         query_string = query_string[:-1]
         request.scope["query_string"] = query_string.encode(self.DECODE_FORMAT)


### PR DESCRIPTION
## What I am changing

- Previously if multiple values for a query param were present on a
request (e.g. for a `List[T] = Query(...)` param) only one of the values
would be present after the `LowerCaseQueryStringMiddleware` ran.

## How I did it

- I noticed this issue in our production TiTiler deployment (running version 0.5.1). I copied the `LowerCaseQueryStringMiddleware` and made this change in our app to verify it worked as intended.
- Also added a unit test demonstrating the fix.

## How you can test it
- A unit test is included.

