### PR TITLE
Add `use_epsg` parameter to WMTS endpoint

### DIFF
--- a/src/titiler/application/tests/routes/test_cog.py
+++ b/src/titiler/application/tests/routes/test_cog.py
@@ -67,6 +67,10 @@ def test_wmts(rio, app):
         "http://testserver/cog/tiles/WebMercatorQuad/{TileMatrix}/{TileCol}/{TileRow}@1x.png?url=https"
         in response.content.decode()
     )
+    assert (
+        "<ows:SupportedCRS>http://www.opengis.net/def/crs/EPSG/0/3857</ows:SupportedCRS>"
+        in response.content.decode()
+    )
 
     response = app.get(
         "/cog/WMTSCapabilities.xml?url=https://myurl.com/cog.tif&tile_scale=2&tile_format=jpg"
@@ -77,6 +81,13 @@ def test_wmts(rio, app):
         "http://testserver/cog/tiles/WebMercatorQuad/{TileMatrix}/{TileCol}/{TileRow}@2x.jpg?url=https"
         in response.content.decode()
     )
+
+    response = app.get(
+        "/cog/WMTSCapabilities.xml?url=https://myurl.com/cog.tif&use_epsg=true"
+    )
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/xml"
+    assert "<ows:SupportedCRS>EPSG:3857</ows:SupportedCRS>" in response.content.decode()
 
 
 @patch("rio_tiler.io.rasterio.rasterio")

--- a/src/titiler/core/titiler/core/templates/wmts.xml
+++ b/src/titiler/core/titiler/core/templates/wmts.xml
@@ -8,7 +8,7 @@
         <ows:Operation name="GetCapabilities">
             <ows:DCP>
                 <ows:HTTP>
-                    <ows:Get xlink:href="{{ request.url }}">
+                    <ows:Get xlink:href="{{ request.url | escape }}">
                         <ows:Constraint name="GetEncoding">
                             <ows:AllowedValues>
                                 <ows:Value>RESTful</ows:Value>
@@ -21,7 +21,7 @@
         <ows:Operation name="GetTile">
             <ows:DCP>
                 <ows:HTTP>
-                    <ows:Get xlink:href="{{ request.url }}">
+                    <ows:Get xlink:href="{{ request.url | escape }}">
                         <ows:Constraint name="GetEncoding">
                             <ows:AllowedValues>
                                 <ows:Value>RESTful</ows:Value>
@@ -58,5 +58,5 @@
             {% endfor %}
         </TileMatrixSet>
     </Contents>
-    <ServiceMetadataURL xlink:href="{{ request.url }}" />
+    <ServiceMetadataURL xlink:href="{{ request.url | escape }}" />
 </Capabilities>

--- a/src/titiler/core/titiler/core/templates/wmts.xml
+++ b/src/titiler/core/titiler/core/templates/wmts.xml
@@ -52,7 +52,7 @@
         </Layer>
         <TileMatrixSet>
             <ows:Identifier>{{ tms.id }}</ows:Identifier>
-            <ows:SupportedCRS>{{ tms.crs.srs }}</ows:SupportedCRS>
+            <ows:SupportedCRS>{{ supported_crs }}</ows:SupportedCRS>
             {% for item in tileMatrix %}
             {{ item | safe }}
             {% endfor %}


### PR DESCRIPTION
## What I am changing

Adds a `use_epsg` parameter to the WMTS endpoint, which changes the format of the CRS for the tile matrix set. This is needed to support ArcMap, which doesn't like the opengis.net-style CRS in the `SupportedCRS`.

Also adds an `escape` to the URLs in the WMTS template, as multiple query parameters were breaking XML parsing b/c of the `&`.


## How you can test it
<!-- How might a reviewer test your changes to verify that they work as expected? -->
I've added unit tests. To manually test, you can hit a **titiler** WMTS endpoint with the parameter, e.g. `http://localhost:8000/cog/WMTSCapabilities.xml?url=your-url-here&use_epsg=true` and check out the `SupportedCRS` field.

## Related Issues

- Should resolve https://github.com/developmentseed/titiler/discussions/732

## Manual testing with ArcMap

This is an ArcMap WMTS configuration against **titiler** endpoint without any modifications:

![Screenshot 2024-02-20 115746](https://github.com/developmentseed/titiler/assets/58314/0022867e-0ff5-4e36-93d3-fe17f5016018)

The layer doesn't load:

![Screenshot 2024-02-20 115759](https://github.com/developmentseed/titiler/assets/58314/18e2ecdb-26ee-4255-9a8e-c8eb4a8c540f)

Adding the `use_epsg` parameter:

![Screenshot 2024-02-20 120041](https://github.com/developmentseed/titiler/assets/58314/a5154fb0-bb78-42a5-ac9b-fd6b80b9dfe6)

It works!

![Screenshot 2024-02-20 115916](https://github.com/developmentseed/titiler/assets/58314/3e3b3cff-ed2f-447f-abba-352ea66d4eb0)


