### PR TITLE
Adding extra="ignore" option to fix pydantic_settings.SettingsConfigDict issue with environement variables

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 0.17.3 (2024-03-21)
+
+### titiler.application
+
+* Add `extra="ignore"` option `ApiSettings` to fix pydantic issue when using `.env` file (author @imanshafiei540, https://github.com/developmentseed/titiler/pull/800)
+
 ## 0.17.2 (2024-03-15)
 
 ### titiler.core

--- a/src/titiler/application/titiler/application/settings.py
+++ b/src/titiler/application/titiler/application/settings.py
@@ -25,7 +25,9 @@ class ApiSettings(BaseSettings):
     # an API key required to access any endpoint, passed via the ?access_token= query parameter
     global_access_token: Optional[str] = None
 
-    model_config = SettingsConfigDict(env_prefix="TITILER_API_", env_file=".env", extra="ignore")
+    model_config = SettingsConfigDict(
+        env_prefix="TITILER_API_", env_file=".env", extra="ignore"
+    )
 
     @field_validator("cors_origins")
     def parse_cors_origin(cls, v):

--- a/src/titiler/application/titiler/application/settings.py
+++ b/src/titiler/application/titiler/application/settings.py
@@ -25,7 +25,7 @@ class ApiSettings(BaseSettings):
     # an API key required to access any endpoint, passed via the ?access_token= query parameter
     global_access_token: Optional[str] = None
 
-    model_config = SettingsConfigDict(env_prefix="TITILER_API_", env_file=".env")
+    model_config = SettingsConfigDict(env_prefix="TITILER_API_", env_file=".env", extra="ignore")
 
     @field_validator("cors_origins")
     def parse_cors_origin(cls, v):


### PR DESCRIPTION
Closes https://github.com/developmentseed/titiler/issues/799

Context:

`pydantic-settings` Released a new update (`2.2.0`) that breaks TiTiler API when using a `.env` file that contains variables inside.

This PR will solve the issue by adding `extra="ignore"` to the `pydantic_settings.SettingsConfigDict` object.
