### PR TITLE
Add a `reproject` query parameter to be passed as a `reproject_method` argument to rio-tiler

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,10 +10,10 @@ cd titiler
 
 python -m pip install \
    pre-commit \
-   -e src/titiler/core["test"] \
-   -e src/titiler/extensions["test,cogeo,stac"] \
-   -e src/titiler/mosaic["test"] \
-   -e src/titiler/application["test"]
+   -e "src/titiler/core[test]" \
+   -e "src/titiler/extensions[test,cogeo,stac]" \
+   -e "src/titiler/mosaic[test]" \
+   -e "src/titiler/application[test]"
 ```
 
 **pre-commit**

--- a/docs/src/advanced/dependencies.md
+++ b/docs/src/advanced/dependencies.md
@@ -119,7 +119,7 @@ class BidxExprParams(ExpressionParams, BidxParams):
 
 #### dataset_dependency
 
-Overwrite nodata value, apply rescaling or change default resampling.
+Overwrite nodata value, apply rescaling, or change the default method used for resampling or reprojection.
 
 ```python
 @dataclass
@@ -139,12 +139,18 @@ class DatasetParams(DefaultDependency):
         alias="resampling",
         description="Resampling method.",
     )
+    reproject_method: ResamplingName = Query(
+        ResamplingName.nearest,  # type: ignore
+        alias="reproject",
+        description="Reproject method.",
+    )
 
     def __post_init__(self):
         """Post Init."""
         if self.nodata is not None:
             self.nodata = numpy.nan if self.nodata == "nan" else float(self.nodata)
         self.resampling_method = self.resampling_method.value  # type: ignore
+        self.reproject_method = self.reproject_method.value  # type: ignore
 ```
 
 #### render_dependency

--- a/docs/src/endpoints/cog.md
+++ b/docs/src/endpoints/cog.md
@@ -47,6 +47,7 @@ The `/cog` routes are based on `titiler.core.factory.TilerFactory` but with `cog
     - **nodata** (str, int, float): Overwrite internal Nodata value.
     - **unscale** (bool): Apply dataset internal Scale/Offset.
     - **resampling** (str): rasterio resampling method. Default is `nearest`.
+    - **reproject** (str): rasterio resampling method to use for reprojection. Default is `nearest`.
     - **rescale** (array[str]): Comma (',') delimited Min,Max range (e.g `rescale=0,1000`, `rescale=0,1000&rescale=0,3000&rescale=0,2000`).
     - **color_formula** (str): rio-color formula.
     - **colormap** (str): JSON encoded custom Colormap.
@@ -80,6 +81,7 @@ Example:
     - **nodata** (str, int, float): Overwrite internal Nodata value.
     - **unscale** (bool): Apply dataset internal Scale/Offset.
     - **resampling** (str): rasterio resampling method. Default is `nearest`.
+    - **reproject** (str): rasterio resampling method to use for reprojection. Default is `nearest`.
     - **rescale** (array[str]): Comma (',') delimited Min,Max range (e.g `rescale=0,1000`, `rescale=0,1000&rescale=0,3000&rescale=0,2000`).
     - **color_formula** (str): rio-color formula.
     - **colormap** (str): JSON encoded custom Colormap.
@@ -118,6 +120,7 @@ Example:
     - **nodata** (str, int, float): Overwrite internal Nodata value.
     - **unscale** (bool): Apply dataset internal Scale/Offset.
     - **resampling** (str): rasterio resampling method. Default is `nearest`.
+    - **reproject** (str): rasterio resampling method to use for reprojection. Default is `nearest`.
     - **rescale** (array[str]): Comma (',') delimited Min,Max range (e.g `rescale=0,1000`, `rescale=0,1000&rescale=0,3000&rescale=0,2000`).
     - **color_formula** (str): rio-color formula.
     - **colormap** (str): JSON encoded custom Colormap.
@@ -154,6 +157,7 @@ Example:
     - **nodata** (str, int, float): Overwrite internal Nodata value.
     - **unscale** (bool): Apply dataset internal Scale/Offset.
     - **resampling** (str): rasterio resampling method. Default is `nearest`.
+    - **reproject** (str): rasterio resampling method to use for reprojection. Default is `nearest`.
     - **rescale** (array[str]): Comma (',') delimited Min,Max range (e.g `rescale=0,1000`, `rescale=0,1000&rescale=0,3000&rescale=0,2000`).
     - **color_formula** (str): rio-color formula.
     - **colormap** (str): JSON encoded custom Colormap.
@@ -188,6 +192,7 @@ Note: if `height` and `width` are provided `max_size` will be ignored.
     - **nodata** (str, int, float): Overwrite internal Nodata value.
     - **unscale** (bool): Apply dataset internal Scale/Offset.
     - **resampling** (str): rasterio resampling method. Default is `nearest`.
+    - **reproject** (str): rasterio resampling method to use for reprojection. Default is `nearest`.
 
 Example:
 
@@ -212,6 +217,7 @@ Example:
     - **nodata** (str, int, float): Overwrite internal Nodata value.
     - **unscale** (bool): Apply dataset internal Scale/Offset.
     - **resampling** (str): rasterio resampling method. Default is `nearest`.
+    - **reproject** (str): rasterio resampling method to use for reprojection. Default is `nearest`.
     - **rescale** (array[str]): Comma (',') delimited Min,Max range (e.g `rescale=0,1000`, `rescale=0,1000&rescale=0,3000&rescale=0,2000`).
     - **color_formula** (str): rio-color formula.
     - **colormap** (str): JSON encoded custom Colormap.
@@ -246,6 +252,7 @@ Example:
     - **nodata** (str, int, float): Overwrite internal Nodata value.
     - **unscale** (bool): Apply dataset internal Scale/Offset.
     - **resampling** (str): rasterio resampling method. Default is `nearest`.
+    - **reproject** (str): rasterio resampling method to use for reprojection. Default is `nearest`.
     - **rescale** (array[str]): Comma (',') delimited Min,Max range (e.g `rescale=0,1000`, `rescale=0,1000&rescale=0,3000&rescale=0,2000`).
     - **color_formula** (str): rio-color formula.
     - **colormap** (str): JSON encoded custom Colormap.
@@ -304,6 +311,7 @@ Advanced raster statistics
     - **nodata** (str, int, float): Overwrite internal Nodata value.
     - **unscale** (bool): Apply dataset internal Scale/Offset.
     - **resampling** (str): rasterio resampling method. Default is `nearest`.
+    - **reproject** (str): rasterio resampling method to use for reprojection. Default is `nearest`.
     - **categorical** (bool): Return statistics for categorical dataset, default is false.
     - **c** (array[float]): Pixels values for categories.
     - **p** (array[int]): Percentile values.
@@ -330,6 +338,7 @@ Example:
     - **nodata** (str, int, float): Overwrite internal Nodata value.
     - **unscale** (bool): Apply dataset internal Scale/Offset.
     - **resampling** (str): rasterio resampling method. Default is `nearest`.
+    - **reproject** (str): rasterio resampling method to use for reprojection. Default is `nearest`.
     - **categorical** (bool): Return statistics for categorical dataset, default is false.
     - **c** (array[float]): Pixels values for categories.
     - **p** (array[int]): Percentile values.

--- a/docs/src/endpoints/stac.md
+++ b/docs/src/endpoints/stac.md
@@ -49,6 +49,7 @@ The `/stac` routes are based on `titiler.core.factory.MultiBaseTilerFactory` but
     - **nodata** (str, int, float): Overwrite internal Nodata value.
     - **unscale** (bool): Apply dataset internal Scale/Offset.
     - **resampling** (str): rasterio resampling method. Default is `nearest`.
+    - **reproject** (str): rasterio resampling method to use for reprojection. Default is `nearest`.
     - **rescale** (array[str]): Comma (',') delimited Min,Max range (e.g `rescale=0,1000`, `rescale=0,1000&rescale=0,3000&rescale=0,2000`).
     - **color_formula** (str): rio-color formula.
     - **colormap** (str): JSON encoded custom Colormap.
@@ -87,6 +88,7 @@ Example:
     - **nodata** (str, int, float): Overwrite internal Nodata value.
     - **unscale** (bool): Apply dataset internal Scale/Offset.
     - **resampling** (str): rasterio resampling method. Default is `nearest`.
+    - **reproject** (str): rasterio resampling method to use for reprojection. Default is `nearest`.
     - **rescale** (array[str]): Comma (',') delimited Min,Max range (e.g `rescale=0,1000`, `rescale=0,1000&rescale=0,3000&rescale=0,2000`).
     - **color_formula** (str): rio-color formula.
     - **colormap** (str): JSON encoded custom Colormap.
@@ -129,6 +131,7 @@ Example:
     - **nodata** (str, int, float): Overwrite internal Nodata value.
     - **unscale** (bool): Apply dataset internal Scale/Offset.
     - **resampling** (str): rasterio resampling method. Default is `nearest`.
+    - **reproject** (str): rasterio resampling method to use for reprojection. Default is `nearest`.
     - **rescale** (array[str]): Comma (',') delimited Min,Max range (e.g `rescale=0,1000`, `rescale=0,1000&rescale=0,3000&rescale=0,2000`).
     - **color_formula** (str): rio-color formula.
     - **colormap** (str): JSON encoded custom Colormap.
@@ -168,6 +171,7 @@ Example:
     - **nodata** (str, int, float): Overwrite internal Nodata value.
     - **unscale** (bool): Apply dataset internal Scale/Offset.
     - **resampling** (str): rasterio resampling method. Default is `nearest`.
+    - **reproject** (str): rasterio resampling method to use for reprojection. Default is `nearest`.
     - **rescale** (array[str]): Comma (',') delimited Min,Max range (e.g `rescale=0,1000`, `rescale=0,1000&rescale=0,3000&rescale=0,2000`).
     - **color_formula** (str): rio-color formula.
     - **colormap** (str): JSON encoded custom Colormap.
@@ -204,6 +208,7 @@ Example:
     - **nodata** (str, int, float): Overwrite internal Nodata value.
     - **unscale** (bool): Apply dataset internal Scale/Offset.
     - **resampling** (str): rasterio resampling method. Default is `nearest`.
+    - **reproject** (str): rasterio resampling method to use for reprojection. Default is `nearest`.
 
 !!! important
     **assets** OR **expression** is required
@@ -232,6 +237,7 @@ Example:
     - **nodata** (str, int, float): Overwrite internal Nodata value.
     - **unscale** (bool): Apply dataset internal Scale/Offset.
     - **resampling** (str): rasterio resampling method. Default is `nearest`.
+    - **reproject** (str): rasterio resampling method to use for reprojection. Default is `nearest`.
     - **rescale** (array[str]): Comma (',') delimited Min,Max range (e.g `rescale=0,1000`, `rescale=0,1000&rescale=0,3000&rescale=0,2000`).
     - **color_formula** (str): rio-color formula.
     - **colormap** (str): JSON encoded custom Colormap.
@@ -270,6 +276,7 @@ Example:
     - **nodata** (str, int, float): Overwrite internal Nodata value.
     - **unscale** (bool): Apply dataset internal Scale/Offset.
     - **resampling** (str): rasterio resampling method. Default is `nearest`.
+    - **reproject** (str): rasterio resampling method to use for reprojection. Default is `nearest`.
     - **rescale** (array[str]): Comma (',') delimited Min,Max range (e.g `rescale=0,1000`, `rescale=0,1000&rescale=0,3000&rescale=0,2000`).
     - **color_formula** (str): rio-color formula.
     - **colormap** (str): JSON encoded custom Colormap.
@@ -345,6 +352,7 @@ Example:
     - **nodata** (str, int, float): Overwrite internal Nodata value.
     - **unscale** (bool): Apply dataset internal Scale/Offset.
     - **resampling** (str): rasterio resampling method. Default is `nearest`.
+    - **reproject** (str): rasterio resampling method to use for reprojection. Default is `nearest`.
     - **categorical** (bool): Return statistics for categorical dataset, default is false.
     - **c** (array[float]): Pixels values for categories.
     - **p** (array[int]): Percentile values.
@@ -370,6 +378,7 @@ Example:
     - **nodata** (str, int, float): Overwrite internal Nodata value.
     - **unscale** (bool): Apply dataset internal Scale/Offset.
     - **resampling** (str): rasterio resampling method. Default is `nearest`.
+    - **reproject** (str): rasterio resampling method to use for reprojection. Default is `nearest`.
     - **categorical** (bool): Return statistics for categorical dataset, default is false.
     - **c** (array[float]): Pixels values for categories.
     - **p** (array[int]): Percentile values.
@@ -399,6 +408,7 @@ Example:
     - **nodata** (str, int, float): Overwrite internal Nodata value.
     - **unscale** (bool): Apply dataset internal Scale/Offset.
     - **resampling** (str): rasterio resampling method. Default is `nearest`.
+    - **reproject** (str): rasterio resampling method to use for reprojection. Default is `nearest`.
     - **categorical** (bool): Return statistics for categorical dataset, default is false.
     - **c** (array[float]): Pixels values for categories.
     - **p** (array[int]): Percentile values.

--- a/src/titiler/core/tests/test_dependencies.py
+++ b/src/titiler/core/tests/test_dependencies.py
@@ -385,11 +385,16 @@ def test_dataset():
     assert not response.json()["nodata"]
     assert not response.json()["unscale"]
     assert response.json()["resampling_method"] == "nearest"
+    assert response.json()["reproject_method"] == "nearest"
 
     response = client.get("/?resampling=cubic")
     assert not response.json()["nodata"]
     assert not response.json()["unscale"]
     assert response.json()["resampling_method"] == "cubic"
+    assert response.json()["reproject_method"] == "nearest"
+
+    response = client.get("/?reproject=bilinear")
+    assert response.json()["reproject_method"] == "bilinear"
 
     response = client.get("/?nodata=10")
     assert response.json()["nodata"] == 10.0

--- a/src/titiler/core/titiler/core/dependencies.py
+++ b/src/titiler/core/titiler/core/dependencies.py
@@ -11,7 +11,7 @@ from rio_tiler.colormap import ColorMaps
 from rio_tiler.colormap import cmap as default_cmap
 from rio_tiler.colormap import parse_color
 from rio_tiler.errors import MissingAssets, MissingBands
-from rio_tiler.types import RIOResampling
+from rio_tiler.types import RIOResampling, WarpResampling
 from typing_extensions import Annotated
 
 
@@ -365,12 +365,20 @@ class DatasetParams(DefaultDependency):
             description="Resampling method.",
         ),
     ] = "nearest"
+    reproject_method: Annotated[
+        WarpResampling,
+        Query(
+            alias="reproject",
+            description="Reprojection method.",
+        ),
+    ] = "nearest"
 
     def __post_init__(self):
         """Post Init."""
         if self.nodata is not None:
             self.nodata = numpy.nan if self.nodata == "nan" else float(self.nodata)
         self.resampling_method = self.resampling_method
+        self.reproject_method = self.reproject_method
 
 
 @dataclass

--- a/src/titiler/core/titiler/core/factory.py
+++ b/src/titiler/core/titiler/core/factory.py
@@ -137,7 +137,7 @@ class BaseTilerFactory(metaclass=abc.ABCMeta):
     # Path Dependency
     path_dependency: Callable[..., Any] = DatasetPathParams
 
-    # Rasterio Dataset Options (nodata, unscale, resampling)
+    # Rasterio Dataset Options (nodata, unscale, resampling, reproject)
     dataset_dependency: Type[DefaultDependency] = DatasetParams
 
     # Indexes/Expression Dependencies


### PR DESCRIPTION
## What I am changing
<!-- What were the high-level goals of the change? -->
`rio-tiler` v5 adds support for a [new `reproject_method` argument](https://cogeotiff.github.io/rio-tiler/migrations/v5_migration/#reprojection-and-resizing-resampling-methods). This PR adds a `reproject` query parameter that's passed as a `reproject_method` argument to rio-tiler, similar to how the `resampling` query param is passed to rio-tiler as `resampling_method`.

## How I did it
<!-- How did you go about achieving these goals? Any considerations made along the way? -->
I followed the prior art from `resampling` and added this in `/src/titiler/core/titiler/core/dependencies.py` as a DatasetParam with a default value and query param alias.

## How you can test it
<!-- How might a reviewer test your changes to verify that they work as expected? -->
I tested this in two ways:
1. I added a test to `/src/titiler/core/tests/test_dependencies.py` to prove that the `reproject` query parameter was successfully being passed as a `reproject_method` argument to rio-tiler. I also test that the value defaults to `"nearest"` if left unspecified.
2. I deployed the change to a Lambda-hosted instance of TiTiler and confirmed that `reproject` had the desired effect on a requested tile. See https://github.com/cogeotiff/rio-tiler/discussions/646#discussioncomment-7305095

## Related Issues
<!-- Reference any issues that inspired this PR. Use a keyword to auto-close any issues when this PR is merged (eg "closes #1") -->


**NOTE**: I believe I need to update the docs, but need some help with this. This command...
```sh
pdocs as_markdown --output_dir docs/src/api --exclude_source --overwrite titiler.core.dependencies titiler.core.factory titiler.core.utils titiler.core.routing titiler.core.errors titiler.core.resources.enums titiler.core.middleware
```

... produces a pretty massive diff:
<img width="1075" alt="image" src="https://github.com/developmentseed/titiler/assets/7377524/8dca0c50-802d-490f-afb2-e1defd1463d2">

Maybe I need a specific version of `pdocs`? Sorry, I'm new to `pdocs`.