### PR TITLE
Conditional Chart install test

### DIFF
--- a/.github/workflows/check_charts.yaml
+++ b/.github/workflows/check_charts.yaml
@@ -75,4 +75,5 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)
-        run: ct install --chart-dirs deployment/k8s
+        run: ct install --chart-dirs deployment/k8s --target-branch ${{ github.event.repository.default_branch }}
+        if: steps.list-changed.outputs.changed == 'true'

--- a/.github/workflows/check_charts.yaml
+++ b/.github/workflows/check_charts.yaml
@@ -75,5 +75,5 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)
-        run: ct install --chart-dirs deployment/k8s --target-branch ${{ github.event.repository.default_branch }}
+        run: ct install --chart-dirs deployment/k8s
         if: steps.list-changed.outputs.changed == 'true'


### PR DESCRIPTION
The chart install step should not execute if no change has been made in the chart. The condition was not present and the action tried to install the chart in a not initialized cluster. This PR fixes the issue.