### PR TITLE
%matplotlib inline

### DIFF
--- a/docs/src/examples/notebooks/Working_with_CloudOptimizedGeoTIFF_simple.ipynb
+++ b/docs/src/examples/notebooks/Working_with_CloudOptimizedGeoTIFF_simple.ipynb
@@ -41,7 +41,7 @@
     "\n",
     "from folium import Map, TileLayer\n",
     "\n",
-    "%pylab inline"
+    "%matplotlib inline"
    ]
   },
   {


### PR DESCRIPTION
in response to this warning..

`%pylab is deprecated, use %matplotlib inline and import the required libraries. Populating the interactive namespace from numpy and matplotlib`
