### PR TITLE
Proposal: Change 404 to 204 NO CONTENT when no asset is found (mosaicjson tiling)

### DIFF
--- a/src/titiler/mosaic/titiler/mosaic/errors.py
+++ b/src/titiler/mosaic/titiler/mosaic/errors.py
@@ -11,8 +11,8 @@ from starlette import status
 
 MOSAIC_STATUS_CODES = {
     MosaicAuthError: status.HTTP_401_UNAUTHORIZED,
-    EmptyMosaicError: status.HTTP_404_NOT_FOUND,
+    EmptyMosaicError: status.HTTP_204_NO_CONTENT,
     MosaicNotFoundError: status.HTTP_404_NOT_FOUND,
-    NoAssetFoundError: status.HTTP_404_NOT_FOUND,
+    NoAssetFoundError: status.HTTP_204_NO_CONTENT,
     MosaicError: status.HTTP_424_FAILED_DEPENDENCY,
 }


### PR DESCRIPTION
Currently, when we mosaic some distant rasters in a large area, leaflet raises a 404 error in the console for every missing tile. Changing from 404 to 204 seems to fix the problem

## Available PR templates

<!--
  Github doesn't allow PR template selection the same way that it is possible with issues.
  Preview this and select the appropriate template
-->

- [Default](?expand=1&template=default.md)
- [Version Release](?expand=1&template=version_release.md)
- _Alternatively delete and start empty_
