### PR TITLE
Templated deployment containerPort via env.PORT

### DIFF
--- a/deployment/k8s/titiler/templates/deployment.yaml
+++ b/deployment/k8s/titiler/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
           {{- end }}
           ports:
             - name: http
-              containerPort: 80
+              containerPort: {{ .Values.env.PORT }}
               protocol: TCP
           livenessProbe:
             httpGet:


### PR DESCRIPTION
Signed-off-by: FischerLGLN <maik.fischer@lgln.niedersachsen.de>

Tested on okd with additional changes:

```yaml
image:
  repository: ghcr.io/developmentseed/titiler

service:
  type: ClusterIP
  port: 8080

env:
  PORT: 8080
```
Kubernetes default deployment is not affected by this patch.