### PR TITLE
Fix leafletjs template maxZoom to great than 18 zoom

### DIFF
--- a/src/titiler/core/titiler/core/templates/map.html
+++ b/src/titiler/core/titiler/core/templates/map.html
@@ -113,7 +113,7 @@ fetch('{{ tilejson_endpoint|safe }}')
     L.tileLayer(
       data.tiles[0], {
         minZoom: data.minzoom,
-        maxNativeZoom: data.maxzoom,
+        maxZoom: data.maxzoom,
         bounds: L.latLngBounds([bottom, left], [top, right]),
       }
     ).addTo(map);


### PR DESCRIPTION
## What I am changing
Fix the leaflet map template to allow zooming beyond zoom 18.

## How I did it
The tilelayer incorrectly set `maxNativeZoom` instead of `maxZoom`. The `maxZoom` default is 18 and would not load tiles beyond 18 regardless of the layer's zoom setting.

## How you can test it
Tested in browser with correct setting.

## Related Issues
