### PR TITLE
fix: Encode URL for cog_viewer and stac_viewer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Encode URL for cog_viewer and stac_viewer (author @guillemc23, https://github.com/developmentseed/titiler/pull/961)
+
 * Remove all default values to the dependencies
     * `DatasetParams.unscale`: `False` -> `None` (default to `False` in rio-tiler)
     * `DatasetParams.resampling_method`: `nearest` -> `None` (default to `nearest` in rio-tiler)

--- a/src/titiler/extensions/titiler/extensions/templates/cog_viewer.html
+++ b/src/titiler/extensions/titiler/extensions/templates/cog_viewer.html
@@ -894,7 +894,7 @@ const addCogeo = () => {
 }
 
 document.getElementById('launch').addEventListener('click', () => {
-  scope.url = document.getElementById('cogeo').value
+  scope.url = encodeURIComponent(document.getElementById('cogeo').value)
   document.getElementById('selector').classList.toggle('none')
   addCogeo()
 })

--- a/src/titiler/extensions/titiler/extensions/templates/stac_viewer.html
+++ b/src/titiler/extensions/titiler/extensions/templates/stac_viewer.html
@@ -1012,7 +1012,7 @@ const addStac = () => {
 }
 
 document.getElementById('launch').addEventListener('click', () => {
-  scope.url = document.getElementById('stac').value
+  scope.url = encodeURIComponent(document.getElementById('stac').value)
   document.getElementById('selector').classList.toggle('none')
   document.getElementById('loader').classList.add('off')
   addStac()


### PR DESCRIPTION
## What I am changing
<!-- What were the high-level goals of the change? -->
- I am testing my own TiTiler instance reading some COGs stored at my own S3 storage. I realized that when passing the signed URL for the resource to the `/viewer` endpoint, it won't work as the first query to `/info` doesn't go through. I tried encoding my urls with an online tool (https://www.urlencoder.org/) and it works perfectly fine. Calling the `/info` endpoint from the docs works as expected with the URL as-is, so I took a look at the Viewer template.
- When testing these urls using the docs, the curl command I get as result looks to have the URL properly encoded.

## How I did it
<!-- How did you go about achieving these goals? Any considerations made along the way? -->
- In the Viewer template, I added the [`encodeURIComponent`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent) function to the introduced URL that does the same thing as the URL encoder referenced above. The [change](https://github.com/guillemc23/titiler/blob/a68ac72571393acb25729f5d87b144348c131af8/src/titiler/extensions/titiler/extensions/templates/cog_viewer.html#L897) is minimal.
-  I [changed](https://github.com/guillemc23/titiler/blob/a68ac72571393acb25729f5d87b144348c131af8/src/titiler/extensions/titiler/extensions/templates/stac_viewer.html#L1015) as well the template for the STAC viewer as I noticed the code for both is very similar. 

## How you can test it
<!-- How might a reviewer test your changes to verify that they work as expected? -->
- Just changing the template should have a minimal impact, but, adding to the viewer a signed url to a S3 resource should work now. My S3 urls look like: `http://s3.mydomain.com/user-data/cog/MAD.tiff?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=XXXXXXX&X-Amz-Date=20240731T071151Z&X-Amz-Expires=1800&X-Amz-SignedHeaders=host&X-Amz-Signature=XXXXXXXXXX`
- I believe this should be the case with any other URL that contains special characters or multiple parameters.

## Related Issues
<!-- Reference any issues that inspired this PR. Use a keyword to auto-close any issues when this PR is merged (eg "closes #1") -->
- None yet, I was faster with the PR than opening a new issue 😄 
