### PR TITLE
Support non-root paths in AWS API Gateway Lambda handler

### DIFF
--- a/deployment/aws/lambda/handler.py
+++ b/deployment/aws/lambda/handler.py
@@ -5,8 +5,11 @@ import logging
 from mangum import Mangum
 
 from titiler.application.main import app
+from titiler.application.settings import ApiSettings
 
 logging.getLogger("mangum.lifespan").setLevel(logging.ERROR)
 logging.getLogger("mangum.http").setLevel(logging.ERROR)
 
-handler = Mangum(app, lifespan="auto")
+api_settings = ApiSettings()
+
+handler = Mangum(app, api_gateway_base_path=api_settings.root_path, lifespan="auto")


### PR DESCRIPTION
## What I am changing
<!-- What were the high-level goals of the change? -->
This PR introduces the ability to host TiTiler on a non-root (non-/) AWS API Gateway route. It's the second attempt after closing developmentseed/titiler#515.

## How I did it
<!-- How did you go about achieving these goals? Any considerations made along the way? -->
As [suggested by Vincent](https://github.com/developmentseed/titiler/pull/515#issuecomment-1332268220), I passed the `TITILER_API_ROOT_PATH` environment variable to Mangum's `api_gateway_base_path` argument.

## How you can test it
<!-- How might a reviewer test your changes to verify that they work as expected? -->
Deploy TiTiler as a proxy Lambda to a non-root AWS API Gateway route. Query the various endpoints to confirm they resolve correctly.

FWIW, I tested this change on AWS.

## Related Issues
<!-- Reference any issues that inspired this PR. Use a keyword to auto-close any issues when this PR is merged (eg "closes #1") -->
Closes #513
