### PR TITLE
Add global access token setting and validation

### DIFF
--- a/docs/src/examples/code/tiler_with_auth.md
+++ b/docs/src/examples/code/tiler_with_auth.md
@@ -140,12 +140,12 @@ def DatasetPathParams(
     """Create dataset path from args"""
 
     if not api_key_query:
-        raise HTTPException(status_code=403, detail="Missing `access_token`")
+        raise HTTPException(status_code=401, detail="Missing `access_token`")
 
     try:
         AccessToken.from_string(api_key_query)
     except JWTError:
-        raise HTTPException(status_code=403, detail="Invalid `access_token`")
+        raise HTTPException(status_code=401, detail="Invalid `access_token`")
 
     return url
 ```

--- a/docs/src/intro.md
+++ b/docs/src/intro.md
@@ -109,11 +109,11 @@ api_key_query = APIKeyQuery(name="access_token", auto_error=False)
 def token_validation(access_token: str = Security(api_key_query)):
     """stupid token validation."""
     if not access_token:
-        raise HTTPException(status_code=403, detail="Missing `access_token`")
+        raise HTTPException(status_code=401, detail="Missing `access_token`")
 
     # if access_token == `token` then OK
     if not access_token == "token":
-        raise HTTPException(status_code=403, detail="Invalid `access_token`")
+        raise HTTPException(status_code=401, detail="Invalid `access_token`")
 
     return True
 

--- a/docs/src/intro.md
+++ b/docs/src/intro.md
@@ -43,6 +43,7 @@ The default application can be customized using environment variables defined in
 - `DISABLE_STAC` (bool): disable `/stac` endpoints.
 - `DISABLE_MOSAIC` (bool): disable `/mosaic` endpoints.
 - `LOWER_CASE_QUERY_PARAMETERS` (bool): transform all query-parameters to lower case (see https://github.com/developmentseed/titiler/pull/321).
+- `GLOBAL_ACCESS_TOKEN` (str | None): a string which is required in the `?access_token=` query param with every request.
 
 ## Customized, minimal app
 

--- a/src/titiler/application/titiler/application/main.py
+++ b/src/titiler/application/titiler/application/main.py
@@ -3,7 +3,7 @@
 import logging
 
 import jinja2
-from fastapi import FastAPI, Depends, HTTPException, Security
+from fastapi import Depends, FastAPI, HTTPException, Security
 from fastapi.security.api_key import APIKeyQuery
 from rio_tiler.io import STACReader
 from starlette.middleware.cors import CORSMiddleware
@@ -51,13 +51,15 @@ api_settings = ApiSettings()
 ###############################################################################
 # Setup a global API access key, if configured
 api_key_query = APIKeyQuery(name="access_token", auto_error=False)
+
+
 def validate_access_token(access_token: str = Security(api_key_query)):
     """Validates API key access token, set as the `api_settings.global_access_token` value.
     Returns True if no access token is required, or if the access token is valid.
     Raises an HTTPException (403) if the access token is required but invalid/missing."""
     if api_settings.global_access_token is None:
         return True
-    
+
     if not access_token:
         raise HTTPException(status_code=403, detail="Missing `access_token`")
 
@@ -66,6 +68,8 @@ def validate_access_token(access_token: str = Security(api_key_query)):
         raise HTTPException(status_code=403, detail="Invalid `access_token`")
 
     return True
+
+
 ###############################################################################
 
 app = FastAPI(
@@ -118,7 +122,9 @@ if not api_settings.disable_stac:
     )
 
     app.include_router(
-        stac.router, prefix="/stac", tags=["SpatioTemporal Asset Catalog"],
+        stac.router,
+        prefix="/stac",
+        tags=["SpatioTemporal Asset Catalog"],
     )
 
 ###############################################################################
@@ -126,21 +132,25 @@ if not api_settings.disable_stac:
 if not api_settings.disable_mosaic:
     mosaic = MosaicTilerFactory(router_prefix="/mosaicjson")
     app.include_router(
-        mosaic.router, prefix="/mosaicjson", tags=["MosaicJSON"],
+        mosaic.router,
+        prefix="/mosaicjson",
+        tags=["MosaicJSON"],
     )
 
 ###############################################################################
 # TileMatrixSets endpoints
 tms = TMSFactory()
 app.include_router(
-    tms.router, tags=["Tiling Schemes"],
+    tms.router,
+    tags=["Tiling Schemes"],
 )
 
 ###############################################################################
 # Algorithms endpoints
 algorithms = AlgorithmFactory()
 app.include_router(
-    algorithms.router, tags=["Algorithms"],
+    algorithms.router,
+    tags=["Algorithms"],
 )
 
 add_exception_handlers(app, DEFAULT_STATUS_CODES)

--- a/src/titiler/application/titiler/application/main.py
+++ b/src/titiler/application/titiler/application/main.py
@@ -56,16 +56,16 @@ api_key_query = APIKeyQuery(name="access_token", auto_error=False)
 def validate_access_token(access_token: str = Security(api_key_query)):
     """Validates API key access token, set as the `api_settings.global_access_token` value.
     Returns True if no access token is required, or if the access token is valid.
-    Raises an HTTPException (403) if the access token is required but invalid/missing."""
+    Raises an HTTPException (401) if the access token is required but invalid/missing."""
     if api_settings.global_access_token is None:
         return True
 
     if not access_token:
-        raise HTTPException(status_code=403, detail="Missing `access_token`")
+        raise HTTPException(status_code=401, detail="Missing `access_token`")
 
     # if access_token == `token` then OK
     if access_token != api_settings.global_access_token:
-        raise HTTPException(status_code=403, detail="Invalid `access_token`")
+        raise HTTPException(status_code=401, detail="Invalid `access_token`")
 
     return True
 

--- a/src/titiler/application/titiler/application/main.py
+++ b/src/titiler/application/titiler/application/main.py
@@ -52,6 +52,9 @@ api_settings = ApiSettings()
 # Setup a global API access key, if configured
 api_key_query = APIKeyQuery(name="access_token", auto_error=False)
 def validate_access_token(access_token: str = Security(api_key_query)):
+    """Validates API key access token, set as the `api_settings.global_access_token` value.
+    Returns True if no access token is required, or if the access token is valid.
+    Raises an HTTPException (403) if the access token is required but invalid/missing."""
     if api_settings.global_access_token is None:
         return True
     

--- a/src/titiler/application/titiler/application/settings.py
+++ b/src/titiler/application/titiler/application/settings.py
@@ -2,7 +2,7 @@
 
 from pydantic import field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
-
+from typing import Union
 
 class ApiSettings(BaseSettings):
     """FASTAPI application settings."""
@@ -21,7 +21,7 @@ class ApiSettings(BaseSettings):
     lower_case_query_parameters: bool = False
 
     # an API key required to access any endpoint, passed via the ?access_token= query parameter
-    global_access_token: str | None = None
+    global_access_token: Union[str, None] = None
 
     model_config = SettingsConfigDict(env_prefix="TITILER_API_", env_file=".env")
 

--- a/src/titiler/application/titiler/application/settings.py
+++ b/src/titiler/application/titiler/application/settings.py
@@ -1,6 +1,6 @@
 """Titiler API settings."""
 
-from typing import Union
+from typing import Optional
 
 from pydantic import field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -23,7 +23,7 @@ class ApiSettings(BaseSettings):
     lower_case_query_parameters: bool = False
 
     # an API key required to access any endpoint, passed via the ?access_token= query parameter
-    global_access_token: Union[str, None] = None
+    global_access_token: Optional[str] = None
 
     model_config = SettingsConfigDict(env_prefix="TITILER_API_", env_file=".env")
 

--- a/src/titiler/application/titiler/application/settings.py
+++ b/src/titiler/application/titiler/application/settings.py
@@ -1,8 +1,10 @@
 """Titiler API settings."""
 
+from typing import Union
+
 from pydantic import field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
-from typing import Union
+
 
 class ApiSettings(BaseSettings):
     """FASTAPI application settings."""

--- a/src/titiler/application/titiler/application/settings.py
+++ b/src/titiler/application/titiler/application/settings.py
@@ -20,6 +20,9 @@ class ApiSettings(BaseSettings):
 
     lower_case_query_parameters: bool = False
 
+    # an API key required to access any endpoint, passed via the ?access_token= query parameter
+    global_access_token: str | None = None
+
     model_config = SettingsConfigDict(env_prefix="TITILER_API_", env_file=".env")
 
     @field_validator("cors_origins")


### PR DESCRIPTION
This PR is a feature addition, which allows the addition of a global access token to all endpoints.

This feature is important because it allows implementing a basic security, in cases where the endpoint is routed through a machine-to-machine connection. For example, a Ruby API handles all incoming requests and performs the user permissions validation, and then proxies the requests onto a TiTiler server; no requests from outside the Ruby API should be allowed to access the TiTiler endpoints directly.

Please advise if any changed are required for acceptance of this small feature addition! 