### PR TITLE
Update requirements.txt

### DIFF
--- a/deployment/azure/requirements.txt
+++ b/deployment/azure/requirements.txt
@@ -3,5 +3,5 @@
 # Manually managing azure-functions-worker may cause unexpected issues
 
 azure-functions
-
+starlette==0.19.1
 titiler.application


### PR DESCRIPTION
was getting an error "fastapi 0.78.0 requires starlette==0.19.1, but you'll have starlette 0.20.0 which is incompatible. "

## Available PR templates

<!--
  Github doesn't allow PR template selection the same way that it is possible with issues.
  Preview this and select the appropriate template
-->

- [Default](?expand=1&template=default.md)
- [Version Release](?expand=1&template=version_release.md)
- _Alternatively delete and start empty_
