### PR TITLE
fix: **kwargs instead of *kwargs

### DIFF
--- a/deployment/aws/cdk/app.py
+++ b/deployment/aws/cdk/app.py
@@ -41,7 +41,7 @@ class titilerLambdaStack(core.Stack):
         **kwargs: Any,
     ) -> None:
         """Define stack."""
-        super().__init__(scope, id, *kwargs)
+        super().__init__(scope, id, **kwargs)
 
         permissions = permissions or []
         environment = environment or {}


### PR DESCRIPTION
Noticed this small bug when modifying the lambda stack. It doesn't affect anything unless you try to pass variables through (such as passing through env which you need to do for vpc lookups).