### PR TITLE
Prefix all routes via path_prefix setting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,3 +28,7 @@ repos:
     hooks:
       - id: mypy
         language_version: python
+        additional_dependencies:
+          - types-simplejson
+          - types-attrs
+          - types-requests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
         language_version: python
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.812
+    rev: v0.971
     hooks:
       - id: mypy
         language_version: python

--- a/src/titiler/application/tests/routes/test_cog.py
+++ b/src/titiler/application/tests/routes/test_cog.py
@@ -465,3 +465,12 @@ def test_json_response_with_nan(rio, app):
     assert response.status_code == 200
     body = response.json()
     assert body["values"][0] is None
+
+
+@pytest.mark.parametrize(
+    "set_env", [{"TITILER_API_PATH_PREFIX": "/foo"}], indirect=True
+)
+def test_path_prefix(app):
+    """test /foo/validate endpoint"""
+    response = app.get(f"/foo/cog/validate?url={os.path.join(DATA_DIR, 'cog.tif')}")
+    assert response.status_code == 200

--- a/src/titiler/application/tests/routes/test_mosaic.py
+++ b/src/titiler/application/tests/routes/test_mosaic.py
@@ -5,6 +5,7 @@ from typing import Any, Callable
 from unittest.mock import patch
 
 import mercantile
+import pytest
 from cogeo_mosaic.backends import FileBackend
 from cogeo_mosaic.mosaic import MosaicJSON
 
@@ -232,3 +233,13 @@ def test_validate(app):
 
     response = app.post("/mosaicjson/validate", json={"nope": "oups"})
     assert response.status_code == 422
+
+
+@pytest.mark.parametrize(
+    "set_env", [{"TITILER_API_PATH_PREFIX": "/foo"}], indirect=True
+)
+def test_path_prefix(app):
+    """test POST /foo/mosaicjson/validate endpoint"""
+    body = read_json_fixture("mosaic.json")
+    response = app.post("/foo/mosaicjson/validate", json=body)
+    assert response.status_code == 200

--- a/src/titiler/application/tests/routes/test_stac.py
+++ b/src/titiler/application/tests/routes/test_stac.py
@@ -4,6 +4,7 @@
 from typing import Dict
 from unittest.mock import patch
 
+import pytest
 from rasterio.io import MemoryFile
 
 from ..conftest import mock_rasterio_open, mock_RequestGet
@@ -11,7 +12,7 @@ from ..conftest import mock_rasterio_open, mock_RequestGet
 
 @patch("rio_tiler.io.stac.httpx")
 def test_bounds(httpx, app):
-    """test /bounds endpoint."""
+    """test /stac/bounds endpoint."""
     httpx.get = mock_RequestGet
 
     response = app.get("/stac/bounds?url=https://myurl.com/item.json")
@@ -23,7 +24,7 @@ def test_bounds(httpx, app):
 @patch("rio_tiler.io.cogeo.rasterio")
 @patch("rio_tiler.io.stac.httpx")
 def test_info(httpx, rio, app):
-    """test /info endpoint."""
+    """test /stac/info endpoint."""
     httpx.get = mock_RequestGet
     rio.open = mock_rasterio_open
 
@@ -100,7 +101,7 @@ def test_tile(httpx, rio, app):
 @patch("rio_tiler.io.cogeo.rasterio")
 @patch("rio_tiler.io.stac.httpx")
 def test_tilejson(httpx, rio, app):
-    """test /tilejson endpoint."""
+    """test /stac/tilejson endpoint."""
     httpx.get = mock_RequestGet
     rio.open = mock_rasterio_open
 
@@ -253,7 +254,7 @@ def test_point(httpx, rio, app):
 @patch("rio_tiler.io.cogeo.rasterio")
 @patch("rio_tiler.io.stac.httpx")
 def test_missing_asset_not_found(httpx, rio, app):
-    """test /info endpoint."""
+    """test /stac/info endpoint."""
     httpx.get = mock_RequestGet
     rio.open = mock_rasterio_open
 
@@ -261,3 +262,15 @@ def test_missing_asset_not_found(httpx, rio, app):
         "/stac/preview?url=https://myurl.com/item.json&assets=B1111&rescale=0,1000&max_size=64"
     )
     assert response.status_code == 404
+
+
+@patch("rio_tiler.io.stac.httpx")
+@pytest.mark.parametrize(
+    "set_env", [{"TITILER_API_PATH_PREFIX": "/foo"}], indirect=True
+)
+def test_path_prefix(httpx, app):
+    """test /foo/stac/bounds endpoint."""
+    httpx.get = mock_RequestGet
+
+    response = app.get("/foo/stac/bounds?url=https://myurl.com/item.json")
+    assert response.status_code == 200

--- a/src/titiler/application/tests/routes/test_tms.py
+++ b/src/titiler/application/tests/routes/test_tms.py
@@ -1,6 +1,7 @@
 """test TileMatrixSets endpoints."""
 
 import morecantile
+import pytest
 
 NB_DEFAULT_TMS = len(morecantile.tms.list())
 
@@ -24,3 +25,12 @@ def test_tilematrixInfo(app):
     body = response.json()
     assert body["type"] == "TileMatrixSetType"
     assert body["identifier"] == "EPSG3413"
+
+
+@pytest.mark.parametrize(
+    "set_env", [{"TITILER_API_PATH_PREFIX": "/foo"}], indirect=True
+)
+def test_path_prefix(app):
+    """test /foo/tileMatrixSet endpoint."""
+    response = app.get("/foo/tileMatrixSets")
+    assert response.status_code == 200

--- a/src/titiler/application/tests/test_main.py
+++ b/src/titiler/application/tests/test_main.py
@@ -1,8 +1,20 @@
 """Test titiler.application.main.app."""
 
+import pytest
+
 
 def test_health(app):
     """Test /healthz endpoint."""
     response = app.get("/healthz")
+    assert response.status_code == 200
+    assert response.json() == {"ping": "pong!"}
+
+
+@pytest.mark.parametrize(
+    "set_env", [{"TITILER_API_PATH_PREFIX": "/foo"}], indirect=True
+)
+def test_path_prefix(app):
+    """Test /foo/healthz endpoint."""
+    response = app.get("/foo/healthz")
     assert response.status_code == 200
     assert response.json() == {"ping": "pong!"}

--- a/src/titiler/application/titiler/application/main.py
+++ b/src/titiler/application/titiler/application/main.py
@@ -15,7 +15,7 @@ from titiler.core.middleware import (
 )
 from titiler.mosaic.errors import MOSAIC_STATUS_CODES
 
-from fastapi import FastAPI, APIRouter
+from fastapi import APIRouter, FastAPI
 
 from starlette.middleware.cors import CORSMiddleware
 from starlette.requests import Request
@@ -36,15 +36,25 @@ app = FastAPI(
 )
 
 if not api_settings.disable_cog:
-    app.include_router(cog.router, prefix=api_settings.path_prefix+"/cog", tags=["Cloud Optimized GeoTIFF"])
+    app.include_router(
+        cog.router,
+        prefix=api_settings.path_prefix + "/cog",
+        tags=["Cloud Optimized GeoTIFF"],
+    )
 
 if not api_settings.disable_stac:
     app.include_router(
-        stac.router, prefix=api_settings.path_prefix+"/stac", tags=["SpatioTemporal Asset Catalog"]
+        stac.router,
+        prefix=api_settings.path_prefix + "/stac",
+        tags=["SpatioTemporal Asset Catalog"],
     )
 
 if not api_settings.disable_mosaic:
-    app.include_router(mosaic.router, prefix=api_settings.path_prefix+"/mosaicjson", tags=["MosaicJSON"])
+    app.include_router(
+        mosaic.router,
+        prefix=api_settings.path_prefix + "/mosaicjson",
+        tags=["MosaicJSON"],
+    )
 
 app.include_router(tms.router, prefix=api_settings.path_prefix, tags=["TileMatrixSets"])
 add_exception_handlers(app, DEFAULT_STATUS_CODES)
@@ -89,6 +99,7 @@ if api_settings.lower_case_query_parameters:
 
 router = APIRouter(prefix=api_settings.path_prefix)
 
+
 @router.get("/healthz", description="Health Check", tags=["Health Check"])
 def ping():
     """Health check."""
@@ -103,5 +114,6 @@ def landing(request: Request):
         context={"request": request},
         media_type="text/html",
     )
+
 
 app.include_router(router)

--- a/src/titiler/application/titiler/application/main.py
+++ b/src/titiler/application/titiler/application/main.py
@@ -86,7 +86,7 @@ app.add_middleware(
 app.add_middleware(
     CacheControlMiddleware,
     cachecontrol=api_settings.cachecontrol,
-    exclude_path={r"/healthz"},
+    exclude_path={api_settings.path_prefix + "/healthz"},
 )
 
 if api_settings.debug:

--- a/src/titiler/application/titiler/application/settings.py
+++ b/src/titiler/application/titiler/application/settings.py
@@ -10,6 +10,7 @@ class ApiSettings(pydantic.BaseSettings):
     cors_origins: str = "*"
     cachecontrol: str = "public, max-age=3600"
     root_path: str = ""
+    path_prefix: str = ""
     debug: bool = False
 
     disable_cog: bool = False


### PR DESCRIPTION
## What I am changing
This PR introduces the ability to host TiTiler on a non-root (non-`/`) API route.

## How I did it
1. Add support for a `path_prefix` setting in `src/titiler/application/titiler/application/settings.py`. This can be set via the `TITILER_API_PATH_PREFIX` environment variable.
2. Make use of the `ApiSettings().path_prefix` in `src/titiler/application/titiler/application/main.py` by concatenating it with the existing prefixes (eg. `"cog"` and `"stac"`).

## How you can test it
Deploy TiTiler as a proxy Lambda to a non-root AWS API Gateway route. Query the various endpoints to confirm they resolve correctly.

## Related Issues
Closes #513