### PR TITLE
Refactor gis tools

### DIFF
--- a/src/titiler/core/titiler/core/factory.py
+++ b/src/titiler/core/titiler/core/factory.py
@@ -263,8 +263,7 @@ class TilerFactory(BaseTilerFactory):
             env=Depends(self.environment_dependency),
         ):
             """Return the bounds of the COG."""
-            return gt.call_with_read(
-                func=gt.bounds,
+            return gt.bounds(
                 reader=self.reader,
                 env=env,
                 src_path=src_path,
@@ -290,8 +289,7 @@ class TilerFactory(BaseTilerFactory):
             env=Depends(self.environment_dependency),
         ):
             """Return dataset's basic info."""
-            return gt.call_with_read(
-                func=gt.info,
+            return gt.info(
                 reader=self.reader,
                 env=env,
                 src_path=src_path,
@@ -317,8 +315,7 @@ class TilerFactory(BaseTilerFactory):
             env=Depends(self.environment_dependency),
         ):
             """Return dataset's basic info as a GeoJSON feature."""
-            return gt.call_with_read(
-                func=gt.info_geojson,
+            return gt.info_geojson(
                 reader=self.reader,
                 env=env,
                 src_path=src_path,
@@ -354,16 +351,17 @@ class TilerFactory(BaseTilerFactory):
             env=Depends(self.environment_dependency),
         ):
             """Get Dataset statistics."""
-            return gt.call_with_read(
-                gt.statistics,
+            return gt.statistics(
                 reader=self.reader,
                 env=env,
                 src_path=src_path,
                 reader_params=reader_params,
-                layer_params=layer_params,
-                image_params=image_params,
-                dataset_params=dataset_params,
-                stats_params=stats_params,
+                stat_params={
+                    **layer_params,
+                    **image_params,
+                    **dataset_params,
+                    **stats_params,
+                },
                 histogram_params=histogram_params,
             )
 
@@ -394,18 +392,21 @@ class TilerFactory(BaseTilerFactory):
             env=Depends(self.environment_dependency),
         ):
             """Get Statistics from a geojson feature or featureCollection."""
-            return gt.call_with_read(
-                gt.geojson_statistics,
+            return gt.geojson_statistics(
                 geojson=geojson,
                 reader=self.reader,
                 env=env,
                 src_path=src_path,
                 reader_params=reader_params,
-                layer_params=layer_params,
-                image_params=image_params,
-                dataset_params=dataset_params,
-                stats_params=stats_params,
-                histogram_params=histogram_params,
+                feature_params={
+                    **layer_params,
+                    **image_params,
+                    **dataset_params
+                },
+                stats_params={
+                    **stats_params,
+                    **histogram_params
+                }
             )
 
     ############################################################################
@@ -559,8 +560,7 @@ class TilerFactory(BaseTilerFactory):
                 tiles_url += f"?{urlencode(qs)}"
 
             reader_params['tms'] = tms
-            return gt.call_with_read(
-                gt.tilejson,
+            return gt.tilejson(
                 reader=self.reader,
                 env=env,
                 src_path=src_path,
@@ -665,8 +665,7 @@ class TilerFactory(BaseTilerFactory):
             """Get Point value for a dataset."""
             timings = []
             with Timer() as t:
-                result = gt.call_with_read(
-                    gt.point,
+                result = gt.point(
                     reader=self.reader,
                     env=env,
                     src_path=src_path,
@@ -715,9 +714,11 @@ class TilerFactory(BaseTilerFactory):
                 reader=self.reader,
                 format=format,
                 src_path=src_path,
-                layer_params=layer_params,
-                dataset_params=dataset_params,
-                img_params=img_params,
+                preview_params={
+                    **layer_params,
+                    **img_params,
+                    **dataset_params,
+                },
                 postprocess_params=postprocess_params,
                 colormap=colormap,
                 render_params=render_params,
@@ -774,9 +775,11 @@ class TilerFactory(BaseTilerFactory):
                 reader=self.reader,
                 format=format,
                 src_path=src_path,
-                layer_params=layer_params,
-                image_params=image_params,
-                dataset_params=dataset_params,
+                part_params={
+                    **layer_params,
+                    **image_params,
+                    **dataset_params,
+                },
                 postprocess_params=postprocess_params,
                 colormap=colormap,
                 render_params=render_params,
@@ -822,18 +825,20 @@ class TilerFactory(BaseTilerFactory):
             """Create image from a geojson feature."""
             headers: Dict[str, str] = {}
 
-            timings, content = gt.part(
+            timings, content = gt.geojson_crop(
                 geojson=geojson,
                 reader=self.reader,
+                reader_params=reader_params,
                 format=format,
                 src_path=src_path,
-                layer_params=layer_params,
-                dataset_params=dataset_params,
-                image_params=image_params,
+                part_params={
+                    **layer_params,
+                    **dataset_params,
+                    **image_params,
+                },
                 postprocess_params=postprocess_params,
                 colormap=colormap,
                 render_params=render_params,
-                reader_params=reader_params,
                 env=env
             )
 
@@ -893,8 +898,7 @@ class MultiBaseTilerFactory(TilerFactory):
             """Get Point value for a dataset."""
             timings = []
             with Timer() as t:
-                result = gt.call_with_read(
-                    gt.point,
+                result = gt.point(
                     reader=self.reader,
                     env=env,
                     src_path=src_path,
@@ -936,8 +940,7 @@ class MultiBaseTilerFactory(TilerFactory):
             env=Depends(self.environment_dependency),
         ):
             """Return dataset's basic info or the list of available assets."""
-            return gt.call_with_read(
-                func=gt.info,
+            return gt.info(
                 reader=self.reader,
                 env=env,
                 src_path=src_path,
@@ -964,8 +967,7 @@ class MultiBaseTilerFactory(TilerFactory):
             env=Depends(self.environment_dependency),
         ):
             """Return dataset's basic info as a GeoJSON feature."""
-            return gt.call_with_read(
-                func=gt.info_geojson_multi,
+            return gt.info_geojson_multi(
                 reader=self.reader,
                 env=env,
                 src_path=src_path,
@@ -984,8 +986,7 @@ class MultiBaseTilerFactory(TilerFactory):
             env=Depends(self.environment_dependency),
         ):
             """Return a list of supported assets."""
-            return gt.call_with_read(
-                func=gt.assets,
+            return gt.assets(
                 reader=self.reader,
                 env=env,
                 src_path=src_path,
@@ -1020,16 +1021,17 @@ class MultiBaseTilerFactory(TilerFactory):
             env=Depends(self.environment_dependency),
         ):
             """Per Asset statistics"""
-            return gt.call_with_read(
-                gt.statistics,
+            return gt.statistics(
                 reader=self.reader,
                 env=env,
                 src_path=src_path,
                 reader_params=reader_params,
-                asset_params=asset_params,
-                image_params=image_params,
-                dataset_params=dataset_params,
-                stats_params=stats_params,
+                stat_params={
+                    **asset_params,
+                    **image_params,
+                    **dataset_params,
+                    **stats_params,
+                },
                 histogram_params=histogram_params,
             )
 
@@ -1058,17 +1060,19 @@ class MultiBaseTilerFactory(TilerFactory):
             env=Depends(self.environment_dependency),
         ):
             """Merged assets statistics."""
-            return gt.call_with_read(
-                gt.merged_statistics,
+            return gt.statistics(
                 reader=self.reader,
+                reader_params=reader_params,
                 env=env,
                 src_path=src_path,
-                layer_params=layer_params,
-                reader_params=reader_params,
-                image_params=image_params,
-                dataset_params=dataset_params,
-                stats_params=stats_params,
+                stats_params={
+                    **stats_params,
+                    **layer_params,
+                    **dataset_params,
+                    **image_params
+                },
                 histogram_params=histogram_params,
+                multi_assets=True
             )
 
         # POST endpoint
@@ -1098,19 +1102,22 @@ class MultiBaseTilerFactory(TilerFactory):
             env=Depends(self.environment_dependency),
         ):
             """Get Statistics from a geojson feature or featureCollection."""
-            return gt.call_with_read(
-                gt.geojson_statistics,
+            return gt.geojson_statistics(
                 reader=self.reader,
                 env=env,
                 src_path=src_path,
                 reader_params=reader_params,
                 geojson=geojson,
                 multi_assets=True,
-                layer_params=layer_params,
-                image_params=image_params,
-                dataset_params=dataset_params,
-                stats_params=stats_params,
-                histogram_params=histogram_params,
+                feature_params={
+                    **layer_params,
+                    **image_params,
+                    **dataset_params,
+                },
+                stats_params={
+                    **stats_params,
+                    **histogram_params
+                }
             )
 
 @dataclass
@@ -1155,8 +1162,7 @@ class MultiBandTilerFactory(TilerFactory):
             env=Depends(self.environment_dependency),
         ):
             """Return dataset's basic info."""
-            return gt.call_with_read(
-                func=gt.info,
+            return gt.info(
                 reader=self.reader,
                 env=env,
                 src_path=src_path,
@@ -1183,8 +1189,7 @@ class MultiBandTilerFactory(TilerFactory):
             env=Depends(self.environment_dependency),
         ):
             """Return dataset's basic info as a GeoJSON feature."""
-            return gt.call_with_read(
-                func=gt.info_geojson,
+            return gt.info_geojson(
                 reader=self.reader,
                 env=env,
                 src_path=src_path,
@@ -1203,8 +1208,7 @@ class MultiBandTilerFactory(TilerFactory):
             env=Depends(self.environment_dependency),
         ):
             """Return a list of supported bands."""
-            return gt.call_with_read(
-                func=gt.bands,
+            return gt.bands(
                 reader=self.reader,
                 env=env,
                 src_path=src_path,
@@ -1238,19 +1242,19 @@ class MultiBandTilerFactory(TilerFactory):
             env=Depends(self.environment_dependency),
         ):
             """Create image from a geojson feature."""
-            return gt.call_with_read(
-                gt.statistics,
+            return gt.statistics(
                 reader=self.reader,
                 env=env,
                 src_path=src_path,
                 reader_params=reader_params,
-                bands_params=bands_params,
-                image_params=image_params,
-                dataset_params=dataset_params,
-                stats_params=stats_params,
+                stat_params={
+                    **bands_params,
+                    **image_params,
+                    **dataset_params,
+                    **stats_params,
+                },
                 histogram_params=histogram_params,
             )
-
 
         # POST endpoint
         @self.router.post(
@@ -1280,18 +1284,21 @@ class MultiBandTilerFactory(TilerFactory):
         ):
             """Get Statistics from a geojson feature or featureCollection."""
 
-            return gt.call_with_read(
-                gt.geojson_statistics,
+            return gt.geojson_statistics(
                 geojson=geojson,
                 reader=self.reader,
                 env=env,
                 src_path=src_path,
                 reader_params=reader_params,
-                layer_params=bands_params,
-                image_params=image_params,
-                dataset_params=dataset_params,
-                stats_params=stats_params,
-                histogram_params=histogram_params,
+                feature_params={
+                    **bands_params,
+                    **image_params,
+                    **dataset_params
+                },
+                stats_params={
+                    **stats_params,
+                    **histogram_params,
+                }
             )
 
 

--- a/src/titiler/core/titiler/core/factory.py
+++ b/src/titiler/core/titiler/core/factory.py
@@ -353,7 +353,7 @@ class TilerFactory(BaseTilerFactory):
                 env=env,
                 src_path=src_path,
                 reader_params=reader_params,
-                stat_params={
+                stats_params={
                     **layer_params,
                     **image_params,
                     **dataset_params,
@@ -450,7 +450,7 @@ class TilerFactory(BaseTilerFactory):
             """Create map tile from a dataset."""
             headers: Dict[str, str] = {}
 
-            content, timings = gt.tile(
+            content, timings, format = gt.tile(
                 reader=self.reader,
                 env=env,
                 src_path=src_path,
@@ -548,7 +548,6 @@ class TilerFactory(BaseTilerFactory):
             if qs:
                 tiles_url += f"?{urlencode(qs)}"
 
-            reader_params["tms"] = tms
             return gt.tilejson(
                 reader=self.reader,
                 env=env,
@@ -557,6 +556,7 @@ class TilerFactory(BaseTilerFactory):
                 tiles_url=tiles_url,
                 minzoom=minzoom,
                 maxzoom=maxzoom,
+                tms=tms,
             )
 
     def wmts(self):  # noqa: C901
@@ -700,7 +700,7 @@ class TilerFactory(BaseTilerFactory):
             """Create preview of a dataset."""
             headers: Dict[str, str] = {}
 
-            timings, content = gt.preview(
+            content, timings, format = gt.preview(
                 reader=self.reader,
                 format=format,
                 src_path=src_path,
@@ -758,13 +758,15 @@ class TilerFactory(BaseTilerFactory):
             headers: Dict[str, str] = {}
 
             timings, content = gt.part(
+                reader=self.reader,
+                env=env,
+                src_path=src_path,
+                reader_params=reader_params,
                 minx=minx,
                 miny=miny,
                 maxx=maxx,
                 maxy=maxy,
-                reader=self.reader,
                 format=format,
-                src_path=src_path,
                 part_params={
                     **layer_params,
                     **image_params,
@@ -773,8 +775,6 @@ class TilerFactory(BaseTilerFactory):
                 postprocess_params=postprocess_params,
                 colormap=colormap,
                 render_params=render_params,
-                reader_params=reader_params,
-                env=env,
             )
 
             if OptionalHeader.server_timing in self.optional_headers:
@@ -815,13 +815,13 @@ class TilerFactory(BaseTilerFactory):
             """Create image from a geojson feature."""
             headers: Dict[str, str] = {}
 
-            timings, content = gt.geojson_crop(
+            timings, content, format = gt.geojson_crop(
                 geojson=geojson,
                 reader=self.reader,
                 reader_params=reader_params,
                 format=format,
                 src_path=src_path,
-                part_params={
+                feature_params={
                     **layer_params,
                     **dataset_params,
                     **image_params,
@@ -1015,7 +1015,7 @@ class MultiBaseTilerFactory(TilerFactory):
                 env=env,
                 src_path=src_path,
                 reader_params=reader_params,
-                stat_params={
+                stats_params={
                     **asset_params,
                     **image_params,
                     **dataset_params,
@@ -1056,12 +1056,11 @@ class MultiBaseTilerFactory(TilerFactory):
                 src_path=src_path,
                 stats_params={
                     **stats_params,
-                    **layer_params,
                     **dataset_params,
                     **image_params,
                 },
                 histogram_params=histogram_params,
-                multi_assets=True,
+                layer_params=layer_params,
             )
 
         # POST endpoint
@@ -1097,9 +1096,8 @@ class MultiBaseTilerFactory(TilerFactory):
                 src_path=src_path,
                 reader_params=reader_params,
                 geojson=geojson,
-                multi_assets=True,
+                layer_params=layer_params,
                 feature_params={
-                    **layer_params,
                     **image_params,
                     **dataset_params,
                 },
@@ -1234,7 +1232,7 @@ class MultiBandTilerFactory(TilerFactory):
                 env=env,
                 src_path=src_path,
                 reader_params=reader_params,
-                stat_params={
+                stats_params={
                     **bands_params,
                     **image_params,
                     **dataset_params,
@@ -1277,7 +1275,8 @@ class MultiBandTilerFactory(TilerFactory):
                 env=env,
                 src_path=src_path,
                 reader_params=reader_params,
-                feature_params={**bands_params, **image_params, **dataset_params},
+                feature_params={**image_params, **dataset_params},
+                bands_params=bands_params,
                 stats_params={
                     **stats_params,
                     **histogram_params,

--- a/src/titiler/core/titiler/core/gis_tools.py
+++ b/src/titiler/core/titiler/core/gis_tools.py
@@ -1,0 +1,420 @@
+from typing import Dict, Optional, Union
+import rasterio
+from geojson_pydantic.features import Feature, FeatureCollection
+from geojson_pydantic.geometries import Polygon
+from rio_tiler.io import BaseReader
+from rio_tiler.models import BandStatistics, Bounds, Info
+from rio_tiler.utils import get_array_statistics
+from morecantile import TileMatrixSet
+from titiler.core.resources.enums import ImageType, MediaType
+from titiler.core.utils import Timer
+
+from starlette.requests import Request
+from starlette.templating import Jinja2Templates
+
+try:
+    from importlib.resources import files as resources_files  # type: ignore
+except ImportError:
+    # Try backported to PY<39 `importlib_resources`.
+    from importlib_resources import files as resources_files  # type: ignore
+
+
+# TODO: mypy fails in python 3.9, we need to find a proper way to do this
+templates = Jinja2Templates(directory=str(resources_files(__package__) / "templates"))  # type: ignore
+
+def call_with_read(func, reader, env, src_path, reader_params, *args, **kwargs):
+    with rasterio.Env(**env):
+        with reader(src_path, **reader_params) as src_dst:
+            return func(src_dst, *args, **kwargs)
+
+def info_geojson(src_dst: BaseReader, info_params={}) -> Feature:
+    """Return dataset's basic info as a GeoJSON feature."""
+    return Feature(
+        geometry=Polygon.from_bounds(*src_dst.geographic_bounds),
+        properties=src_dst.info(**info_params),
+    )
+
+def info_geojson_multi(src_dst: BaseReader, asset_params) -> Feature:
+    """Return dataset's basic info as a GeoJSON feature."""
+    return Feature(
+        geometry=Polygon.from_bounds(*src_dst.geographic_bounds),
+        properties={
+            asset: asset_info
+            for asset, asset_info in src_dst.info(
+                **asset_params
+            ).items()
+        },
+    )
+
+def info(src_dst: BaseReader, info_params={}) -> Info:
+    """Return dataset's basic info."""
+    return src_dst.info(**info_params)
+
+def assets(src_dst: BaseReader) -> Info:
+    """Return a list of supported assets."""
+    return src_dst.assets
+
+def bands(src_dst: BaseReader) -> Info:
+    """Return a list of supported bands."""
+    return src_dst.bands
+
+def bounds(src_dst: BaseReader) -> Bounds:
+    """Return the bounds of the COG."""
+    return {"bounds": src_dst.geographic_bounds}
+
+def statistics(src_dst: BaseReader, layer_params, image_params, dataset_params, stats_params, histogram_params, asset_params={}, band_params={}) -> Dict[str, BandStatistics]:
+    """Get Dataset statistics."""
+    return src_dst.statistics(
+        **asset_params,
+        **layer_params,
+        **image_params,
+        **dataset_params,
+        **stats_params,
+        hist_options={**histogram_params},
+    )
+
+def merged_statistics(src_dst: BaseReader, layer_params, image_params, dataset_params, stats_params, histogram_params) -> Dict[str, BandStatistics]:
+    """Merged assets statistics."""
+    # Default to all available assets
+    if not layer_params.assets and not layer_params.expression:
+        layer_params.assets = src_dst.assets
+
+    return src_dst.merged_statistics(
+        **layer_params,
+        **image_params,
+        **dataset_params,
+        **stats_params,
+        hist_options={**histogram_params},
+    )
+
+def geojson_statistics(src_dst: BaseReader, geojson: Union[FeatureCollection, Feature], layer_params, image_params, dataset_params, stats_params, histogram_params, multi_assets: bool=False, multi_bands: bool=False):
+    """Get Statistics from a geojson feature or featureCollection."""
+    # Default to all available assets
+    if multi_assets and not layer_params.assets and not layer_params.expression:
+        layer_params.assets = src_dst.assets
+
+    # Default to all available bands
+    if multi_bands and not layer_params.bands and not layer_params.expression:
+        layer_params.bands = src_dst.bands
+
+    # TODO: stream features for FeatureCollection
+    if isinstance(geojson, FeatureCollection):
+        for feature in geojson:
+            data = src_dst.feature(
+                feature.dict(exclude_none=True),
+                **layer_params,
+                **image_params,
+                **dataset_params,
+            )
+            stats = get_array_statistics(
+                data.as_masked(),
+                **stats_params,
+                **histogram_params,
+            )
+
+        feature.properties = feature.properties or {}
+        feature.properties.update(
+            {
+                # NOTE: because we use `src_dst.feature` the statistics will be in form of
+                # `Dict[str, BandStatistics]` and not `Dict[str, Dict[str, BandStatistics]]`
+                "statistics": {
+                    f"{data.band_names[ix]}": BandStatistics(
+                        **stats[ix]
+                    )
+                    for ix in range(len(stats))
+                }
+            }
+        )
+
+    else:  # simple feature
+        data = src_dst.feature(
+            geojson.dict(exclude_none=True),
+            **layer_params,
+            **image_params,
+            **dataset_params,
+        )
+        stats = get_array_statistics(
+            data.as_masked(),
+            **stats_params,
+            **histogram_params,
+        )
+
+        geojson.properties = geojson.properties or {}
+        geojson.properties.update(
+            {
+                "statistics": {
+                    f"{data.band_names[ix]}": BandStatistics(
+                        **stats[ix]
+                    )
+                    for ix in range(len(stats))
+                }
+            }
+        )
+
+    return geojson
+
+def tile(
+    reader: BaseReader,
+    z: int,
+    x: int,
+    y: int,
+    tms: TileMatrixSet,
+    scale: int,
+    format: ImageType,
+    src_path,
+    layer_params,
+    dataset_params,
+    postprocess_params,
+    colormap,
+    render_params,
+    tile_buffer: Optional[float],
+    reader_params,
+    env,
+):
+    """Create map tile from a dataset."""
+    timings = []
+
+    tilesize = scale * 256
+
+    with Timer() as t:
+        with rasterio.Env(**env):
+            with reader(src_path, tms=tms, **reader_params) as src_dst:
+                data = src_dst.tile(
+                    x,
+                    y,
+                    z,
+                    tilesize=tilesize,
+                    tile_buffer=tile_buffer,
+                    **layer_params,
+                    **dataset_params,
+                )
+                dst_colormap = getattr(src_dst, "colormap", None)
+    timings.append(("dataread", round(t.elapsed * 1000, 2)))
+
+    if not format:
+        format = ImageType.jpeg if data.mask.all() else ImageType.png
+
+    with Timer() as t:
+        image = data.post_process(**postprocess_params)
+    timings.append(("postprocess", round(t.elapsed * 1000, 2)))
+
+    with Timer() as t:
+        content = image.render(
+            img_format=format.driver,
+            colormap=colormap or dst_colormap,
+            **format.profile,
+            **render_params,
+        )
+    timings.append(("format", round(t.elapsed * 1000, 2)))
+
+    return content, timings
+
+def tilejson(
+    src_dst: BaseReader,
+    tiles_url: str,
+    minzoom: Optional[int],
+    maxzoom: Optional[int],
+) -> Dict:
+    """Return TileJSON document for a dataset."""
+    return {
+        "bounds": src_dst.geographic_bounds,
+        "minzoom": minzoom if minzoom is not None else src_dst.minzoom,
+        "maxzoom": maxzoom if maxzoom is not None else src_dst.maxzoom,
+        "tiles": [tiles_url],
+    }
+
+def wmts(
+    request: Request,
+    reader: BaseReader,
+    tile_format: ImageType,
+    tms: TileMatrixSet,
+    tiles_url: str,
+    src_path,
+    reader_params,
+    env,
+):
+    """Returns a WMTS xml document."""
+    with rasterio.Env(**env):
+        with reader(src_path, tms=tms, **reader_params) as src_dst:
+            bounds = src_dst.geographic_bounds
+            minzoom = minzoom if minzoom is not None else src_dst.minzoom
+            maxzoom = maxzoom if maxzoom is not None else src_dst.maxzoom
+
+    tileMatrix = []
+    for zoom in range(minzoom, maxzoom + 1):
+        matrix = tms.matrix(zoom)
+        tm = f"""
+                <TileMatrix>
+                    <ows:Identifier>{matrix.identifier}</ows:Identifier>
+                    <ScaleDenominator>{matrix.scaleDenominator}</ScaleDenominator>
+                    <TopLeftCorner>{matrix.topLeftCorner[0]} {matrix.topLeftCorner[1]}</TopLeftCorner>
+                    <TileWidth>{matrix.tileWidth}</TileWidth>
+                    <TileHeight>{matrix.tileHeight}</TileHeight>
+                    <MatrixWidth>{matrix.matrixWidth}</MatrixWidth>
+                    <MatrixHeight>{matrix.matrixHeight}</MatrixHeight>
+                </TileMatrix>"""
+        tileMatrix.append(tm)
+
+    return templates.TemplateResponse(
+        "wmts.xml",
+        {
+            "request": request,
+            "tiles_endpoint": tiles_url,
+            "bounds": bounds,
+            "tileMatrix": tileMatrix,
+            "tms": tms,
+            "title": "Cloud Optimized GeoTIFF",
+            "layer_name": "cogeo",
+            "media_type": tile_format.mediatype,
+        },
+        media_type=MediaType.xml.value,
+    )
+
+def point(src_dst: BaseReader, lon: float, lat: float, layer_params, dataset_params):
+    """Get Point value for a dataset."""
+    values = src_dst.point(
+        lon,
+        lat,
+        **layer_params,
+        **dataset_params,
+    )
+    return {"coordinates": [lon, lat], "values": values}
+
+
+def preview(
+    reader: BaseReader,
+    format: ImageType,
+    src_path,
+    layer_params,
+    dataset_params,
+    img_params,
+    postprocess_params,
+    colormap,
+    render_params,
+    reader_params,
+    env,
+):
+    """Create preview of a dataset."""
+    timings = []
+
+    with Timer() as t:
+        with rasterio.Env(**env):
+            with reader(src_path, **reader_params) as src_dst:
+                data = src_dst.preview(
+                    **layer_params,
+                    **img_params,
+                    **dataset_params,
+                )
+                dst_colormap = getattr(src_dst, "colormap", None)
+    timings.append(("dataread", round(t.elapsed * 1000, 2)))
+
+    if not format:
+        format = ImageType.jpeg if data.mask.all() else ImageType.png
+
+    with Timer() as t:
+        image = data.post_process(**postprocess_params)
+    timings.append(("postprocess", round(t.elapsed * 1000, 2)))
+
+    with Timer() as t:
+        content = image.render(
+            img_format=format.driver,
+            colormap=colormap or dst_colormap,
+            **format.profile,
+            **render_params,
+        )
+    timings.append(("format", round(t.elapsed * 1000, 2)))
+
+    return timings, content
+
+def part(
+    minx: float,
+    miny: float,
+    maxx: float,
+    maxy: float,
+    reader: BaseReader,
+    format: ImageType,
+    src_path,
+    layer_params,
+    dataset_params,
+    image_params,
+    postprocess_params,
+    colormap,
+    render_params,
+    reader_params,
+    env,
+):
+    timings = []
+
+    with Timer() as t:
+        with rasterio.Env(**env):
+            with reader(src_path, **reader_params) as src_dst:
+                data = src_dst.part(
+                    [minx, miny, maxx, maxy],
+                    **layer_params,
+                    **image_params,
+                    **dataset_params,
+                )
+                dst_colormap = getattr(src_dst, "colormap", None)
+    timings.append(("dataread", round(t.elapsed * 1000, 2)))
+
+    with Timer() as t:
+        image = data.post_process(**postprocess_params)
+    timings.append(("postprocess", round(t.elapsed * 1000, 2)))
+
+    with Timer() as t:
+        content = image.render(
+            img_format=format.driver,
+            colormap=colormap or dst_colormap,
+            **format.profile,
+            **render_params,
+        )
+    timings.append(("format", round(t.elapsed * 1000, 2)))
+
+    return timings, content
+
+def geojson_crop(
+    geojson: Feature,
+    reader: BaseReader,
+    format: ImageType,
+    src_path,
+    layer_params,
+    dataset_params,
+    image_params,
+    postprocess_params,
+    colormap,
+    render_params,
+    reader_params,
+    env,
+):
+    """Create image from a geojson feature."""
+    timings = []
+    headers: Dict[str, str] = {}
+
+    with Timer() as t:
+        with rasterio.Env(**env):
+            with reader(src_path, **reader_params) as src_dst:
+                data = src_dst.feature(
+                    geojson.dict(exclude_none=True),
+                    **layer_params,
+                    **image_params,
+                    **dataset_params,
+                )
+                dst_colormap = getattr(src_dst, "colormap", None)
+    timings.append(("dataread", round(t.elapsed * 1000, 2)))
+
+    with Timer() as t:
+        image = data.post_process(**postprocess_params)
+    timings.append(("postprocess", round(t.elapsed * 1000, 2)))
+
+    if not format:
+        format = ImageType.jpeg if data.mask.all() else ImageType.png
+
+    with Timer() as t:
+        content = image.render(
+            img_format=format.driver,
+            colormap=colormap or dst_colormap,
+            **format.profile,
+            **render_params,
+        )
+    timings.append(("format", round(t.elapsed * 1000, 2)))
+    return timings, content


### PR DESCRIPTION
## What I am changing
I moved the GIS manipulation logic into a separate module. This allows for importing and using the data manipulation logic in different contexts. Hopefully, I haven't broken anything in the process.

## How I did it
I refactored the factory.py module and moved the data manipulation logic into a separate module (gis_tools.py).
I also modified some of the functions slightly in order to regroup similar code contained in the different subclasses of the TilerFactory (for example, using multi_bands=True or multi_assets=True and calling the same geojson_statistics function).

## How you can test it
By verifying nothing is broken in the various API routes.

## Related Issues
I initially tried to implement a custom /x/y/z route but had to copy the tile fetch logic in my code: https://github.com/developmentseed/titiler/discussions/531. With this PR, I should be able to import the gis_tools.tile function directly and use it in my custom route which should prevent some of the potential maintenance issues in the future. 
