### PR TITLE
basic WMS Getfeatureinfo implementation

### DIFF
--- a/src/titiler/extensions/tests/test_wms.py
+++ b/src/titiler/extensions/tests/test_wms.py
@@ -386,3 +386,53 @@ def test_wmsExtension_GetMap():
             -52.301598718454485,
             74.66298001264106,
         ]
+
+
+def test_wmsExtension_GetFeatureInfo():
+    """Test wmsValidateExtension class for GetFeatureInfo request."""
+    tiler_plus_wms = TilerFactory(extensions=[wmsExtension()])
+
+    app = FastAPI()
+    app.include_router(tiler_plus_wms.router)
+
+    with TestClient(app) as client:
+        # Setup the basic GetFeatureInfo request
+        params = {
+            "VERSION": "1.3.0",
+            "REQUEST": "GetFeatureInfo",
+            "LAYERS": cog,
+            "QUERY_LAYERS": cog,
+            "BBOX": "500975.102,8182890.453,501830.647,8183959.884",
+            "CRS": "EPSG:32621",
+            "WIDTH": 334,
+            "HEIGHT": 333,
+            "INFO_FORMAT": "text/html",
+            "I": "0",
+            "J": "0",
+        }
+
+        response = client.get("/wms", params=params)
+
+        assert response.status_code == 200
+        assert response.content == b"2800"
+
+        params = {
+            "VERSION": "1.3.0",
+            "REQUEST": "GetFeatureInfo",
+            "LAYERS": cog,
+            "QUERY_LAYERS": cog,
+            "BBOX": "500975.102,8182890.453,501830.647,8183959.884",
+            "CRS": "EPSG:32621",
+            "WIDTH": 334,
+            "HEIGHT": 333,
+            "INFO_FORMAT": "text/html",
+            "I": "333",
+            "J": "332",
+        }
+
+        response = client.get("/wms", params=params)
+
+        assert response.status_code == 200
+        assert response.content == b"3776"
+
+        # Add additional assertions to check the text response

--- a/src/titiler/extensions/titiler/extensions/templates/wms_1.3.0.xml
+++ b/src/titiler/extensions/titiler/extensions/templates/wms_1.3.0.xml
@@ -29,6 +29,15 @@
         </HTTP>
       </DCPType>
     </GetMap>
+    <GetFeatureInfo>
+      <Format>text/html</Format>
+      <DCPType>
+        <HTTP>
+          <Get><OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="{{ request_url }}"/></Get>
+          <Post><OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="{{ request_url }}"/></Post>
+        </HTTP>
+      </DCPType>
+    </GetFeatureInfo>
   </Request>
   <Exception>
     <Format>XML</Format>
@@ -56,7 +65,7 @@
     <BoundingBox CRS="EPSG:4326" minx="{{service_dict['xmin']}}" miny="{{service_dict['ymin']}}" maxx="{{service_dict['xmax']}}" maxy="{{service_dict['ymax']}}" />
     
     {% for layer in layers_dict.keys() %}
-    <Layer queryable="0" opaque="0" cascaded="0">
+    <Layer queryable="1" opaque="0" cascaded="0">
         <Name>{{layer}}</Name>
         <Title>{{layer}}</Title>
         <Abstract>{{layers_dict[layer]['abstract']}}</Abstract>

--- a/src/titiler/extensions/titiler/extensions/wms.py
+++ b/src/titiler/extensions/titiler/extensions/wms.py
@@ -145,7 +145,8 @@ class wmsExtension(FactoryExtension):
                             "title": "Output format of service metadata/map",
                             "type": "string",
                             "enum": [
-                                "text/html" "application/xml",
+                                "text/html",
+                                "application/xml",
                                 "image/png",
                                 "image/jpeg",
                                 "image/jpg",


### PR DESCRIPTION
## What I am changing

I'm adding a basic GetFeatureInfo implementation to the Titiler WMS extension. This provides compatibility so that various WMS clients can automatically provide a users with queried point values. 


## How I did it

GetFeatureInfo reuses most of the logic from GetMap and queries a point within the returned image tile. 


## How you can test it

You can test this using the cog/wms endpoint in a WMS client like QGIS or nationalmap.gov.au and using the feature info capabilities to query a point. For some reason in QGIS some datasets like https://oin-hotosm.s3.amazonaws.com/56f9b5a963ebf4bc00074e70/0/56f9c2d42b67227a79b4faec.tif require invert axis orientation to be selected. 

