### PR TITLE
fastapi-slim replaces fastapi

### DIFF
--- a/src/titiler/core/pyproject.toml
+++ b/src/titiler/core/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "fastapi>=0.107.0",
+    "fastapi-slim",
     "geojson-pydantic>=1.0,<2.0",
     "jinja2>=2.11.2,<4.0.0",
     "numpy",


### PR DESCRIPTION
## What I am changing
<!-- What were the high-level goals of the change? -->
Replace the `fastapi` dependency with `fastapi-slim`. 

See https://github.com/tiangolo/fastapi/pull/11522 for details. My brief summary of what happened in the FastAPI project: Installing `fastapi` now comes along with dependencies that are helpful for development and deployment, at the expense of installing more dependencies. Since tiler applications are opinionated in their dependencies additional dependencies raise the risk of conflicts, albeit slightly. This change keeps the same dependencies that FastAPI pulls in transitively.

## How I did it
<!-- How did you go about achieving these goals? Any considerations made along the way? -->
Swap the dependency specification, meaning nothing would change :smile:.

## How you can test it
<!-- How might a reviewer test your changes to verify that they work as expected? -->
Unit tests, standard CI should be more than enough because this result in nothing changing.

## Related Issues
<!-- Reference any issues that inspired this PR. Use a keyword to auto-close any issues when this PR is merged (eg "closes #1") -->
N/A.