### PR TITLE
Fix pydantic to last working version

### DIFF
--- a/deployment/aws/requirements-cdk.txt
+++ b/deployment/aws/requirements-cdk.txt
@@ -5,5 +5,5 @@ aws_cdk-aws_apigatewayv2_integrations_alpha==2.76.0a0
 constructs>=10.0.0
 
 # pydantic settings
-pydantic
+pydantic==1.10.11
 python-dotenv


### PR DESCRIPTION
Pydantic underwent a major API change in June-July 2023, from v1 to v2.
Explicitly specifying pydantic version to fix API mismatch works just fine.

## Available PR templates

<!--
  Github doesn't allow PR template selection the same way that it is possible with issues.
  Preview this and select the appropriate template
-->

- [Default](?expand=1&template=default.md)
- [Version Release](?expand=1&template=version_release.md)
- _Alternatively delete and start empty_
