### PR TITLE
add left and right sources to visualize dateline crossing dataset

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## Next (TBD)
+
+* handle dateline crossing dataset in COG/STAC Viewer
+
 ## 0.11.2 (2023-03-08)
 
 * Add OSM background in `/map` viewer when using WebMercator TMS

--- a/src/titiler/core/titiler/core/templates/index.html
+++ b/src/titiler/core/titiler/core/templates/index.html
@@ -55,11 +55,11 @@ var map = L.map('map', {
   maxZoom: {{ tms.maxzoom }}
 });
 
-// const nullIsland = L.marker([0, 0]).addTo(map);
-// const madrid = L.marker([40, -3]).addTo(map);
-// const london = L.marker([51.50722, -0.1275]).addTo(map)
-// const auckland = L.marker([-36.864664, 174.792059]).addTo(map);
-// const seattle = L.marker([47.596842, -122.333087]).addTo(map);
+const nullIsland = L.marker([0, 0]).addTo(map);
+const madrid = L.marker([40, -3]).addTo(map);
+const london = L.marker([51.50722, -0.1275]).addTo(map)
+const auckland = L.marker([-36.864664, 174.792059]).addTo(map);
+const seattle = L.marker([47.596842, -122.333087]).addTo(map);
 
 if ("{{ tms.identifier }}" === "WebMercatorQuad") {
   L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
@@ -76,6 +76,29 @@ fetch('{{ tilejson_endpoint|safe }}')
     console.log(data)
 
     let bounds = [...data.bounds]
+
+    let geo;
+    // handle files that span accross dateline
+    if (bounds[0] > bounds[2]) {
+      geo = {
+        "type": "FeatureCollection",
+        "features": [
+          bboxPolygon([-180, bounds[1], bounds[2], bounds[3]]),
+          bboxPolygon([bounds[0], bounds[1], 180, bounds[3]]),
+        ]
+      }
+    } else {
+      geo = {
+        "type": "FeatureCollection",
+        "features": [bboxPolygon(bounds)]
+      }
+    }
+
+    var aoi = L.geoJSON(geo, {
+        color: '#3bb2d0', fill: false
+    }).addTo(map);
+    map.fitBounds(aoi.getBounds());
+
     // Bounds crossing dateline
     if (bounds[0] > bounds[2]) {
       bounds[0] = bounds[0] - 360
@@ -84,13 +107,6 @@ fetch('{{ tilejson_endpoint|safe }}')
       bottom = bounds[1],
       right = bounds[2],
       top = bounds[3];
-
-    var aoi = L.geoJSON(
-      bboxPolygon(bounds), {
-        color: '#3bb2d0', fill: false
-      }
-    ).addTo(map);
-    map.fitBounds(aoi.getBounds());
 
     L.tileLayer(
       data.tiles[0], {

--- a/src/titiler/extensions/titiler/extensions/templates/cog_index.html
+++ b/src/titiler/extensions/titiler/extensions/templates/cog_index.html
@@ -344,6 +344,63 @@ map.on('zoom', function (e) {
   document.getElementById('zoom').textContent = z
 })
 
+const setMapLayers = (url) => {
+  fetch(url)
+    .then(res => {
+      if (res.ok) return res.json()
+      throw new Error('Network response was not ok.');
+    })
+    .then(data => {
+      let bounds = [...data.bounds]
+      if (bounds[0] > bounds[2]) {
+        if (map.getLayer('raster-l')) map.removeLayer('raster-l')
+        if (map.getSource('raster-l')) map.removeSource('raster-l')
+        if (map.getLayer('raster-r')) map.removeLayer('raster-r')
+        if (map.getSource('raster-r')) map.removeSource('raster-r')
+
+        // 2 sources and 2 layers
+        // left
+        map.addSource('raster-l', {
+          type: 'raster',
+          bounds: [-180, bounds[1], bounds[2], bounds[3]],
+          minzoom: data.minzoom,
+          maxzoom: data.maxzoom,
+          tiles: data.tiles,
+          tileSize: 256
+        })
+        map.addLayer({id: 'raster-l', type: 'raster', source: 'raster-l'})
+
+        //right
+        map.addSource('raster-r', {
+          type: 'raster',
+          bounds: [bounds[0], bounds[1], 180, bounds[3]],
+          minzoom: data.minzoom,
+          maxzoom: data.maxzoom,
+          tiles: data.tiles,
+          tileSize: 256
+        })
+        map.addLayer({id: 'raster-r', type: 'raster', source: 'raster-r'})
+
+      } else {
+        if (map.getLayer('raster')) map.removeLayer('raster')
+        if (map.getSource('raster')) map.removeSource('raster')
+
+        map.addSource('raster', {
+          type: 'raster',
+          bounds: data.bounds,
+          minzoom: data.minzoom,
+          maxzoom: data.maxzoom,
+          tiles: data.tiles,
+          tileSize: 256
+        })
+        map.addLayer({id: 'raster', type: 'raster', source: 'raster'})
+      }
+    })
+    .catch(err => {
+      console.warn(err)
+    })
+}
+
 const set1bViz = () => {
   params = {
     url: scope.url
@@ -359,9 +416,7 @@ const set1bViz = () => {
 
   const url_params = Object.keys(params).map(i => `${i}=${params[i]}`).join('&')
   let url = `${tilejson_endpoint}?${url_params}`
-
-  map.addSource('raster', { type: 'raster', url: url , tileSize: 256})
-  map.addLayer({id: 'raster', type: 'raster', source: 'raster'})
+  setMapLayers(url)
   if (scope.dataset_statistics) addHisto1Band()
 }
 
@@ -381,16 +436,11 @@ const set3bViz = () => {
 
   const indexes_params = [r, g, b].map(i => `bidx=${i}`).join('&')
   let url = `${tilejson_endpoint}?${url_params}${indexes_params}`
-
-  map.addSource('raster', { type: 'raster', url: url, tileSize: 256})
-  map.addLayer({id: 'raster', type: 'raster', source: 'raster'})
+  setMapLayers(url)
   if (scope.dataset_statistics) addHisto3Bands()
 }
 
 const updateViz = () => {
-  if (map.getLayer('raster')) map.removeLayer('raster')
-  if (map.getSource('raster')) map.removeSource('raster')
-
   const rasterType = document.getElementById('toolbar').querySelector(".active").id
   switch (rasterType) {
     case '1b':
@@ -681,15 +731,29 @@ const bboxPolygon = (bounds) => {
 const addAOI = (bounds) => {
   if (map.getLayer('aoi-polygon')) map.removeLayer('aoi-polygon')
   if (map.getSource('aoi')) map.removeSource('aoi')
-  const geojson = {
-      "type": "FeatureCollection",
-      "features": [bboxPolygon(bounds)]
-  }
 
-  map.addSource('aoi', {
-    'type': 'geojson',
-    'data': geojson
-  })
+  // handle files that span accross dateline
+  if (bounds[0] > bounds[2]) {
+    map.addSource('aoi', {
+      'type': 'geojson',
+      'data': {
+        "type": "FeatureCollection",
+        "features": [
+          bboxPolygon([-180, bounds[1], bounds[2], bounds[3]]),
+          bboxPolygon([bounds[0], bounds[1], 180, bounds[3]]),
+        ]
+      }
+    })
+
+  } else {
+    map.addSource('aoi', {
+      'type': 'geojson',
+      'data': {
+        "type": "FeatureCollection",
+        "features": [bboxPolygon(bounds)]
+      }
+    })
+  }
 
   map.addLayer({
     id: 'aoi-polygon',
@@ -796,7 +860,7 @@ const addCogeo = () => {
       map.fitBounds(
         [[bounds[0], bounds[1]], [bounds[2], bounds[3]]]
       )
-      addAOI(bounds)
+      addAOI(data.bounds)
 
       if (nbands === 1) {
         document.getElementById('3b').classList.add('disabled')

--- a/src/titiler/extensions/titiler/extensions/templates/stac_index.html
+++ b/src/titiler/extensions/titiler/extensions/templates/stac_index.html
@@ -369,6 +369,63 @@ map.on('zoom', function (e) {
     document.getElementById('zoom').textContent = z
 })
 
+const setMapLayers = (url) => {
+  fetch(url)
+    .then(res => {
+      if (res.ok) return res.json()
+      throw new Error('Network response was not ok.');
+    })
+    .then(data => {
+      let bounds = [...data.bounds]
+      if (bounds[0] > bounds[2]) {
+        if (map.getLayer('raster-l')) map.removeLayer('raster-l')
+        if (map.getSource('raster-l')) map.removeSource('raster-l')
+        if (map.getLayer('raster-r')) map.removeLayer('raster-r')
+        if (map.getSource('raster-r')) map.removeSource('raster-r')
+
+        // 2 sources and 2 layers
+        // left
+        map.addSource('raster-l', {
+          type: 'raster',
+          bounds: [-180, bounds[1], bounds[2], bounds[3]],
+          minzoom: data.minzoom,
+          maxzoom: data.maxzoom,
+          tiles: data.tiles,
+          tileSize: 256
+        })
+        map.addLayer({id: 'raster-l', type: 'raster', source: 'raster-l'})
+
+        //right
+        map.addSource('raster-r', {
+          type: 'raster',
+          bounds: [bounds[0], bounds[1], 180, bounds[3]],
+          minzoom: data.minzoom,
+          maxzoom: data.maxzoom,
+          tiles: data.tiles,
+          tileSize: 256
+        })
+        map.addLayer({id: 'raster-r', type: 'raster', source: 'raster-r'})
+
+      } else {
+        if (map.getLayer('raster')) map.removeLayer('raster')
+        if (map.getSource('raster')) map.removeSource('raster')
+
+        map.addSource('raster', {
+          type: 'raster',
+          bounds: data.bounds,
+          minzoom: data.minzoom,
+          maxzoom: data.maxzoom,
+          tiles: data.tiles,
+          tileSize: 256
+        })
+        map.addLayer({id: 'raster', type: 'raster', source: 'raster'})
+      }
+    })
+    .catch(err => {
+      console.warn(err)
+    })
+}
+
 const set1bViz = () => {
     params = {
       url: scope.url
@@ -392,9 +449,7 @@ const set1bViz = () => {
 
     const url_params = Object.keys(params).map(i => `${i}=${params[i]}`).join('&')
     let url = `${tilejson_endpoint}?${url_params}`
-
-    map.addSource('raster', { type: 'raster', url: url , tileSize: 256})
-    map.addLayer({ id: 'raster', type: 'raster', source: 'raster' })
+    setMapLayers(url)
     if (scope.dataset_statistics) addHisto1Band()
 }
 
@@ -429,9 +484,7 @@ const set3bViz = () => {
 
   const url_params = Object.keys(params).map(i => `${i}=${params[i]}`).join('&')
   let url = `{{ tilejson_endpoint }}?${url_params}&${asset_params}&${indexes_params}`
-
-  map.addSource('raster', { type: 'raster', url: url, tileSize: 256 })
-  map.addLayer({ id: 'raster', type: 'raster', source: 'raster' })
+  setMapLayers(url)
   if (scope.dataset_statistics) addHisto3Bands()
 }
 
@@ -716,15 +769,28 @@ const addAOI = (bounds) => {
   if (map.getLayer('aoi-polygon')) map.removeLayer('aoi-polygon')
   if (map.getSource('aoi')) map.removeSource('aoi')
 
-  const geojson = {
-    "type": "FeatureCollection",
-    "features": [bboxPolygon(bounds)]
-  }
+  // handle files that span accross dateline
+  if (bounds[0] > bounds[2]) {
+    map.addSource('aoi', {
+      'type': 'geojson',
+      'data': {
+        "type": "FeatureCollection",
+        "features": [
+          bboxPolygon([-180, bounds[1], bounds[2], bounds[3]]),
+          bboxPolygon([bounds[0], bounds[1], 180, bounds[3]]),
+        ]
+      }
+    })
 
-  map.addSource('aoi', {
-    'type': 'geojson',
-    'data': geojson
-  })
+  } else {
+    map.addSource('aoi', {
+      'type': 'geojson',
+      'data': {
+        "type": "FeatureCollection",
+        "features": [bboxPolygon(bounds)]
+      }
+    })
+  }
 
   map.addLayer({
     id: 'aoi-polygon',
@@ -874,7 +940,7 @@ const updateUI = () => {
     map.fitBounds(
       [[bounds[0], bounds[1]], [bounds[2], bounds[3]]]
     )
-    addAOI(bounds)
+    addAOI(info.bounds)
 
     if (nbands === 1) {
       document.getElementById('3b').classList.add('disabled')


### PR DESCRIPTION
This PR `fixes` the cog/stac viewer to handle dataset crossing the dateline by using 2 different Layers on each side of the line.

<img width="1480" alt="Screenshot 2023-03-09 at 2 52 52 AM" src="https://user-images.githubusercontent.com/10407788/223895512-2f01aa7e-2ad9-48e3-bcc7-1ffe15d5fc9c.png">
