### PR TITLE
Allow the default pixel_selection method to be overidden 

### DIFF
--- a/src/titiler/mosaic/tests/test_factory.py
+++ b/src/titiler/mosaic/tests/test_factory.py
@@ -15,6 +15,7 @@ from cogeo_mosaic.mosaic import MosaicJSON
 from titiler.core.dependencies import DefaultDependency, WebMercatorTMSParams
 from titiler.core.resources.enums import OptionalHeader
 from titiler.mosaic.factory import MosaicTilerFactory
+from titiler.mosaic.resources.enums import PixelSelectionMethod
 
 from .conftest import DATA_DIR
 
@@ -112,7 +113,6 @@ def test_MosaicTilerFactory():
         response = client.get(
             "/mosaic/tiles/7/37/45.npy", params={"url": mosaic_file, "buffer": 10}
         )
-        assert response.status_code == 200
         assert response.status_code == 200
         assert response.headers["content-type"] == "application/x-binary"
         npy_tile = numpy.load(BytesIO(response.content))
@@ -289,3 +289,34 @@ def test_MosaicTilerFactory_ReaderParams():
         )
         value_two = response.json()["values"][0][1][0]
         assert value_two == 2 * value
+
+
+def test_MosaicTilerFactory_PixelSelectionParams():
+    """Test MosaicTilerFactory factory with a customized default PixelSelectionMethod."""
+    mosaic = MosaicTilerFactory(router_prefix="/mosaic")
+    mosaic_highest = MosaicTilerFactory(
+        pixel_selection_dependency=lambda: PixelSelectionMethod.highest.method(),
+        router_prefix="/mosaic_highest",
+    )
+
+    app = FastAPI()
+    app.include_router(mosaic.router, prefix="/mosaic")
+    app.include_router(mosaic_highest.router, prefix="/mosaic_highest")
+    client = TestClient(app)
+
+    with tmpmosaic() as mosaic_file:
+        response = client.get("/mosaic/tiles/7/37/45.npy", params={"url": mosaic_file})
+        assert response.status_code == 200
+        assert response.headers["content-type"] == "application/x-binary"
+        npy_tile = numpy.load(BytesIO(response.content))
+        assert npy_tile.shape == (4, 256, 256)  # mask + data
+
+        response = client.get(
+            "/mosaic_highest/tiles/7/37/45.npy", params={"url": mosaic_file}
+        )
+        assert response.status_code == 200
+        assert response.headers["content-type"] == "application/x-binary"
+        npy_tile_highest = numpy.load(BytesIO(response.content))
+        assert npy_tile_highest.shape == (4, 256, 256)  # mask + data
+
+        assert (npy_tile != npy_tile_highest).any()


### PR DESCRIPTION
in the `MosaicTilerFactory`.

For https://github.com/developmentseed/titiler/discussions/492

The default `PixelSelectionParams` function doesn't change the existing
behavior (it uses `PixelSelectionMethod.first` if no `pixel_selection`
query param is provided), but a custom function can be used to change
the default behavior.

