### PR TITLE
docs: Update titiler.errors to titiler.core.errors in exmaples

### DIFF
--- a/docs/src/examples/code/tiler_with_auth.md
+++ b/docs/src/examples/code/tiler_with_auth.md
@@ -198,7 +198,7 @@ app/main.py
 """
 
 from titiler.core.factory import TilerFactory
-from titiler.errors import DEFAULT_STATUS_CODES, add_exception_handlers
+from titiler.core.errors import DEFAULT_STATUS_CODES, add_exception_handlers
 
 from fastapi import FastAPI
 

--- a/docs/src/examples/code/tiler_with_cache.md
+++ b/docs/src/examples/code/tiler_with_cache.md
@@ -323,7 +323,7 @@ app/main.py
 
 """
 
-from titiler.errors import DEFAULT_STATUS_CODES, add_exception_handlers
+from titiler.core.errors import DEFAULT_STATUS_CODES, add_exception_handlers
 
 from fastapi import FastAPI
 


### PR DESCRIPTION
The [auth](https://developmentseed.org/titiler/examples/code/tiler_with_auth/) and [cache](https://developmentseed.org/titiler/examples/code/tiler_with_cache/) examples have outdated
```
from titiler.errors import DEFAULT_STATUS_CODES, add_exception_handlers
```

This minor PR updates the import to
```
from titiler.core.errors import DEFAULT_STATUS_CODES, add_exception_handlers
```