### PR TITLE
Map viewer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 * update FastAPI requirement to `>=0.87`
 * update rio-tiler requirement to `>=4.0,<4.1`
 * remove `rescale` and `color_formula` from the `post_process` dependency
+* add `/map` endpoint in TilerFactory to display tiles given query-parameters
 
 **breaking changes**
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,6 @@
 * update FastAPI requirement to `>=0.87`
 * update rio-tiler requirement to `>=4.0,<4.1`
 * remove `rescale` and `color_formula` from the `post_process` dependency
-* add `/map` endpoint in TilerFactory to display tiles given query-parameters
 
 **breaking changes**
 
@@ -18,6 +17,7 @@
 * remove `asset_expression` (except in `/asset_statistics` endpoint) (see https://cogeotiff.github.io/rio-tiler/v4_migration/#multibasereader-expressions)
 * update Point output model to include `band_names`
 * histogram and info band names are prefixed with `b` (e.g `b1`) (ref: https://cogeotiff.github.io/rio-tiler/v4_migration/#band-names)
+* add `/map` endpoint in TilerFactory to display tiles given query-parameters
 
 ### titiler.mosaic
 

--- a/docs/src/advanced/tiler_factories.md
+++ b/docs/src/advanced/tiler_factories.md
@@ -20,13 +20,15 @@ app.include_router(cog.router, tags=["Cloud Optimized GeoTIFF"])
 | `GET`  | `/info.geojson`                                                 | GeoJSON ([InfoGeoJSON][info_geojson_model]) | return dataset's basic info as a GeoJSON feature
 | `GET`  | `/statistics`                                                   | JSON ([Statistics][stats_model])            | return dataset's statistics
 | `POST` | `/statistics`                                                   | GeoJSON ([Statistics][stats_geojson_model]) | return dataset's statistics for a GeoJSON
-| `GET`  | `/tiles/[{TileMatrixSetId}]/{z}/{x}/{y}[@{scale}x][.{format}]`  | image/bin                                   | create a web map tile image from a dataset
-| `GET`  | `/[{TileMatrixSetId}]/tilejson.json`                            | JSON ([TileJSON][tilejson_model])           | return a Mapbox TileJSON document
-| `GET`  | `/{TileMatrixSetId}/WMTSCapabilities.xml`                       | XML                                         | return OGC WMTS Get Capabilities
+| `GET`  | `/tiles[/{TileMatrixSetId}]/{z}/{x}/{y}[@{scale}x][.{format}]`  | image/bin                                   | create a web map tile image from a dataset
+| `GET`  | `[/{TileMatrixSetId}]/tilejson.json`                            | JSON ([TileJSON][tilejson_model])           | return a Mapbox TileJSON document
+| `GET`  | `[/{TileMatrixSetId}]/WMTSCapabilities.xml`                     | XML                                         | return OGC WMTS Get Capabilities
 | `GET`  | `/point/{lon},{lat}`                                            | JSON ([Point][point_model])                 | return pixel values from a dataset
 | `GET`  | `/preview[.{format}]`                                           | image/bin                                   | create a preview image from a dataset (**Optional**)
 | `GET`  | `/crop/{minx},{miny},{maxx},{maxy}[/{width}x{height}].{format}` | image/bin                                   | create an image from part of a dataset (**Optional**)
 | `POST` | `/crop[/{width}x{height}][.{format}]`                           | image/bin                                   | create an image from a GeoJSON feature (**Optional**)
+| `GET`  | `/map`                                                          | HTML                                        | return a simple map viewer
+| `GET`  | `[/{TileMatrixSetId}]/map`                                      | HTML                                        | return a simple map viewer
 
 ### `titiler.core.factory.MultiBaseTilerFactory`
 
@@ -52,13 +54,14 @@ app.include_router(cog.router, tags=["STAC"])
 | `GET`  | `/asset_statistics`                                             | JSON ([Statistics][multistats_model])            | return per asset statistics
 | `GET`  | `/statistics`                                                   | JSON ([Statistics][stats_model])                 | return assets statistics (merged)
 | `POST` | `/statistics`                                                   | GeoJSON ([Statistics][multistats_geojson_model]) | return assets statistics for a GeoJSON (merged)
-| `GET`  | `/tiles/[{TileMatrixSetId}]/{z}/{x}/{y}[@{scale}x][.{format}]`  | image/bin                                        | create a web map tile image from assets
+| `GET`  | `/tiles[/{TileMatrixSetId}]/{z}/{x}/{y}[@{scale}x][.{format}]`  | image/bin                                        | create a web map tile image from assets
 | `GET`  | `/[{TileMatrixSetId}]/tilejson.json`                            | JSON ([TileJSON][tilejson_model])                | return a Mapbox TileJSON document
 | `GET`  | `/{TileMatrixSetId}/WMTSCapabilities.xml`                       | XML                                              | return OGC WMTS Get Capabilities
 | `GET`  | `/point/{lon},{lat}`                                            | JSON ([Point][multipoint_model])                 | return pixel values from assets
 | `GET`  | `/preview[.{format}]`                                           | image/bin                                        | create a preview image from assets (**Optional**)
 | `GET`  | `/crop/{minx},{miny},{maxx},{maxy}[/{width}x{height}].{format}` | image/bin                                        | create an image from part of assets (**Optional**)
 | `POST` | `/crop[/{width}x{height}][.{format}]`                           | image/bin                                        | create an image from a geojson feature intersecting assets (**Optional**)
+| `GET`  | `[/{TileMatrixSetId}]/map`                                      | HTML                                             | return a simple map viewer
 
 ### `titiler.core.factory.MultiBandTilerFactory`
 
@@ -89,14 +92,14 @@ app.include_router(cog.router, tags=["Landsat"])
 | `GET`  | `/info.geojson`                                                 | GeoJSON ([InfoGeoJSON][info_geojson_model])  | return basic info for a dataset as a GeoJSON feature
 | `GET`  | `/statistics`                                                   | JSON ([Statistics][stats_model])             | return info and statistics for a dataset
 | `POST` | `/statistics`                                                   | GeoJSON ([Statistics][stats_geojson_model])  | return info and statistics for a dataset
-| `GET`  | `/tiles/[{TileMatrixSetId}]/{z}/{x}/{y}[@{scale}x][.{format}]`  | image/bin                                    | create a web map tile image from a dataset
+| `GET`  | `/tiles[/{TileMatrixSetId}]/{z}/{x}/{y}[@{scale}x][.{format}]`  | image/bin                                    | create a web map tile image from a dataset
 | `GET`  | `/[{TileMatrixSetId}]/tilejson.json`                            | JSON ([TileJSON][tilejson_model])            | return a Mapbox TileJSON document
 | `GET`  | `/{TileMatrixSetId}/WMTSCapabilities.xml`                       | XML                                          | return OGC WMTS Get Capabilities
 | `GET`  | `/point/{lon},{lat}`                                            | JSON ([Point][point_model])                  | return pixel value from a dataset
 | `GET`  | `/preview[.{format}]`                                           | image/bin                                    | create a preview image from a dataset
 | `GET`  | `/crop/{minx},{miny},{maxx},{maxy}[/{width}x{height}].{format}` | image/bin                                    | create an image from part of a dataset
 | `POST` | `/crop[/{width}x{height}][.{format}]`                           | image/bin                                    | create an image from a geojson feature
-
+| `GET`  | `[/{TileMatrixSetId}]/map`                                      | HTML                                         | return a simple map viewer
 
 ### `titiler.mosaic.factory.MosaicTilerFactory`
 
@@ -107,13 +110,14 @@ app.include_router(cog.router, tags=["Landsat"])
 | `GET`  | `/bounds`                                                       | JSON ([Bounds][bounds_model])                      | return mosaic's bounds
 | `GET`  | `/info`                                                         | JSON ([Info][mosaic_info_model])                   | return mosaic's basic info
 | `GET`  | `/info.geojson`                                                 | GeoJSON ([InfoGeoJSON][mosaic_geojson_info_model]) | return mosaic's basic info  as a GeoJSON feature
-| `GET`  | `/tiles/[{TileMatrixSetId}]/{z}/{x}/{y}[@{scale}x][.{format}]`  | image/bin                                          | create a web map tile image from a MosaicJSON
-| `GET`  | `/[{TileMatrixSetId}]/tilejson.json`                            | JSON ([TileJSON][tilejson_model])                  | return a Mapbox TileJSON document
-| `GET`  | `/{TileMatrixSetId}/WMTSCapabilities.xml`                       | XML                                                | return OGC WMTS Get Capabilities
+| `GET`  | `/tiles[/{TileMatrixSetId}]/{z}/{x}/{y}[@{scale}x][.{format}]`  | image/bin                                          | create a web map tile image from a MosaicJSON
+| `GET`  | `[/{TileMatrixSetId}]/tilejson.json`                            | JSON ([TileJSON][tilejson_model])                  | return a Mapbox TileJSON document
+| `GET`  | `[/{TileMatrixSetId}]/WMTSCapabilities.xml`                     | XML                                                | return OGC WMTS Get Capabilities
 | `GET`  | `/point/{lon},{lat}`                                            | JSON ([Point][mosaic_point])                       | return pixel value from a MosaicJSON dataset
 | `GET`  | `/{z}/{x}/{y}/assets`                                           | JSON                                               | return list of assets intersecting a XYZ tile
 | `GET`  | `/{lon},{lat}/assets`                                           | JSON                                               | return list of assets intersecting a point
 | `GET`  | `/{minx},{miny},{maxx},{maxy}/assets`                           | JSON                                               | return list of assets intersecting a bounding box
+| `GET`  | `[/{TileMatrixSetId}]/map`                                      | HTML                                               | return a simple map viewer
 
 
 !!! Important

--- a/docs/src/endpoints/cog.md
+++ b/docs/src/endpoints/cog.md
@@ -22,13 +22,14 @@ app.include_router(cog.router, prefix="/cog", tags=["Cloud Optimized GeoTIFF"])
 | `GET`  | `/cog/info.geojson`                                                 | GeoJSON   | return dataset's basic info as a GeoJSON feature
 | `GET`  | `/cog/statistics`                                                   | JSON      | return dataset's statistics
 | `POST` | `/cog/statistics`                                                   | GeoJSON   | return dataset's statistics for a GeoJSON
-| `GET`  | `/cog/tiles/[{TileMatrixSetId}]/{z}/{x}/{y}[@{scale}x][.{format}]`  | image/bin | create a web map tile image from a dataset
-| `GET`  | `/cog/[{TileMatrixSetId}]/tilejson.json`                            | JSON      | return a Mapbox TileJSON document
-| `GET`  | `/cog/{TileMatrixSetId}/WMTSCapabilities.xml`                       | XML       | return OGC WMTS Get Capabilities
+| `GET`  | `/cog/tiles[/{TileMatrixSetId}]/{z}/{x}/{y}[@{scale}x][.{format}]`  | image/bin | create a web map tile image from a dataset
+| `GET`  | `/cog[/{TileMatrixSetId}]/tilejson.json`                            | JSON      | return a Mapbox TileJSON document
+| `GET`  | `/cog[/{TileMatrixSetId}]/WMTSCapabilities.xml`                     | XML       | return OGC WMTS Get Capabilities
 | `GET`  | `/cog/point/{lon},{lat}`                                            | JSON      | return pixel values from a dataset
 | `GET`  | `/cog/preview[.{format}]`                                           | image/bin | create a preview image from a dataset
 | `GET`  | `/cog/crop/{minx},{miny},{maxx},{maxy}[/{width}x{height}].{format}` | image/bin | create an image from part of a dataset
 | `POST` | `/cog/crop[/{width}x{height}][].{format}]`                          | image/bin | create an image from a GeoJSON feature
+| `GET`  | `/cog[/{TileMatrixSetId}]/map`                                      | HTML      | simple map viewer
 | `GET`  | `/cog/validate`                                                     | JSON      | validate a COG and return dataset info (Not in `TilerFactory`)
 | `GET`  | `/cog/viewer`                                                       | HTML      | demo webpage (Not in `TilerFactory`)
 
@@ -36,7 +37,7 @@ app.include_router(cog.router, prefix="/cog", tags=["Cloud Optimized GeoTIFF"])
 
 ### Tiles
 
-`:endpoint:/cog/tiles/[{TileMatrixSetId}]/{z}/{x}/{y}[@{scale}x][.{format}]`
+`:endpoint:/cog/tiles[/{TileMatrixSetId}]/{z}/{x}/{y}[@{scale}x][.{format}]`
 
 - PathParams:
     - **TileMatrixSetId** (str): TileMatrixSet name, default is `WebMercatorQuad`. **Optional**
@@ -102,6 +103,7 @@ Example:
 ### Crop / Part
 
 `:endpoint:/cog/crop/{minx},{miny},{maxx},{maxy}.{format}`
+
 `:endpoint:/cog/crop/{minx},{miny},{maxx},{maxy}/{width}x{height}.{format}`
 
 - PathParams:
@@ -190,7 +192,7 @@ Example:
 
 ### TilesJSON
 
-`:endpoint:/cog/[{TileMatrixSetId}]/tilejson.json` tileJSON document
+`:endpoint:/cog[/{TileMatrixSetId}]/tilejson.json` tileJSON document
 
 - PathParams:
     - **TileMatrixSetId**: TileMatrixSet name, default is `WebMercatorQuad`. **Optional**
@@ -218,6 +220,39 @@ Example:
 - `https://myendpoint/cog/tilejson.json?url=https://somewhere.com/mycog.tif`
 - `https://myendpoint/cog/tilejson.json?url=https://somewhere.com/mycog.tif&tile_format=png`
 - `https://myendpoint/cog/WorldCRS84Quad/tilejson.json?url=https://somewhere.com/mycog.tif&tile_scale=2&bidx=1,2,3`
+
+
+### Map
+
+`:endpoint:/cog[/{TileMatrixSetId}]/map` Simple viewer
+
+- PathParams:
+    - **TileMatrixSetId**: TileMatrixSet name (only `WebMercatorQuad` is supported). **Optional**
+
+- QueryParams:
+    - **url** (str): Cloud Optimized GeoTIFF URL. **Required**
+    - **tile_format** (str): Output image format, default is set to None and will be either JPEG or PNG depending on masked value.
+    - **tile_scale** (int): Tile size scale, default is set to 1 (256x256).
+    - **minzoom** (int): Overwrite default minzoom.
+    - **maxzoom** (int): Overwrite default maxzoom.
+    - **bidx** (array[int]): Dataset band indexes (e.g `bidx=1`, `bidx=1&bidx=2&bidx=3`).
+    - **expression** (str): rio-tiler's band math expression (e.g B1/B2).
+    - **nodata** (str, int, float): Overwrite internal Nodata value.
+    - **unscale** (bool): Apply dataset internal Scale/Offset.
+    - **resampling** (str): rasterio resampling method. Default is `nearest`.
+    - **rescale** (array[str]): Comma (',') delimited Min,Max range (e.g `rescale=0,1000`, `rescale=0,1000&rescale=0,3000&rescale=0,2000`).
+    - **color_formula** (str): rio-color formula.
+    - **colormap** (str): JSON encoded custom Colormap.
+    - **colormap_name** (str): rio-tiler color map name.
+    - **return_mask** (bool): Add mask to the output data. Default is True.
+    - **buffer** (float): Add buffer on each side of the tile (e.g 0.5 = 257x257, 1.0 = 258x258).
+
+Example:
+
+- `https://myendpoint/cog/map?url=https://somewhere.com/mycog.tif`
+- `https://myendpoint/cog/map?url=https://somewhere.com/mycog.tif&tile_format=png`
+- `https://myendpoint/cog/WebMercatorQuad/map?url=https://somewhere.com/mycog.tif&tile_scale=2&bidx=1,2,3`
+
 
 ### Bounds
 

--- a/docs/src/endpoints/mosaic.md
+++ b/docs/src/endpoints/mosaic.md
@@ -13,13 +13,14 @@ Read Mosaic Info/Metadata and create Web map Tiles from a multiple COG. The `mos
 | `GET`  | `/mosaicjson/bounds`                                                       | JSON      | return mosaic's bounds
 | `GET`  | `/mosaicjson/info`                                                         | JSON      | return mosaic's basic info
 | `GET`  | `/mosaicjson/info.geojson`                                                 | GeoJSON   | return mosaic's basic info as a GeoJSON feature
-| `GET`  | `/mosaicjson/tiles/[{TileMatrixSetId}]/{z}/{x}/{y}[@{scale}x][.{format}]`  | image/bin | create a web map tile image from mosaic assets
-| `GET`  | `/mosaicjson/[{TileMatrixSetId}]/tilejson.json`                            | JSON      | return a Mapbox TileJSON document
-| `GET`  | `/mosaicjson/{TileMatrixSetId}/WMTSCapabilities.xml`                       | XML       | return OGC WMTS Get Capabilities
+| `GET`  | `/mosaicjson/tiles[/{TileMatrixSetId}]/{z}/{x}/{y}[@{scale}x][.{format}]`  | image/bin | create a web map tile image from mosaic assets
+| `GET`  | `/mosaicjson[/{TileMatrixSetId}]/tilejson.json`                            | JSON      | return a Mapbox TileJSON document
+| `GET`  | `/mosaicjson[/{TileMatrixSetId}]/WMTSCapabilities.xml`                       | XML       | return OGC WMTS Get Capabilities
 | `GET`  | `/mosaicjson/point/{lon},{lat}`                                            | JSON      | return pixel value from a mosaic assets
 | `GET`  | `/mosaicjson/{z}/{x}/{y}/assets`                                           | JSON      | return list of assets intersecting a XYZ tile
 | `GET`  | `/mosaicjson/{lon},{lat}/assets`                                           | JSON      | return list of assets intersecting a point
 | `GET`  | `/mosaicjson/{minx},{miny},{maxx},{maxy}/assets`                           | JSON      | return list of assets intersecting a bounding box
+| `GET`  | `/mosaicjson[/{TileMatrixSetId}]/map`                                      | HTML      | simple map viewer
 
 ## Description
 

--- a/docs/src/endpoints/stac.md
+++ b/docs/src/endpoints/stac.md
@@ -24,20 +24,21 @@ app.include_router(stac.router, prefix="/stac", tags=["SpatioTemporal Asset Cata
 | `GET`  | `/stac/asset_statistics`                                             | JSON      | return per asset statistics
 | `GET`  | `/stac/statistics`                                                   | JSON      | return asset's statistics
 | `POST` | `/stac/statistics`                                                   | GeoJSON   | return asset's statistics for a GeoJSON
-| `GET`  | `/stac/tiles/[{TileMatrixSetId}]/{z}/{x}/{y}[@{scale}x][.{format}]`  | image/bin | create a web map tile image from assets
-| `GET`  | `/stac/[{TileMatrixSetId}]/tilejson.json`                            | JSON      | return a Mapbox TileJSON document
-| `GET`  | `/stac/{TileMatrixSetId}/WMTSCapabilities.xml`                       | XML       | return OGC WMTS Get Capabilities
+| `GET`  | `/stac/tiles[/{TileMatrixSetId}]/{z}/{x}/{y}[@{scale}x][.{format}]`  | image/bin | create a web map tile image from assets
+| `GET`  | `/stac[/{TileMatrixSetId}]/tilejson.json`                            | JSON      | return a Mapbox TileJSON document
+| `GET`  | `/stac[/{TileMatrixSetId}]/WMTSCapabilities.xml`                       | XML       | return OGC WMTS Get Capabilities
 | `GET`  | `/stac/point/{lon},{lat}`                                            | JSON      | return pixel value from assets
 | `GET`  | `/stac/preview[.{format}]`                                           | image/bin | create a preview image from assets
 | `GET`  | `/stac/crop/{minx},{miny},{maxx},{maxy}[/{width}x{height}].{format}` | image/bin | create an image from part of assets
 | `POST` | `/stac/crop[/{width}x{height}][].{format}]`                          | image/bin | create an image from a geojson covering the assets
+| `GET`  | `/stac[/{TileMatrixSetId}]/map`                                      | HTML      | simple map viewer
 | `GET`  | `/stac/viewer`                                                       | HTML      | demo webpage (Not in `MultiBaseTilerFactory`)
 
 ## Description
 
 ### Tiles
 
-`:endpoint:/stac/tiles/[{TileMatrixSetId}]/{z}/{x}/{y}[@{scale}x][.{format}]`
+`:endpoint:/stac/tiles[/{TileMatrixSetId}]/{z}/{x}/{y}[@{scale}x][.{format}]`
 
 - PathParams:
     - **TileMatrixSetId** (str): TileMatrixSet name, default is `WebMercatorQuad`. **Optional**
@@ -112,6 +113,7 @@ Example:
 ### Crop / Part
 
 `:endpoint:/stac/crop/{minx},{miny},{maxx},{maxy}.{format}`
+
 `:endpoint:/stac/crop/{minx},{miny},{maxx},{maxy}/{width}x{height}.{format}`
 
 - PathParams:
@@ -209,7 +211,7 @@ Example:
 
 ### TilesJSON
 
-`:endpoint:/stac/[{TileMatrixSetId}]/tilejson.json` tileJSON document
+`:endpoint:/stac[/{TileMatrixSetId}]/tilejson.json` tileJSON document
 
 - PathParams:
     - **TileMatrixSetId**: TileMatrixSet name, default is `WebMercatorQuad`.
@@ -242,6 +244,43 @@ Example:
 - `https://myendpoint/stac/tilejson.json?url=https://somewhere.com/item.json&assets=B01`
 - `https://myendpoint/stac/tilejson.json?url=https://somewhere.com/item.json&assets=B01&tile_format=png`
 - `https://myendpoint/stac/WorldCRS84Quad/tilejson.json?url=https://somewhere.com/item.json&tile_scale=2&expression=B01/B02`
+
+### Map
+
+`:endpoint:/stac[/{TileMatrixSetId}]/map`  Simple viewer
+
+- PathParams:
+    - **TileMatrixSetId**: TileMatrixSet name (only `WebMercatorQuad` is supported). **Optional**
+
+- QueryParams:
+    - **url** (str): STAC Item URL. **Required**
+    - **assets** (array[str]): asset names.
+    - **expression** (str): rio-tiler's math expression with asset names (e.g `Asset1/Asset2`).
+    - **asset_bidx** (array[str]): Per asset band math expression (e.g `Asset1|1;2;3`).
+    - **asset_expression** (array[str]): Per asset band math expression (e.g `Asset1|b1\*b2`).
+    - **tile_format** (str): Output image format, default is set to None and will be either JPEG or PNG depending on masked value.
+    - **tile_scale** (int): Tile size scale, default is set to 1 (256x256).
+    - **minzoom** (int): Overwrite default minzoom.
+    - **maxzoom** (int): Overwrite default maxzoom.
+    - **nodata** (str, int, float): Overwrite internal Nodata value.
+    - **unscale** (bool): Apply dataset internal Scale/Offset.
+    - **resampling** (str): rasterio resampling method. Default is `nearest`.
+    - **rescale** (array[str]): Comma (',') delimited Min,Max range (e.g `rescale=0,1000`, `rescale=0,1000&rescale=0,3000&rescale=0,2000`).
+    - **color_formula** (str): rio-color formula.
+    - **colormap** (str): JSON encoded custom Colormap.
+    - **colormap_name** (str): rio-tiler color map name.
+    - **return_mask** (bool): Add mask to the output data. Default is True.
+    - **buffer** (float): Add buffer on each side of the tile (e.g 0.5 = 257x257, 1.0 = 258x258).
+
+!!! important
+    **assets** OR **expression** is required
+
+Example:
+
+- `https://myendpoint/stac/tilejson.json?url=https://somewhere.com/item.json&assets=B01`
+- `https://myendpoint/stac/tilejson.json?url=https://somewhere.com/item.json&assets=B01&tile_format=png`
+- `https://myendpoint/stac/WorldCRS84Quad/tilejson.json?url=https://somewhere.com/item.json&tile_scale=2&expression=B01/B02`
+
 
 ### Bounds
 

--- a/src/titiler/core/tests/test_factories.py
+++ b/src/titiler/core/tests/test_factories.py
@@ -37,7 +37,7 @@ NB_DEFAULT_TMS = len(morecantile.tms.list())
 def test_TilerFactory():
     """Test TilerFactory class."""
     cog = TilerFactory()
-    assert len(cog.router.routes) == 25
+    assert len(cog.router.routes) == 26
     assert cog.tms_dependency == TMSParams
 
     cog = TilerFactory(router_prefix="something", tms_dependency=WebMercatorTMSParams)
@@ -53,7 +53,7 @@ def test_TilerFactory():
     response = client.get(f"/something/NZTM2000/tilejson.json?url={DATA_DIR}/cog.tif")
     assert response.status_code == 422
 
-    cog = TilerFactory(add_preview=False, add_part=False)
+    cog = TilerFactory(add_preview=False, add_part=False, add_viewer=False)
     assert len(cog.router.routes) == 18
 
     app = FastAPI()
@@ -603,7 +603,7 @@ def test_MultiBaseTilerFactory(rio):
     rio.open = mock_rasterio_open
 
     stac = MultiBaseTilerFactory(reader=STACReader)
-    assert len(stac.router.routes) == 27
+    assert len(stac.router.routes) == 28
 
     app = FastAPI()
     app.include_router(stac.router)
@@ -911,7 +911,7 @@ def test_MultiBandTilerFactory():
     bands = MultiBandTilerFactory(
         reader=BandFileReader, path_dependency=CustomPathParams
     )
-    assert len(bands.router.routes) == 26
+    assert len(bands.router.routes) == 27
 
     app = FastAPI()
     app.include_router(bands.router)
@@ -1236,7 +1236,7 @@ def test_TilerFactory_WithDependencies():
         ],
         router_prefix="something",
     )
-    assert len(cog.router.routes) == 25
+    assert len(cog.router.routes) == 26
     assert cog.tms_dependency == TMSParams
 
     app = FastAPI()

--- a/src/titiler/core/tests/test_factories.py
+++ b/src/titiler/core/tests/test_factories.py
@@ -23,7 +23,6 @@ from titiler.core.factory import (
     TilerFactory,
     TMSFactory,
 )
-from titiler.core.resources.enums import OptionalHeader
 
 from .conftest import DATA_DIR, mock_rasterio_open, parse_img
 
@@ -37,7 +36,7 @@ NB_DEFAULT_TMS = len(morecantile.tms.list())
 def test_TilerFactory():
     """Test TilerFactory class."""
     cog = TilerFactory()
-    assert len(cog.router.routes) == 26
+    assert len(cog.router.routes) == 27
     assert cog.tms_dependency == TMSParams
 
     cog = TilerFactory(router_prefix="something", tms_dependency=WebMercatorTMSParams)
@@ -57,7 +56,7 @@ def test_TilerFactory():
     assert len(cog.router.routes) == 18
 
     app = FastAPI()
-    cog = TilerFactory(optional_headers=[OptionalHeader.server_timing])
+    cog = TilerFactory()
     app.include_router(cog.router)
 
     add_exception_handlers(app, DEFAULT_STATUS_CODES)
@@ -603,7 +602,7 @@ def test_MultiBaseTilerFactory(rio):
     rio.open = mock_rasterio_open
 
     stac = MultiBaseTilerFactory(reader=STACReader)
-    assert len(stac.router.routes) == 28
+    assert len(stac.router.routes) == 29
 
     app = FastAPI()
     app.include_router(stac.router)
@@ -911,7 +910,7 @@ def test_MultiBandTilerFactory():
     bands = MultiBandTilerFactory(
         reader=BandFileReader, path_dependency=CustomPathParams
     )
-    assert len(bands.router.routes) == 27
+    assert len(bands.router.routes) == 28
 
     app = FastAPI()
     app.include_router(bands.router)
@@ -1236,7 +1235,7 @@ def test_TilerFactory_WithDependencies():
         ],
         router_prefix="something",
     )
-    assert len(cog.router.routes) == 26
+    assert len(cog.router.routes) == 27
     assert cog.tms_dependency == TMSParams
 
     app = FastAPI()

--- a/src/titiler/core/titiler/core/factory.py
+++ b/src/titiler/core/titiler/core/factory.py
@@ -34,6 +34,7 @@ from titiler.core.dependencies import (
     StatisticsParams,
     TileMatrixSetName,
     TMSParams,
+    WebMercatorTMSParams,
 )
 from titiler.core.models.mapbox import TileJSON
 from titiler.core.models.OGC import TileMatrixSetList
@@ -602,10 +603,12 @@ class TilerFactory(BaseTilerFactory):
     def map_viewer(self):  # noqa: C901
         """Register /map endpoint."""
 
+        @self.router.get("/{TileMatrixSetId}/map", response_class=HTMLResponse)
         @self.router.get("/map", response_class=HTMLResponse)
         def map_viewer(
             request: Request,
             src_path=Depends(self.path_dependency),
+            tms: TileMatrixSet = Depends(WebMercatorTMSParams),  # noqa
             tile_format: Optional[ImageType] = Query(
                 None, description="Output image type. Default is auto."
             ),  # noqa

--- a/src/titiler/core/titiler/core/templates/index.html
+++ b/src/titiler/core/titiler/core/templates/index.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+    <html>
+    <head>
+        <meta charset='utf-8' />
+        <title>TiTiler Map Viewer</title>
+        <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
+        <script src='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.js'></script>
+        <link href='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.css' rel='stylesheet' />
+
+        <style>
+            body { margin:0; padding:0; width:100%; height:100%;}
+            #map { position:absolute; top:0; bottom:0; width:100%; }
+            .zoom-info {
+                z-index: 10;
+                position: absolute;
+                bottom: 17px;
+                right: 0;
+                padding: 5px;
+                width: auto;
+                height: auto;
+                font-size: 12px;
+                color: #000;
+            }
+            @media(max-width: 767px) {
+              .maplibrectrl-attrib {
+                  font-size: 10px;
+              }
+            }
+        </style>
+    </head>
+    <body>
+
+    <div id='map'>
+      <div class="zoom-info"><span id="zoom"></span></div>
+    </div>
+
+    <script>
+
+var map = new maplibregl.Map({
+  container: 'map',
+  style: {
+    version: 8,
+    sources: {
+      'toner-lite': {
+        type: 'raster',
+        tiles: [
+          'https://stamen-tiles-a.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png',
+          'https://stamen-tiles-b.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png',
+          'https://stamen-tiles-c.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png',
+          'https://stamen-tiles-d.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png'
+        ],
+        tileSize: 256,
+        attribution:
+          'Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.'
+      }
+    },
+    layers: [
+      {
+        'id': 'basemap',
+        'type': 'raster',
+        'source': 'toner-lite',
+        'minzoom': 0,
+        'maxzoom': 14
+      }
+    ]
+  },
+  center: [0, 0],
+  zoom: 1
+})
+
+map.on('zoom', function (e) {
+  const z = (map.getZoom()).toString().slice(0, 6)
+  document.getElementById('zoom').textContent = z
+})
+
+const bboxPolygon = (bounds) => {
+    return {
+        'type': 'Feature',
+        'geometry': {
+            'type': 'Polygon',
+            'coordinates': [[
+                [bounds[0], bounds[1]],
+                [bounds[2], bounds[1]],
+                [bounds[2], bounds[3]],
+                [bounds[0], bounds[3]],
+                [bounds[0], bounds[1]]
+            ]]
+        },
+        'properties': {}
+    }
+}
+
+const addAOI = (bounds) => {
+  if (map.getLayer('aoi-polygon')) map.removeLayer('aoi-polygon')
+  if (map.getSource('aoi')) map.removeSource('aoi')
+  const geojson = {
+      "type": "FeatureCollection",
+      "features": [bboxPolygon(bounds)]
+  }
+
+  map.addSource('aoi', {
+    'type': 'geojson',
+    'data': geojson
+  })
+
+  map.addLayer({
+    id: 'aoi-polygon',
+    type: 'line',
+    source: 'aoi',
+    layout: {
+      'line-cap': 'round',
+      'line-join': 'round'
+    },
+    paint: {
+      'line-color': '#3bb2d0',
+      'line-width': 1
+    }
+  })
+  return
+}
+
+map.on('load', () => {
+
+  fetch('{{ tilejson_endpoint|safe }}')
+    .then(res => {
+      if (res.ok) return res.json()
+      throw new Error('Network response was not ok.')
+    })
+    .then(data => {
+      console.log(data)
+
+      let bounds = [...data.bounds]
+      // Bounds crossing dateline
+      if (bounds[0] > bounds[2]) {
+        bounds[0] = bounds[0] - 360
+      }
+      map.fitBounds(
+        [[bounds[0], bounds[1]], [bounds[2], bounds[3]]]
+      )
+      addAOI(bounds)
+
+      map.addSource(
+        'raster',
+        {
+          type: 'raster',
+          bounds: data.bounds,
+          minzoom: data.minzoom,
+          maxzoom: data.maxzoom,
+          tiles: data.tiles,
+        }
+      )
+
+      map.addLayer(
+        {
+          id: 'raster',
+          type: 'raster',
+          source: 'raster',
+        }
+      )
+
+    })
+    .catch(err => {
+      console.warn(err)
+    })
+})
+    </script>
+    </body>
+    </html>

--- a/src/titiler/mosaic/tests/test_factory.py
+++ b/src/titiler/mosaic/tests/test_factory.py
@@ -44,10 +44,10 @@ def tmpmosaic():
 def test_MosaicTilerFactory():
     """Test MosaicTilerFactory class."""
     mosaic = MosaicTilerFactory(
-        optional_headers=[OptionalHeader.server_timing, OptionalHeader.x_assets],
+        optional_headers=[OptionalHeader.x_assets],
         router_prefix="mosaic",
     )
-    assert len(mosaic.router.routes) == 22
+    assert len(mosaic.router.routes) == 24
     assert mosaic.tms_dependency == WebMercatorTMSParams
 
     app = FastAPI()

--- a/src/titiler/mosaic/titiler/mosaic/factory.py
+++ b/src/titiler/mosaic/titiler/mosaic/factory.py
@@ -32,7 +32,7 @@ from titiler.mosaic.resources.enums import PixelSelectionMethod
 from fastapi import Depends, Path, Query
 
 from starlette.requests import Request
-from starlette.responses import Response
+from starlette.responses import HTMLResponse, Response
 
 
 def PixelSelectionParams(
@@ -70,6 +70,9 @@ class MosaicTilerFactory(BaseTilerFactory):
 
     pixel_selection_dependency: Callable[..., MosaicMethodBase] = PixelSelectionParams
 
+    # Add/Remove some endpoints
+    add_viewer: bool = True
+
     def register_routes(self):
         """
         This Method register routes to the router.
@@ -89,6 +92,10 @@ class MosaicTilerFactory(BaseTilerFactory):
         self.point()
         self.validate()
         self.assets()
+
+        # Optional Routes
+        if self.add_viewer:
+            self.map_viewer()
 
     ############################################################################
     # /read
@@ -406,6 +413,64 @@ class MosaicTilerFactory(BaseTilerFactory):
                         "maxzoom": maxzoom if maxzoom is not None else src_dst.maxzoom,
                         "tiles": [tiles_url],
                     }
+
+    def map_viewer(self):  # noqa: C901
+        """Register /map endpoint."""
+
+        @self.router.get("/{TileMatrixSetId}/map", response_class=HTMLResponse)
+        @self.router.get("/map", response_class=HTMLResponse)
+        def map_viewer(
+            request: Request,
+            src_path=Depends(self.path_dependency),
+            tms: TileMatrixSet = Depends(WebMercatorTMSParams),  # noqa
+            tile_format: Optional[ImageType] = Query(
+                None, description="Output image type. Default is auto."
+            ),
+            tile_scale: int = Query(
+                1, gt=0, lt=4, description="Tile size scale. 1=256x256, 2=512x512..."
+            ),
+            minzoom: Optional[int] = Query(
+                None, description="Overwrite default minzoom."
+            ),
+            maxzoom: Optional[int] = Query(
+                None, description="Overwrite default maxzoom."
+            ),
+            layer_params=Depends(self.layer_dependency),  # noqa
+            dataset_params=Depends(self.dataset_dependency),  # noqa
+            pixel_selection=Depends(self.pixel_selection_dependency),  # noqa
+            buffer: Optional[float] = Query(  # noqa
+                None,
+                gt=0,
+                title="Tile buffer.",
+                description="Buffer on each side of the given tile. It must be a multiple of `0.5`. Output **tilesize** will be expanded to `tilesize + 2 * tile_buffer` (e.g 0.5 = 257x257, 1.0 = 258x258).",
+            ),
+            rescale: Optional[List[Tuple[float, ...]]] = Depends(
+                RescalingParams
+            ),  # noqa
+            color_formula: Optional[str] = Query(  # noqa
+                None,
+                title="Color Formula",
+                description="rio-color formula (info: https://github.com/mapbox/rio-color)",
+            ),
+            colormap=Depends(self.colormap_dependency),  # noqa
+            render_params=Depends(self.render_dependency),  # noqa
+            backend_params=Depends(self.backend_dependency),  # noqa
+            reader_params=Depends(self.reader_dependency),  # noqa
+            env=Depends(self.environment_dependency),  # noqa
+        ):
+            """Return TileJSON document for a dataset."""
+            tilejson_url = self.url_for(request, "tilejson")
+            if request.query_params._list:
+                tilejson_url += f"?{urlencode(request.query_params._list)}"
+
+            return templates.TemplateResponse(
+                name="index.html",
+                context={
+                    "request": request,
+                    "tilejson_endpoint": tilejson_url,
+                },
+                media_type="text/html",
+            )
 
     def wmts(self):  # noqa: C901
         """Add wmts endpoint."""


### PR DESCRIPTION
This PR adds a simple map viewer 

```
http://127.0.0.1:8081/cog/map?url=https://oin-hotosm.s3.amazonaws.com/5ac626e091b5310010e0d482/0/5ac626e091b5310010e0d483.tif
```
<img width="856" alt="Screen Shot 2022-11-24 at 11 50 07 PM" src="https://user-images.githubusercontent.com/10407788/203871704-d89e5cfe-2f0d-4c04-ac5b-c6a71f1b3539.png">

The endpoint takes the same inputs as the Tilejson endpoint (which is used in the viewer)
