### PR TITLE
make terrainrgb interval and baseval floats to support more quantizers

### DIFF
--- a/src/titiler/core/titiler/core/algorithm/dem.py
+++ b/src/titiler/core/titiler/core/algorithm/dem.py
@@ -128,8 +128,8 @@ class TerrainRGB(BaseAlgorithm):
     """Encode DEM into RGB (Mapbox Terrain RGB)."""
 
     # parameters
-    interval: int = 1
-    baseval: int = -10000
+    interval: float = 1.0
+    baseval: float = -10000.0
 
     # metadata
     input_nbands: int = 1


### PR DESCRIPTION
as per some changes in https://github.com/AndrewAnnex/planetcantile/pull/9, this would expand the default terrainrgb to be more flexible on how the quantizers are defined by accepting floats instead of integers. Shouldn't break or change anything as-is.