### PR TITLE
add coord-crs options

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,9 @@
 # Release Notes
 
-## Next
+## 0.11.6 (2023-04-14)
 
 * Allow a default `rescale` parameter to be set via a dependency (author @samn, https://github.com/developmentseed/titiler/pull/619)
+* add `coord-crs` parameter for `/point`, `/part` and `/feature` endpoints
 
 ## 0.11.5 (2023-03-22)
 

--- a/docs/src/endpoints/cog.md
+++ b/docs/src/endpoints/cog.md
@@ -113,6 +113,7 @@ Example:
     - **url** (str): Cloud Optimized GeoTIFF URL. **Required**
     - **bidx** (array[int]): Dataset band indexes (e.g `bidx=1`, `bidx=1&bidx=2&bidx=3`).
     - **expression** (str): rio-tiler's band math expression (e.g B1/B2).
+    - **coord-crs** (str): Coordinate Reference System of the input coordinates. Default to `epsg:4326`.
     - **max_size** (int): Max image size, default is 1024.
     - **nodata** (str, int, float): Overwrite internal Nodata value.
     - **unscale** (bool): Apply dataset internal Scale/Offset.
@@ -148,6 +149,7 @@ Example:
     - **url** (str): Cloud Optimized GeoTIFF URL. **Required**
     - **bidx** (array[int]): Dataset band indexes (e.g `bidx=1`, `bidx=1&bidx=2&bidx=3`).
     - **expression** (str): rio-tiler's band math expression (e.g B1/B2).
+    - **coord-crs** (str): Coordinate Reference System of the input geometry coordinates. Default to `epsg:4326`.
     - **max_size** (int): Max image size, default is 1024.
     - **nodata** (str, int, float): Overwrite internal Nodata value.
     - **unscale** (bool): Apply dataset internal Scale/Offset.
@@ -182,6 +184,7 @@ Note: if `height` and `width` are provided `max_size` will be ignored.
     - **url** (str): Cloud Optimized GeoTIFF URL. **Required**
     - **bidx** (array[int]): Dataset band indexes (e.g `bidx=1`, `bidx=1&bidx=2&bidx=3`).
     - **expression** (str): rio-tiler's band math expression (e.g B1/B2).
+    - **coord-crs** (str): Coordinate Reference System of the input coordinates. Default to `epsg:4326`.
     - **nodata** (str, int, float): Overwrite internal Nodata value.
     - **unscale** (bool): Apply dataset internal Scale/Offset.
     - **resampling** (str): rasterio resampling method. Default is `nearest`.
@@ -320,6 +323,7 @@ Example:
     - **url** (str): Cloud Optimized GeoTIFF URL. **Required**
     - **bidx** (array[int]): Dataset band indexes (e.g `bidx=1`, `bidx=1&bidx=2&bidx=3`).
     - **expression** (str): rio-tiler's band math expression (e.g B1/B2).
+    - **coord-crs** (str): Coordinate Reference System of the input geometry coordinates. Default to `epsg:4326`.
     - **max_size** (int): Max image size from which to calculate statistics, default is 1024.
     - **height** (int): Force image height from which to calculate statistics.
     - **width** (int): Force image width from which to calculate statistics.

--- a/docs/src/endpoints/stac.md
+++ b/docs/src/endpoints/stac.md
@@ -124,6 +124,7 @@ Example:
     - **expression** (str): rio-tiler's math expression with asset names (e.g `Asset1_b1/Asset2_b1`).
     - **asset_as_band** (bool): tell rio-tiler that each asset is a 1 band dataset, so expression `Asset1/Asset2` can be passed.
     - **asset_bidx** (array[str]): Per asset band math expression (e.g `Asset1|1,2,3`).
+    - **coord-crs** (str): Coordinate Reference System of the input coordinates. Default to `epsg:4326`.
     - **max_size** (int): Max image size, default is 1024.
     - **nodata** (str, int, float): Overwrite internal Nodata value.
     - **unscale** (bool): Apply dataset internal Scale/Offset.
@@ -162,6 +163,7 @@ Example:
     - **expression** (str): rio-tiler's math expression with asset names (e.g `Asset1_b1/Asset2_b1`).
     - **asset_as_band** (bool): tell rio-tiler that each asset is a 1 band dataset, so expression `Asset1/Asset2` can be passed.
     - **asset_bidx** (array[str]): Per asset band math expression (e.g `Asset1|1,2,3`).
+    - **coord-crs** (str): Coordinate Reference System of the input geometry coordinates. Default to `epsg:4326`.
     - **max_size** (int): Max image size, default is 1024.
     - **nodata** (str, int, float): Overwrite internal Nodata value.
     - **unscale** (bool): Apply dataset internal Scale/Offset.
@@ -198,6 +200,7 @@ Example:
     - **expression** (str): rio-tiler's math expression with asset names (e.g `Asset1_b1/Asset2_b1`).
     - **asset_as_band** (bool): tell rio-tiler that each asset is a 1 band dataset, so expression `Asset1/Asset2` can be passed.
     - **asset_bidx** (array[str]): Per asset band math expression (e.g `Asset1|1,2,3`).
+    - **coord-crs** (str): Coordinate Reference System of the input coordinates. Default to `epsg:4326`.
     - **nodata** (str, int, float): Overwrite internal Nodata value.
     - **unscale** (bool): Apply dataset internal Scale/Offset.
     - **resampling** (str): rasterio resampling method. Default is `nearest`.
@@ -389,6 +392,7 @@ Example:
     - **expression** (str): rio-tiler's math expression with asset names (e.g `Asset1_b1/Asset2_b1`).
     - **asset_as_band** (bool): tell rio-tiler that each asset is a 1 band dataset, so expression `Asset1/Asset2` can be passed.
     - **asset_bidx** (array[str]): Per asset band math expression (e.g `Asset1|1,2,3`).
+    - **coord-crs** (str): Coordinate Reference System of the input geometry coordinates. Default to `epsg:4326`.
     - **max_size** (int): Max image size from which to calculate statistics, default is 1024.
     - **height** (int): Force image height from which to calculate statistics.
     - **width** (int): Force image width from which to calculate statistics.

--- a/src/titiler/application/tests/routes/test_cog.py
+++ b/src/titiler/application/tests/routes/test_cog.py
@@ -59,7 +59,7 @@ def test_wmts(rio, app):
     assert response.headers["content-type"] == "application/xml"
     assert response.headers["Cache-Control"] == "private, max-age=3600"
     assert (
-        "http://testserver/cog/WMTSCapabilities.xml?url=https://myurl.com/cog.tif"
+        "http://testserver/cog/WMTSCapabilities.xml?url=https"
         in response.content.decode()
     )
     assert "<ows:Identifier>cogeo</ows:Identifier>" in response.content.decode()

--- a/src/titiler/core/tests/test_dependencies.py
+++ b/src/titiler/core/tests/test_dependencies.py
@@ -250,10 +250,10 @@ def test_assets():
     assert response.json()["asset_indexes"] == {"data": [1, 2, 3], "image": [1]}
 
     response = client.get(
-        "/third?assets=data&assets=image&asset_expression=data|b1\b2&asset_expression=image|b1*b2"
+        "/third?assets=data&assets=image&asset_expression=data|b1/b2&asset_expression=image|b1*b2"
     )
     assert response.json()["assets"] == ["data", "image"]
-    assert response.json()["asset_expression"] == {"data": "b1\b2", "image": "b1*b2"}
+    assert response.json()["asset_expression"] == {"data": "b1/b2", "image": "b1*b2"}
 
 
 def test_bands():

--- a/src/titiler/core/tests/test_factories.py
+++ b/src/titiler/core/tests/test_factories.py
@@ -189,6 +189,14 @@ def test_TilerFactory():
     assert len(response.json()["values"]) == 1
     assert response.json()["band_names"] == ["b1"]
 
+    response = client.get(
+        f"/point/-6259272.328324187,12015838.020930404?url={DATA_DIR}/cog.tif&coord-crs=EPSG:3857"
+    )
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/json"
+    assert len(response.json()["values"]) == 1
+    assert response.json()["band_names"] == ["b1"]
+
     response = client.get(f"/point/-56.228,72.715?url={DATA_DIR}/cog.tif&bidx=1&bidx=1")
     assert len(response.json()["values"]) == 2
     assert response.json()["band_names"] == ["b1", "b1"]

--- a/src/titiler/core/titiler/core/dependencies.py
+++ b/src/titiler/core/titiler/core/dependencies.py
@@ -7,6 +7,7 @@ from typing import Dict, List, Optional, Sequence, Tuple, Union
 
 import numpy
 from fastapi import HTTPException, Query
+from rasterio.crs import CRS
 from rasterio.enums import Resampling
 from rio_tiler.colormap import cmap, parse_color
 from rio_tiler.errors import MissingAssets, MissingBands
@@ -448,3 +449,17 @@ link: https://numpy.org/doc/stable/reference/generated/numpy.histogram.html
 
         if self.range:
             self.range = list(map(float, self.range.split(",")))  # type: ignore
+
+
+def CRSParams(
+    crs: str = Query(
+        None,
+        alias="coord-crs",
+        description="Coordinate Reference System of the input coords. Default to `epsg:4326`.",
+    )
+) -> Optional[CRS]:
+    """Coordinate Reference System Coordinates Param."""
+    if crs:
+        return CRS.from_user_input(crs)
+
+    return None

--- a/src/titiler/mosaic/titiler/mosaic/factory.py
+++ b/src/titiler/mosaic/titiler/mosaic/factory.py
@@ -205,7 +205,9 @@ class MosaicTilerFactory(BaseTilerFactory):
                 ) as src_dst:
                     info = src_dst.info()
                     return Feature(
-                        geometry=Polygon.from_bounds(*info.bounds), properties=info
+                        type="Feature",
+                        geometry=Polygon.from_bounds(*info.bounds),
+                        properties=info,
                     )
 
     ############################################################################


### PR DESCRIPTION
closes #631 

This PR adds a `coord-crs=` option to `/point`, `/crop`, `/feature` and `/statistics[POST]` method to allow user to specify the CRS for the input coordinates.

Notes: Sadly it's not as simple for the mosaic endpoint (see https://github.com/developmentseed/cogeo-mosaic/issues/209)

@AndrewAnnex could you double check that's it works for you 🙏 