### PR TITLE
Fix errors in extension example docs

### DIFF
--- a/docs/src/advanced/Extensions.md
+++ b/docs/src/advanced/Extensions.md
@@ -89,6 +89,7 @@ See [titiler.application](../application) for a full example.
 from dataclasses import dataclass, field
 from typing import Tuple, List, Optional
 
+import rasterio
 from starlette.responses import Response
 from fastapi import Depends, FastAPI, Query
 from titiler.core.factory import BaseTilerFactory, FactoryExtension, TilerFactory
@@ -140,8 +141,8 @@ class thumbnailExtension(FactoryExtension):
             env=Depends(factory.environment_dependency),
         ):
             with rasterio.Env(**env):
-                with self.reader(src_path, **reader_params) as src_dst:
-                    im = src.preview(
+                with factory.reader(src_path, **reader_params) as src:
+                    image = src.preview(
                         max_size=self.max_size,
                         **layer_params,
                         **dataset_params,

--- a/docs/src/advanced/Extensions.md
+++ b/docs/src/advanced/Extensions.md
@@ -161,7 +161,7 @@ class thumbnailExtension(FactoryExtension):
 
             content = image.render(
                 img_format=format.driver,
-                colormap=colormap or dst_colormap,
+                colormap=colormap,
                 **format.profile,
                 **render_params,
             )

--- a/src/titiler/extensions/README.md
+++ b/src/titiler/extensions/README.md
@@ -118,12 +118,12 @@ class thumbnailExtension(FactoryExtension):
             env=Depends(factory.environment_dependency),
         ):
             with rasterio.Env(**env):
-                with self.reader(src_path, **reader_params) as src_dst:
-                        im = src.preview(
-                            max_size=self.max_size,
-                            **layer_params,
-                            **dataset_params,
-                        )
+                with factory.reader(src_path, **reader_params) as src:
+                    image = src.preview(
+                        max_size=self.max_size,
+                        **layer_params,
+                        **dataset_params,
+                    )
 
             if post_process:
                 image = post_process(image)
@@ -138,7 +138,7 @@ class thumbnailExtension(FactoryExtension):
 
             content = image.render(
                 img_format=format.driver,
-                colormap=colormap or dst_colormap,
+                colormap=colormap,
                 **format.profile,
                 **render_params,
             )


### PR DESCRIPTION
## What I am changing
- Fixed a few errors in the thumbnail custom extension example. These corrections have been implemented in both the documentation and the extension readme.

## How I did it
- import rasterio
- use factory for reader
- fixed var names

## How you can test it

## Related Issues

