### PR TITLE
Added securityContext for k8s

### DIFF
--- a/deployment/k8s/charts/Chart.yaml
+++ b/deployment/k8s/charts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.11.7
 description: A dynamic Web Map tile server
 name: titiler
-version: 1.1.1
+version: 1.1.2
 icon: https://raw.githubusercontent.com/developmentseed/titiler/main/docs/logos/TiTiler_logo_small.png
 maintainers:
   - name: emmanuelmathot  # Emmanuel Mathot

--- a/deployment/k8s/charts/templates/deployment.yaml
+++ b/deployment/k8s/charts/templates/deployment.yaml
@@ -14,10 +14,14 @@ spec:
       labels:
         {{- include "titiler.selectorLabels" . | nindent 8 }}
     spec:
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
           env:
           {{- range $key, $val := .Values.env }}
             - name: {{ $key }}

--- a/deployment/k8s/charts/values.yaml
+++ b/deployment/k8s/charts/values.yaml
@@ -65,3 +65,17 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #     - ALL
+  # readOnlyRootFilesystem: true
+  # allowPrivilegeEscalation: false
+  # runAsNonRoot: true
+  # runAsUser: 1001
+
+podSecurityContext: {}
+  # fsGroup: 1001
+  # runAsNonRoot: true
+  # runAsUser: 1001


### PR DESCRIPTION
SecurityContext needed for hardening, which you can define in your values.yaml as follows:

```
securityContext:
  capabilities:
    drop:
      - ALL
  readOnlyRootFilesystem: true
  allowPrivilegeEscalation: false
  runAsNonRoot: true
  runAsUser: 1000

podSecurityContext:
  readOnlyRootFilesystem: true
  runAsNonRoot: true
  runAsUser: 1000 
```
- [Default](?expand=1&template=default.md)
- [Version Release](?expand=1&template=version_release.md)