### PR TITLE
Allow a default color_formula to be defined on the factory

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## Next Release
+
+* Allow a default `color_formula` parameter to be set via a dependency (author @samn, https://github.com/developmentseed/titiler/pull/707)
+
+
 ## 0.15.0 (2023-09-28)
 
 ### titiler.core

--- a/src/titiler/core/titiler/core/factory.py
+++ b/src/titiler/core/titiler/core/factory.py
@@ -146,6 +146,7 @@ class BaseTilerFactory(metaclass=abc.ABCMeta):
     # Image rendering Dependencies
     render_dependency: Type[DefaultDependency] = ImageRenderingParams
     colormap_dependency: Callable[..., Optional[ColorMapType]] = ColorMapParams
+    color_formula_dependency: Callable[..., Optional[str]] = ColorFormulaParams
 
     rescale_dependency: Callable[..., Optional[RescaleType]] = RescalingParams
 
@@ -539,7 +540,7 @@ class TilerFactory(BaseTilerFactory):
             buffer=Depends(BufferParams),
             post_process=Depends(self.process_dependency),
             rescale=Depends(self.rescale_dependency),
-            color_formula=Depends(ColorFormulaParams),
+            color_formula=Depends(self.color_formula_dependency),
             colormap=Depends(self.colormap_dependency),
             render_params=Depends(self.render_dependency),
             reader_params=Depends(self.reader_dependency),
@@ -625,7 +626,7 @@ class TilerFactory(BaseTilerFactory):
             buffer=Depends(BufferParams),
             post_process=Depends(self.process_dependency),
             rescale=Depends(self.rescale_dependency),
-            color_formula=Depends(ColorFormulaParams),
+            color_formula=Depends(self.color_formula_dependency),
             colormap=Depends(self.colormap_dependency),
             render_params=Depends(self.render_dependency),
             reader_params=Depends(self.reader_dependency),
@@ -705,7 +706,7 @@ class TilerFactory(BaseTilerFactory):
             buffer=Depends(BufferParams),
             post_process=Depends(self.process_dependency),
             rescale=Depends(self.rescale_dependency),
-            color_formula=Depends(ColorFormulaParams),
+            color_formula=Depends(self.color_formula_dependency),
             colormap=Depends(self.colormap_dependency),
             render_params=Depends(self.render_dependency),
             reader_params=Depends(self.reader_dependency),
@@ -767,7 +768,7 @@ class TilerFactory(BaseTilerFactory):
             buffer=Depends(BufferParams),
             post_process=Depends(self.process_dependency),
             rescale=Depends(self.rescale_dependency),
-            color_formula=Depends(ColorFormulaParams),
+            color_formula=Depends(self.color_formula_dependency),
             colormap=Depends(self.colormap_dependency),
             render_params=Depends(self.render_dependency),
             reader_params=Depends(self.reader_dependency),
@@ -898,7 +899,7 @@ class TilerFactory(BaseTilerFactory):
             image_params=Depends(self.img_preview_dependency),
             post_process=Depends(self.process_dependency),
             rescale=Depends(self.rescale_dependency),
-            color_formula=Depends(ColorFormulaParams),
+            color_formula=Depends(self.color_formula_dependency),
             colormap=Depends(self.colormap_dependency),
             render_params=Depends(self.render_dependency),
             reader_params=Depends(self.reader_dependency),
@@ -965,7 +966,7 @@ class TilerFactory(BaseTilerFactory):
             image_params=Depends(self.img_part_dependency),
             post_process=Depends(self.process_dependency),
             rescale=Depends(self.rescale_dependency),
-            color_formula=Depends(ColorFormulaParams),
+            color_formula=Depends(self.color_formula_dependency),
             colormap=Depends(self.colormap_dependency),
             render_params=Depends(self.render_dependency),
             reader_params=Depends(self.reader_dependency),
@@ -1028,7 +1029,7 @@ class TilerFactory(BaseTilerFactory):
             image_params=Depends(self.img_part_dependency),
             post_process=Depends(self.process_dependency),
             rescale=Depends(self.rescale_dependency),
-            color_formula=Depends(ColorFormulaParams),
+            color_formula=Depends(self.color_formula_dependency),
             colormap=Depends(self.colormap_dependency),
             render_params=Depends(self.render_dependency),
             reader_params=Depends(self.reader_dependency),

--- a/src/titiler/mosaic/titiler/mosaic/factory.py
+++ b/src/titiler/mosaic/titiler/mosaic/factory.py
@@ -24,12 +24,7 @@ from starlette.requests import Request
 from starlette.responses import HTMLResponse, Response
 from typing_extensions import Annotated
 
-from titiler.core.dependencies import (
-    BufferParams,
-    ColorFormulaParams,
-    CoordCRSParams,
-    DefaultDependency,
-)
+from titiler.core.dependencies import BufferParams, CoordCRSParams, DefaultDependency
 from titiler.core.factory import BaseTilerFactory, img_endpoint_params
 from titiler.core.models.mapbox import TileJSON
 from titiler.core.resources.enums import ImageType, MediaType, OptionalHeader
@@ -274,7 +269,7 @@ class MosaicTilerFactory(BaseTilerFactory):
             buffer=Depends(BufferParams),
             post_process=Depends(self.process_dependency),
             rescale=Depends(self.rescale_dependency),
-            color_formula=Depends(ColorFormulaParams),
+            color_formula=Depends(self.color_formula_dependency),
             colormap=Depends(self.colormap_dependency),
             render_params=Depends(self.render_dependency),
             backend_params=Depends(self.backend_dependency),
@@ -393,7 +388,7 @@ class MosaicTilerFactory(BaseTilerFactory):
             buffer=Depends(BufferParams),
             post_process=Depends(self.process_dependency),
             rescale=Depends(self.rescale_dependency),
-            color_formula=Depends(ColorFormulaParams),
+            color_formula=Depends(self.color_formula_dependency),
             colormap=Depends(self.colormap_dependency),
             render_params=Depends(self.render_dependency),
             backend_params=Depends(self.backend_dependency),
@@ -485,7 +480,7 @@ class MosaicTilerFactory(BaseTilerFactory):
             pixel_selection=Depends(self.pixel_selection_dependency),
             buffer=Depends(BufferParams),
             rescale=Depends(self.rescale_dependency),
-            color_formula=Depends(ColorFormulaParams),
+            color_formula=Depends(self.color_formula_dependency),
             colormap=Depends(self.colormap_dependency),
             render_params=Depends(self.render_dependency),
             backend_params=Depends(self.backend_dependency),
@@ -549,7 +544,7 @@ class MosaicTilerFactory(BaseTilerFactory):
             buffer=Depends(BufferParams),
             post_process=Depends(self.process_dependency),
             rescale=Depends(self.rescale_dependency),
-            color_formula=Depends(ColorFormulaParams),
+            color_formula=Depends(self.color_formula_dependency),
             colormap=Depends(self.colormap_dependency),
             render_params=Depends(self.render_dependency),
             backend_params=Depends(self.backend_dependency),


### PR DESCRIPTION
instead of needing it to be passed through query params.

## What I am changing
- Add a `color_formula_dependency` field to `BaseTilerFactory` & `MosaicTilerFactory` (defaulting to the existing `ColorFormulaParams`) so users can override the logic for supplying a color formula. This lets us define a default color formula from a separate config without needing to include it in the query params for every request.

## How I did it
- Added a dependency to get the `color_formula` value, rather than using a `Query` directly that can't be overridden.

## How you can test it
- Via the integration tests, or by using the `color_formula_dependency` in an existing application.

