### PR TITLE
Simplify band loading

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 - replace mapbox-gl by maplibre
 - replace Stamen by OpenStreetMap tiles
+- simplify band selection handling (author @tayden, https://github.com/developmentseed/titiler/pull/688)
 
 ## 0.13.1 (2023-08-21)
 

--- a/src/titiler/extensions/titiler/extensions/templates/cog_viewer.html
+++ b/src/titiler/extensions/titiler/extensions/templates/cog_viewer.html
@@ -858,35 +858,17 @@ const addCogeo = () => {
       }
 
       // Populate R/G/B (3b) selectors
-      const rList = document.getElementById('r-selector')
-      for (var i = 0; i < nbands; i++) {
-        let l = document.createElement('option')
-        l.setAttribute('bidx', i + 1)
-        l.setAttribute('bname', band_descr[i][0])
-        l.text = band_descr[i][1] || band_descr[i][0]
-        if (i === 0) l.selected="selected"
-        rList.appendChild(l)
-      }
-
-      const gList = document.getElementById('g-selector')
-      for (var i = 0; i < nbands; i++) {
-        let l = document.createElement('option')
-        l.setAttribute('bidx', i + 1)
-        l.setAttribute('bname', band_descr[i][0])
-        l.text = band_descr[i][1] || band_descr[i][0]
-        if (i === 1) l.selected="selected"
-        gList.appendChild(l)
-      }
-
-      const bList = document.getElementById('b-selector')
-      for (var i = 0; i < nbands; i++) {
-        let l = document.createElement('option')
-        l.setAttribute('bidx', i + 1)
-        l.setAttribute('bname', band_descr[i][0])
-        l.text = band_descr[i][1] || band_descr[i][0]
-        if (i === 2) l.selected="selected"
-        bList.appendChild(l)
-      }
+      ['r-selector', 'g-selector', 'b-selector'].forEach((elId, idx) => {
+        const list = document.getElementById(elId)
+        for (var i = 0; i < nbands; i++) {
+          let l = document.createElement('option')
+          l.setAttribute('bidx', i + 1)
+          l.setAttribute('bname', band_descr[i][0])
+          l.text = band_descr[i][1] || band_descr[i][0]
+          if (i === idx) l.selected="selected"
+          list.appendChild(l)
+        }
+      })
 
       // remove loader
       document.getElementById('loader').classList.toggle('off')

--- a/src/titiler/extensions/titiler/extensions/templates/cog_viewer.html
+++ b/src/titiler/extensions/titiler/extensions/templates/cog_viewer.html
@@ -884,11 +884,7 @@ const addCogeo = () => {
         l.setAttribute('bidx', i + 1)
         l.setAttribute('bname', band_descr[i][0])
         l.text = band_descr[i][1] || band_descr[i][0]
-        if (band_descr.length > 2 && i === 2) {
-          l.selected="selected"
-        } else {
-          l.selected="selected"
-        }
+        if (i === 2) l.selected="selected"
         bList.appendChild(l)
       }
 

--- a/src/titiler/extensions/titiler/extensions/templates/stac_viewer.html
+++ b/src/titiler/extensions/titiler/extensions/templates/stac_viewer.html
@@ -900,7 +900,7 @@ const updateUI = () => {
       l.setAttribute('bidx', scope.assets[i])
       l.setAttribute('bname', scope.assets[i])
       l.text = scope.assets[i]
-      l.selected = "selected"
+      if (i === 2) l.selected = "selected"
       bList.appendChild(l)
     }
 
@@ -957,11 +957,7 @@ const updateUI = () => {
       l.setAttribute('bidx', i + 1)
       l.setAttribute('bname', band_descr[i][0])
       l.text = band_descr[i][1] || band_descr[i][0]
-      if (band_descr.length > 2 && i === 2) {
-          l.selected="selected"
-      } else {
-          l.selected="selected"
-      }
+      if (i === 2) l.selected="selected"
       bList.appendChild(l)
     }
 

--- a/src/titiler/extensions/titiler/extensions/templates/stac_viewer.html
+++ b/src/titiler/extensions/titiler/extensions/templates/stac_viewer.html
@@ -931,35 +931,17 @@ const updateUI = () => {
     }
 
     // Populate R/G/B (3b) selectors
-    const rList = document.getElementById('r-selector')
-    for (var i = 0; i < nbands; i++) {
-      let l = document.createElement('option')
-      l.setAttribute('bidx', i + 1)
-      l.setAttribute('bname', band_descr[i][0])
-      l.text = band_descr[i][1] || band_descr[i][0]
-      if (i === 0) l.selected="selected"
-      rList.appendChild(l)
-    }
-
-    const gList = document.getElementById('g-selector')
-    for (var i = 0; i < nbands; i++) {
-      let l = document.createElement('option')
-      l.setAttribute('bidx', i + 1)
-      l.setAttribute('bname', band_descr[i][0])
-      l.text = band_descr[i][1] || band_descr[i][0]
-      if (i === 1) l.selected="selected"
-      gList.appendChild(l)
-    }
-
-    const bList = document.getElementById('b-selector')
-    for (var i = 0; i < nbands; i++) {
-      let l = document.createElement('option')
-      l.setAttribute('bidx', i + 1)
-      l.setAttribute('bname', band_descr[i][0])
-      l.text = band_descr[i][1] || band_descr[i][0]
-      if (i === 2) l.selected="selected"
-      bList.appendChild(l)
-    }
+    ['r-selector', 'g-selector', 'b-selector'].forEach((elId, idx) => {
+      const list = document.getElementById(elId)
+      for (var i = 0; i < nbands; i++) {
+        let l = document.createElement('option')
+        l.setAttribute('bidx', i + 1)
+        l.setAttribute('bname', band_descr[i][0])
+        l.text = band_descr[i][1] || band_descr[i][0]
+        if (i === idx) l.selected="selected"
+        list.appendChild(l)
+      }
+    })
 
     if (['uint8','int8'].indexOf(info.dtype) === -1) {
       document.getElementById('minmax-data').classList.remove('none')


### PR DESCRIPTION
## What I am changing
<!-- What were the high-level goals of the change? -->
- Simplify and improve default band selection in RGB viewer for both COG and STAC images

## How I did it
<!-- How did you go about achieving these goals? Any considerations made along the way? -->
- Removed the special band selection logic that applied to the blue band but not the others.
- Simplified the loading logic so the first three image bands are loaded into the R+G+B channels, respectively, in the viewer.
- Tested by running the app and manually checking things worked as expected

## How you can test it
<!-- How might a reviewer test your changes to verify that they work as expected? -->
- Run the server, load a COG or STAC item

## Related Issues
<!-- Reference any issues that inspired this PR. Use a keyword to auto-close any issues when this PR is merged (eg "closes #1") -->
- #685 
