### PR TITLE
refactor TMS dependency

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,9 @@
 * update Point output model to include `band_names`
 * histogram and info band names are prefixed with `b` (e.g `b1`) (ref: https://cogeotiff.github.io/rio-tiler/v4_migration/#band-names)
 * add `/map` endpoint in TilerFactory to display tiles given query-parameters
+* remove `TMSParams` and `WebMercatorTMSParams` dependencies.
+* replace `TilerFactory.tms_dependency` attribute by `TilerFactory.supported_tms`. This attribute gets a `morecantile.defaults.TileMatrixSets` store and will create the tms dependencies dynamically
+* replace `TMSFactory.tms_dependency` attribute by `TMSFactory.supported_tms`. This attribute gets a `morecantile.defaults.TileMatrixSets` store and will create the tms dependencies dynamically
 
 ### titiler.mosaic
 
@@ -26,6 +29,7 @@
 **breaking changes**
 
 * remove `timing headers`
+* replace `MosaicTilerFactory.tms_dependency` attribute by `MosaicTilerFactory.supported_tms`. This attribute gets a `morecantile.defaults.TileMatrixSets` store and will create the tms dependencies dynamically
 
 ### titiler.application
 

--- a/docs/src/advanced/customization.md
+++ b/docs/src/advanced/customization.md
@@ -62,26 +62,8 @@ EPSG6933 = TileMatrixSet.custom(
 # 2. Register TMS
 tms = tms.register([EPSG6933])
 
-# 3. Create ENUM with available TMS
-TileMatrixSetNames = Enum(  # type: ignore
-    "TileMatrixSetNames", [(a, a) for a in sorted(tms.list())]
-)
-
-# 4. Create Custom TMS dependency
-def TMSParams(
-    TileMatrixSetId: TileMatrixSetNames = Query(
-        TileMatrixSetNames.WebMercatorQuad,  # type: ignore
-        description="TileMatrixSet Name (default: 'WebMercatorQuad')",
-    )
-) -> TileMatrixSet:
-    """TileMatrixSet Dependency."""
-    return tms.get(TileMatrixSetId.name)
-
-# 5. Create Tiler
-COGTilerWithCustomTMS = TilerFactory(
-    reader=COGReader,
-    tms_dependency=TMSParams,
-)
+# 3. Create Tiler
+COGTilerWithCustomTMS = TilerFactory(supported_tms=tms)
 ```
 
 ### Add a MosaicJSON creation endpoint

--- a/docs/src/advanced/dependencies.md
+++ b/docs/src/advanced/dependencies.md
@@ -76,33 +76,6 @@ def DatasetPathParams(
     return url
 ```
 
-#### tms_dependency
-
-The TMS dependency sets the available TMS for a tile endpoint.
-
-```python
-# Allow all morecantile TMS
-def TMSParams(
-    TileMatrixSetId: TileMatrixSetNames = Query(
-        TileMatrixSetNames.WebMercatorQuad,  # type: ignore
-        description="TileMatrixSet Name (default: 'WebMercatorQuad')",
-    )
-) -> morecantile.TileMatrixSet:
-    """TileMatrixSet Dependency."""
-    return morecantile.tms.get(TileMatrixSetId.name)
-
-# or
-# Restrict the TMS to `WebMercatorQuad` only
-def WebMercatorTMSParams(
-    TileMatrixSetId: WebMercatorTileMatrixSetName = Query(
-        WebMercatorTileMatrixSetName.WebMercatorQuad,  # type: ignore
-        description="TileMatrixSet Name (default: 'WebMercatorQuad')",
-    )
-) -> morecantile.TileMatrixSet:
-    """TileMatrixSet Dependency."""
-    return morecantile.tms.get(TileMatrixSetId.name)
-```
-
 #### layer_dependency
 
 Define band indexes or expression
@@ -174,37 +147,6 @@ class DatasetParams(DefaultDependency):
         self.resampling_method = self.resampling_method.value  # type: ignore
 ```
 
-
-#### process_dependency
-
-Post-Process data before rendering.
-
-```python
-@dataclass
-class PostProcessParams(DefaultDependency):
-    """Data Post-Processing options."""
-
-    in_range: Optional[List[str]] = Query(
-        None,
-        alias="rescale",
-        title="Min/Max data Rescaling",
-        description="comma (',') delimited Min,Max range. Can set multiple time for multiple bands.",
-        example=["0,2000", "0,1000", "0,10000"],  # band 1  # band 2  # band 3
-    )
-    color_formula: Optional[str] = Query(
-        None,
-        title="Color Formula",
-        description="rio-color formula (info: https://github.com/mapbox/rio-color)",
-    )
-
-    def __post_init__(self):
-        """Post Init."""
-        if self.in_range:
-            self.in_range = [  # type: ignore
-                tuple(map(float, r.replace(" ", "").split(","))) for r in self.in_range
-            ]
-```
-
 #### render_dependency
 
 Image rendering options.
@@ -249,6 +191,30 @@ def ColorMapParams(
 #### reader_dependency
 
 Additional reader options. Defaults to `DefaultDependency` (empty).
+
+
+#### Other Attributes
+
+##### Supported TMS
+
+
+The TMS dependency sets the available TMS for a tile endpoint.
+
+```python
+# Allow all morecantile TMS
+from morecantile import tms as default_tms
+
+tiler = TilerFactory(supported_tms=default_tms)
+
+
+# Restrict the TMS to `WebMercatorQuad` only
+from morecantile import tms
+from morecantile.defaults import TileMatrixSets
+
+# Construct a TileMatrixSets object with only the `WebMercatorQuad` tms
+default_tms = TileMatrixSets({"WebMercatorQuad": tms.get("WebMercatorQuad")})
+tiler = TilerFactory(supported_tms=default_tms)
+```
 
 ### TilerFactory
 

--- a/src/titiler/core/tests/test_dependencies.py
+++ b/src/titiler/core/tests/test_dependencies.py
@@ -2,15 +2,16 @@
 
 import json
 from dataclasses import dataclass
+from typing import Literal
 
 import pytest
-from morecantile import TileMatrixSet
+from morecantile import tms
 from rio_tiler.types import ColorMapType
 
 from titiler.core import dependencies, errors
 from titiler.core.resources.responses import JSONResponse
 
-from fastapi import Depends, FastAPI
+from fastapi import Depends, FastAPI, Query
 
 from starlette.testclient import TestClient
 
@@ -20,14 +21,14 @@ def test_tms():
     app = FastAPI()
 
     @app.get("/web/{TileMatrixSetId}")
-    def web(tms: TileMatrixSet = Depends(dependencies.WebMercatorTMSParams)):
+    def web(TileMatrixSetId: Literal["WebMercatorQuad"] = Query(...)):
         """return tms id."""
-        return tms.identifier
+        return TileMatrixSetId
 
     @app.get("/all/{TileMatrixSetId}")
-    def all(tms: TileMatrixSet = Depends(dependencies.TMSParams)):
+    def all(TileMatrixSetId: Literal[tuple(tms.list())] = Query(...)):
         """return tms id."""
-        return tms.identifier
+        return TileMatrixSetId
 
     client = TestClient(app)
     response = client.get("/web/WebMercatorQuad")

--- a/src/titiler/core/titiler/core/dependencies.py
+++ b/src/titiler/core/titiler/core/dependencies.py
@@ -6,8 +6,6 @@ from enum import Enum
 from typing import Dict, List, Optional, Sequence, Tuple, Union
 
 import numpy
-from morecantile import tms
-from morecantile.models import TileMatrixSet
 from rasterio.enums import Resampling
 from rio_tiler.colormap import cmap, parse_color
 from rio_tiler.errors import MissingAssets, MissingBands
@@ -21,32 +19,6 @@ ColorMapName = Enum(  # type: ignore
 ResamplingName = Enum(  # type: ignore
     "ResamplingName", [(r.name, r.name) for r in Resampling]
 )
-WebMercatorTileMatrixSetName = Enum(  # type: ignore
-    "WebMercatorTileMatrixSetName", [("WebMercatorQuad", "WebMercatorQuad")]
-)
-TileMatrixSetName = Enum(  # type: ignore
-    "TileMatrixSetName", [(a, a) for a in sorted(tms.list())]
-)
-
-
-def WebMercatorTMSParams(
-    TileMatrixSetId: WebMercatorTileMatrixSetName = Query(
-        WebMercatorTileMatrixSetName.WebMercatorQuad,  # type: ignore
-        description="TileMatrixSet Name (default: 'WebMercatorQuad')",
-    )
-) -> TileMatrixSet:
-    """TileMatrixSet Dependency."""
-    return tms.get(TileMatrixSetId.name)
-
-
-def TMSParams(
-    TileMatrixSetId: TileMatrixSetName = Query(
-        TileMatrixSetName.WebMercatorQuad,  # type: ignore
-        description="TileMatrixSet Name (default: 'WebMercatorQuad')",
-    )
-) -> TileMatrixSet:
-    """TileMatrixSet Dependency."""
-    return tms.get(TileMatrixSetId.name)
 
 
 def ColorMapParams(

--- a/src/titiler/core/titiler/core/factory.py
+++ b/src/titiler/core/titiler/core/factory.py
@@ -2,13 +2,15 @@
 
 import abc
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
+from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Type, Union
 from urllib.parse import urlencode
 
 import rasterio
 from geojson_pydantic.features import Feature, FeatureCollection
 from geojson_pydantic.geometries import Polygon
 from morecantile import TileMatrixSet
+from morecantile import tms as default_tms
+from morecantile.defaults import TileMatrixSets
 from rio_tiler.io import BaseReader, MultiBandReader, MultiBaseReader, Reader
 from rio_tiler.models import BandStatistics, Bounds, Info
 from rio_tiler.types import ColorMapType
@@ -32,9 +34,6 @@ from titiler.core.dependencies import (
     ImageRenderingParams,
     RescalingParams,
     StatisticsParams,
-    TileMatrixSetName,
-    TMSParams,
-    WebMercatorTMSParams,
 )
 from titiler.core.models.mapbox import TileJSON
 from titiler.core.models.OGC import TileMatrixSetList
@@ -140,14 +139,14 @@ class BaseTilerFactory(metaclass=abc.ABCMeta):
     # Post Processing Dependencies (algorithm)
     process_dependency: Type[DefaultDependency] = DefaultDependency
 
-    # TileMatrixSet dependency
-    tms_dependency: Callable[..., TileMatrixSet] = TMSParams
-
     # Reader dependency
     reader_dependency: Type[DefaultDependency] = DefaultDependency
 
     # GDAL ENV dependency
     environment_dependency: Callable[..., Dict] = lambda: dict()
+
+    # TileMatrixSet dependency
+    supported_tms: TileMatrixSets = default_tms
 
     # Router Prefix is needed to find the path for /tile if the TilerFactory.router is mounted
     # with other router (multiple `.../tile` routes).
@@ -453,7 +452,10 @@ class TilerFactory(BaseTilerFactory):
             z: int = Path(..., ge=0, le=30, description="TMS tiles's zoom level"),
             x: int = Path(..., description="TMS tiles's column"),
             y: int = Path(..., description="TMS tiles's row"),
-            tms: TileMatrixSet = Depends(self.tms_dependency),
+            TileMatrixSetId: Literal[tuple(self.supported_tms.list())] = Query(
+                "WebMercatorQuad",
+                description="TileMatrixSet Name (default: 'WebMercatorQuad')",
+            ),
             scale: int = Query(
                 1, gt=0, lt=4, description="Tile size scale. 1=256x256, 2=512x512..."
             ),
@@ -481,6 +483,7 @@ class TilerFactory(BaseTilerFactory):
             env=Depends(self.environment_dependency),
         ):
             """Create map tile from a dataset."""
+            tms = self.supported_tms.get(TileMatrixSetId)
             with rasterio.Env(**env):
                 with self.reader(src_path, tms=tms, **reader_params) as src_dst:
                     image = src_dst.tile(
@@ -529,7 +532,10 @@ class TilerFactory(BaseTilerFactory):
         )
         def tilejson(
             request: Request,
-            tms: TileMatrixSet = Depends(self.tms_dependency),
+            TileMatrixSetId: Literal[tuple(self.supported_tms.list())] = Query(
+                "WebMercatorQuad",
+                description="TileMatrixSet Name (default: 'WebMercatorQuad')",
+            ),
             src_path=Depends(self.path_dependency),
             tile_format: Optional[ImageType] = Query(
                 None, description="Output image type. Default is auto."
@@ -570,7 +576,7 @@ class TilerFactory(BaseTilerFactory):
                 "x": "{x}",
                 "y": "{y}",
                 "scale": tile_scale,
-                "TileMatrixSetId": tms.identifier,
+                "TileMatrixSetId": TileMatrixSetId,
             }
             if tile_format:
                 route_params["format"] = tile_format.value
@@ -591,6 +597,7 @@ class TilerFactory(BaseTilerFactory):
             if qs:
                 tiles_url += f"?{urlencode(qs)}"
 
+            tms = self.supported_tms.get(TileMatrixSetId)
             with rasterio.Env(**env):
                 with self.reader(src_path, tms=tms, **reader_params) as src_dst:
                     return {
@@ -608,7 +615,10 @@ class TilerFactory(BaseTilerFactory):
         def map_viewer(
             request: Request,
             src_path=Depends(self.path_dependency),
-            tms: TileMatrixSet = Depends(WebMercatorTMSParams),  # noqa
+            TileMatrixSetId: Literal["WebMercatorQuad"] = Query(
+                "WebMercatorQuad",
+                description="TileMatrixSet Name (default: 'WebMercatorQuad')",
+            ),  # noqa
             tile_format: Optional[ImageType] = Query(
                 None, description="Output image type. Default is auto."
             ),  # noqa
@@ -666,7 +676,10 @@ class TilerFactory(BaseTilerFactory):
         )
         def wmts(
             request: Request,
-            tms: TileMatrixSet = Depends(self.tms_dependency),
+            TileMatrixSetId: Literal[tuple(self.supported_tms.list())] = Query(
+                "WebMercatorQuad",
+                description="TileMatrixSet Name (default: 'WebMercatorQuad')",
+            ),
             src_path=Depends(self.path_dependency),
             tile_format: ImageType = Query(
                 ImageType.png, description="Output image type. Default is png."
@@ -708,7 +721,7 @@ class TilerFactory(BaseTilerFactory):
                 "y": "{TileRow}",
                 "scale": tile_scale,
                 "format": tile_format.value,
-                "TileMatrixSetId": tms.identifier,
+                "TileMatrixSetId": TileMatrixSetId,
             }
             tiles_url = self.url_for(request, "tile", **route_params)
 
@@ -729,6 +742,7 @@ class TilerFactory(BaseTilerFactory):
             if qs:
                 tiles_url += f"?{urlencode(qs)}"
 
+            tms = self.supported_tms.get(TileMatrixSetId)
             with rasterio.Env(**env):
                 with self.reader(src_path, tms=tms, **reader_params) as src_dst:
                     bounds = src_dst.geographic_bounds
@@ -1413,11 +1427,7 @@ class MultiBandTilerFactory(TilerFactory):
 class TMSFactory:
     """TileMatrixSet endpoints Factory."""
 
-    # Enum of supported TMS
-    supported_tms: Type[TileMatrixSetName] = TileMatrixSetName
-
-    # TileMatrixSet dependency
-    tms_dependency: Callable[..., TileMatrixSet] = TMSParams
+    supported_tms: TileMatrixSets = default_tms
 
     # FastAPI router
     router: APIRouter = field(default_factory=APIRouter)
@@ -1456,21 +1466,21 @@ class TMSFactory:
             return {
                 "tileMatrixSets": [
                     {
-                        "id": tms.name,
-                        "title": tms.name,
+                        "id": tms.identifier,
+                        "title": tms.identifier,
                         "links": [
                             {
                                 "href": self.url_for(
                                     request,
                                     "TileMatrixSet_info",
-                                    TileMatrixSetId=tms.name,
+                                    TileMatrixSetId=tms.identifier,
                                 ),
                                 "rel": "item",
                                 "type": "application/json",
                             }
                         ],
                     }
-                    for tms in self.supported_tms
+                    for tms in self.supported_tms.tms.values()
                 ]
             }
 
@@ -1479,6 +1489,10 @@ class TMSFactory:
             response_model=TileMatrixSet,
             response_model_exclude_none=True,
         )
-        async def TileMatrixSet_info(tms: TileMatrixSet = Depends(self.tms_dependency)):
+        async def TileMatrixSet_info(
+            TileMatrixSetId: Literal[tuple(self.supported_tms.list())] = Path(
+                ..., description="TileMatrixSet Name."
+            )
+        ):
             """Return TileMatrixSet JSON document."""
-            return tms
+            return self.supported_tms.get(TileMatrixSetId)

--- a/src/titiler/mosaic/tests/test_factory.py
+++ b/src/titiler/mosaic/tests/test_factory.py
@@ -12,7 +12,7 @@ import numpy
 from cogeo_mosaic.backends import FileBackend
 from cogeo_mosaic.mosaic import MosaicJSON
 
-from titiler.core.dependencies import DefaultDependency, WebMercatorTMSParams
+from titiler.core.dependencies import DefaultDependency
 from titiler.core.resources.enums import OptionalHeader
 from titiler.mosaic.factory import MosaicTilerFactory
 from titiler.mosaic.resources.enums import PixelSelectionMethod
@@ -48,7 +48,6 @@ def test_MosaicTilerFactory():
         router_prefix="mosaic",
     )
     assert len(mosaic.router.routes) == 24
-    assert mosaic.tms_dependency == WebMercatorTMSParams
 
     app = FastAPI()
     app.include_router(mosaic.router, prefix="/mosaic")

--- a/src/titiler/mosaic/titiler/mosaic/factory.py
+++ b/src/titiler/mosaic/titiler/mosaic/factory.py
@@ -2,7 +2,7 @@
 
 import os
 from dataclasses import dataclass
-from typing import Callable, Dict, List, Optional, Tuple, Type, Union
+from typing import Callable, Dict, List, Literal, Optional, Tuple, Type, Union
 from urllib.parse import urlencode
 
 import rasterio
@@ -11,17 +11,14 @@ from cogeo_mosaic.models import Info as mosaicInfo
 from cogeo_mosaic.mosaic import MosaicJSON
 from geojson_pydantic.features import Feature
 from geojson_pydantic.geometries import Polygon
-from morecantile import TileMatrixSet
+from morecantile import tms
+from morecantile.defaults import TileMatrixSets
 from rio_tiler.constants import MAX_THREADS
 from rio_tiler.io import BaseReader, MultiBandReader, MultiBaseReader, Reader
 from rio_tiler.models import Bounds
 from rio_tiler.mosaic.methods.base import MosaicMethodBase
 
-from titiler.core.dependencies import (
-    DefaultDependency,
-    RescalingParams,
-    WebMercatorTMSParams,
-)
+from titiler.core.dependencies import DefaultDependency, RescalingParams
 from titiler.core.factory import BaseTilerFactory, img_endpoint_params, templates
 from titiler.core.models.mapbox import TileJSON
 from titiler.core.resources.enums import ImageType, MediaType, OptionalHeader
@@ -33,6 +30,9 @@ from fastapi import Depends, Path, Query
 
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, Response
+
+# BaseBackend does not support other TMS than WebMercator
+default_tms = TileMatrixSets({"WebMercatorQuad": tms.get("WebMercatorQuad")})
 
 
 def PixelSelectionParams(
@@ -63,12 +63,11 @@ class MosaicTilerFactory(BaseTilerFactory):
         Type[MultiBandReader],
     ] = Reader
 
-    # BaseBackend does not support other TMS than WebMercator
-    tms_dependency: Callable[..., TileMatrixSet] = WebMercatorTMSParams
-
     backend_dependency: Type[DefaultDependency] = DefaultDependency
 
     pixel_selection_dependency: Callable[..., MosaicMethodBase] = PixelSelectionParams
+
+    supported_tms: TileMatrixSets = default_tms
 
     # Add/Remove some endpoints
     add_viewer: bool = True
@@ -242,7 +241,10 @@ class MosaicTilerFactory(BaseTilerFactory):
             z: int = Path(..., ge=0, le=30, description="Mercator tiles's zoom level"),
             x: int = Path(..., description="Mercator tiles's column"),
             y: int = Path(..., description="Mercator tiles's row"),
-            tms: TileMatrixSet = Depends(self.tms_dependency),
+            TileMatrixSetId: Literal[tuple(self.supported_tms.list())] = Query(
+                "WebMercatorQuad",
+                description="TileMatrixSet Name (default: 'WebMercatorQuad')",
+            ),  # noqa
             scale: int = Query(
                 1, gt=0, lt=4, description="Tile size scale. 1=256x256, 2=512x512..."
             ),
@@ -332,7 +334,10 @@ class MosaicTilerFactory(BaseTilerFactory):
         )
         def tilejson(
             request: Request,
-            tms: TileMatrixSet = Depends(self.tms_dependency),
+            TileMatrixSetId: Literal[tuple(self.supported_tms.list())] = Query(
+                "WebMercatorQuad",
+                description="TileMatrixSet Name (default: 'WebMercatorQuad')",
+            ),  # noqa
             src_path=Depends(self.path_dependency),
             tile_format: Optional[ImageType] = Query(
                 None, description="Output image type. Default is auto."
@@ -375,7 +380,7 @@ class MosaicTilerFactory(BaseTilerFactory):
                 "x": "{x}",
                 "y": "{y}",
                 "scale": tile_scale,
-                "TileMatrixSetId": tms.identifier,
+                "TileMatrixSetId": TileMatrixSetId,
             }
             if tile_format:
                 route_params["format"] = tile_format.value
@@ -422,7 +427,10 @@ class MosaicTilerFactory(BaseTilerFactory):
         def map_viewer(
             request: Request,
             src_path=Depends(self.path_dependency),
-            tms: TileMatrixSet = Depends(WebMercatorTMSParams),  # noqa
+            TileMatrixSetId: Literal["WebMercatorQuad"] = Query(
+                "WebMercatorQuad",
+                description="TileMatrixSet Name (default: 'WebMercatorQuad')",
+            ),  # noqa
             tile_format: Optional[ImageType] = Query(
                 None, description="Output image type. Default is auto."
             ),
@@ -481,7 +489,10 @@ class MosaicTilerFactory(BaseTilerFactory):
         )
         def wmts(
             request: Request,
-            tms: TileMatrixSet = Depends(self.tms_dependency),
+            TileMatrixSetId: Literal[tuple(self.supported_tms.list())] = Query(
+                "WebMercatorQuad",
+                description="TileMatrixSet Name (default: 'WebMercatorQuad')",
+            ),  # noqa
             src_path=Depends(self.path_dependency),
             tile_format: ImageType = Query(
                 ImageType.png, description="Output image type. Default is png."
@@ -525,7 +536,7 @@ class MosaicTilerFactory(BaseTilerFactory):
                 "y": "{TileRow}",
                 "scale": tile_scale,
                 "format": tile_format.value,
-                "TileMatrixSetId": tms.identifier,
+                "TileMatrixSetId": TileMatrixSetId,
             }
             tiles_url = self.url_for(request, "tile", **route_params)
 
@@ -546,6 +557,7 @@ class MosaicTilerFactory(BaseTilerFactory):
             if qs:
                 tiles_url += f"?{urlencode(qs)}"
 
+            tms = self.supported_tms.get(TileMatrixSetId)
             with rasterio.Env(**env):
                 with self.reader(
                     src_path,


### PR DESCRIPTION
This PR refactor the TMS dependency within the TilerFactory to replace it by a simple attribute that gets a `TileMatrixSets` store. The Factory will then create the dependency needed