### PR TITLE
Corse allow methods in env options. #683

### DIFF
--- a/docs/src/intro.md
+++ b/docs/src/intro.md
@@ -35,6 +35,7 @@ The default application can be customized using environment variables defined in
 
 - `NAME` (str): name of the application. Defaults to `titiler`.
 - `CORS_ORIGINS` (str, `,` delimited origins): allowed CORS origin. Defaults to `*`.
+- `CORS_ALLOW_METHODS` (str, `,` delimited methods): allowed CORS methods. Defaults to `GET`.
 - `CACHECONTROL` (str): Cache control header to add to responses. Defaults to `"public, max-age=3600"`.
 - `ROOT_PATH` (str): path behind proxy.
 - `DEBUG` (str): adds `LoggerMiddleware` and `TotalTimeMiddleware` in the middleware stack.

--- a/src/titiler/application/titiler/application/main.py
+++ b/src/titiler/application/titiler/application/main.py
@@ -120,7 +120,7 @@ if api_settings.cors_origins:
         CORSMiddleware,
         allow_origins=api_settings.cors_origins,
         allow_credentials=True,
-        allow_methods=["GET"],
+        allow_methods=api_settings.cors_allow_methods,
         allow_headers=["*"],
     )
 

--- a/src/titiler/application/titiler/application/settings.py
+++ b/src/titiler/application/titiler/application/settings.py
@@ -9,6 +9,7 @@ class ApiSettings(BaseSettings):
 
     name: str = "TiTiler"
     cors_origins: str = "*"
+    cors_allow_methods: str = "GET"
     cachecontrol: str = "public, max-age=3600"
     root_path: str = ""
     debug: bool = False
@@ -25,3 +26,8 @@ class ApiSettings(BaseSettings):
     def parse_cors_origin(cls, v):
         """Parse CORS origins."""
         return [origin.strip() for origin in v.split(",")]
+
+    @field_validator("cors_allow_methods")
+    def parse_cors_allow_methods(cls, v):
+        """Parse CORS allowed methods."""
+        return [method.strip().upper() for method in v.split(",")]


### PR DESCRIPTION
As for in discussion #683 

The default settings don't allow to use the `statistics` with geojson `POST` endpoint from a web-app, as only the `GET` method is allowed.

This pull request includes a three-lines change to allow users to allow also the `POST` method by setting `TITILER_API_CORS_ALLOW_METHODS='GET,POST'`.

I know about the ongoing discussion on whether or not to include this middleware in the default application. I am ok with my contribution being rejected if it is not in line with your ideas.

However, I would have saved a day of development if this option were available and documented and it might be help other people not expert in HTTP request to quickly test and deploy their own `titiler` backend.