### PR TITLE
feature: add links for render parameters and /cog/map link to /cog/viewer dashboard

### DIFF
--- a/src/titiler/extensions/titiler/extensions/templates/cog_viewer.html
+++ b/src/titiler/extensions/titiler/extensions/templates/cog_viewer.html
@@ -955,8 +955,7 @@ document.getElementById('btn-share-link').addEventListener('click', () => {
     params.append('rescale', `${document.getElementById("data-min").value},${document.getElementById("data-max").value}`);
   }
 
-  const path_name = `${window.location.pathname}`.replace("viewer", "map");
-  console.log("path_name: ", path_name);
+  const path_name = `${window.location.pathname}`.replace("viewer", "WebMercatorQuad/map");
   const shareUrl = `${window.location.origin}${path_name}?${params.toString()}`;
   
   // Create a temporary input element to copy the URL
@@ -972,43 +971,70 @@ document.getElementById('btn-share-link').addEventListener('click', () => {
 
 document.getElementById('btn-export').addEventListener('click', () => {
   const rasterType = document.getElementById("toolbar").querySelector(".active").id;
-  params = {}
-  if (rasterType === "1b") {
+  let params = {};
 
-    params.bidx = document.getElementById("layer-selector").selectedOptions[0].getAttribute("bidx");
+  if (rasterType === "1b") {
+    // Convert bidx to a single-element array
+    params.bidx = [parseInt(document.getElementById("layer-selector").selectedOptions[0].getAttribute("bidx"))];
+
     const colormap_name = document.getElementById('colormap-selector').value;
-    if (colormap_name != "b&w") {
+    if (colormap_name !== "b&w") {
       params.colormap_name = colormap_name;
     }
+  } else if (rasterType === "3b") {
+    params.bidx = [
+      parseFloat(document.getElementById("r-selector").selectedOptions[0].getAttribute("bidx")),
+      parseFloat(document.getElementById("g-selector").selectedOptions[0].getAttribute("bidx")),
+      parseFloat(document.getElementById("b-selector").selectedOptions[0].getAttribute("bidx")),
+    ]
   } 
+
   // Add rescale parameter for both 1b and 3b if applicable
   if (["uint8", "int8"].indexOf(scope.data_type) === -1 && !scope.colormap) {
-    params.rescale = `${document.getElementById("data-min").value},${document.getElementById("data-max").value}`;
+    // Convert rescale to a nested array
+    params.rescale = [[
+      parseFloat(document.getElementById("data-min").value),
+      parseFloat(document.getElementById("data-max").value)
+    ]];
   }
+
   showJsonPopup(params);
 });
-  function showJsonPopup(jsonContent) {
-    const popup = document.createElement('div');
-    popup.style.position = 'fixed';
-    popup.style.left = '50%';
-    popup.style.top = '50%';
-    popup.style.transform = 'translate(-50%, -50%)';
-    popup.style.backgroundColor = 'white';
-    popup.style.padding = '20px';
-    popup.style.border = '1px solid black';
-    popup.style.zIndex = '1000';
+function showJsonPopup(jsonContent) {
+  const popup = document.createElement('div');
+  popup.style.position = 'fixed';
+  popup.style.left = '50%';
+  popup.style.top = '50%';
+  popup.style.transform = 'translate(-50%, -50%)';
+  popup.style.backgroundColor = 'white';
+  popup.style.padding = '30px 20px 20px'; // Increased top padding for close button
+  popup.style.border = '1px solid black';
+  popup.style.zIndex = '1000';
+  popup.style.borderRadius = '5px'; // Optional: rounded corners
+  popup.style.boxShadow = '0 4px 6px rgba(0, 0, 0, 0.1)'; // Optional: shadow for depth
 
-    const pre = document.createElement('pre');
-    pre.textContent = JSON.stringify(jsonContent, null, 2);
-    popup.appendChild(pre);
+  const closeButton = document.createElement('button');
+  closeButton.textContent = '×'; // Using '×' character for close
+  closeButton.style.position = 'absolute';
+  closeButton.style.right = '10px';
+  closeButton.style.top = '10px';
+  closeButton.style.border = 'none';
+  closeButton.style.background = 'none';
+  closeButton.style.fontSize = '20px';
+  closeButton.style.cursor = 'pointer';
+  closeButton.style.color = '#333';
+  closeButton.onclick = () => document.body.removeChild(popup);
+  popup.appendChild(closeButton);
 
-    const closeButton = document.createElement('button');
-    closeButton.textContent = 'Close';
-    closeButton.onclick = () => document.body.removeChild(popup);
-    popup.appendChild(closeButton);
+  const pre = document.createElement('pre');
+  pre.textContent = JSON.stringify(jsonContent, null, 2);
+  pre.style.margin = '0'; // Remove default margins
+  pre.style.whiteSpace = 'pre-wrap'; // Allow text to wrap
+  pre.style.wordBreak = 'break-word'; // Break long words if necessary
+  popup.appendChild(pre);
 
-    document.body.appendChild(popup);
-  }
+  document.body.appendChild(popup);
+}
     </script>
   </body>
 </html>

--- a/src/titiler/extensions/titiler/extensions/templates/cog_viewer.html
+++ b/src/titiler/extensions/titiler/extensions/templates/cog_viewer.html
@@ -284,6 +284,29 @@
           <table id="histogram-table" class="none"></table>
         </div>
 
+        <div class="px6 py6 w-full">
+          <div class="txt-h5 color-black">
+            <svg class="icon icon--l inline-block">
+              <use xlink:href="#icon-share" />
+            </svg>
+            Share
+          </div>
+          <div id="export-div" class="w-full align-center">
+            <button
+              id="btn-export"
+              class="btn bts--xs btn--stroke bg-darken25-on-hover inline-block txt-s color-black mx12 my12"
+            >
+              Show Render Parameters
+            </button>
+            <button
+              id="btn-share-link"
+              class="btn bts--xs btn--stroke bg-darken25-on-hover inline-block txt-s color-black mx12 my12"
+            >
+              Share Map
+            </button>
+          </div>
+        </div>
+      </div>
       </div>
       <button id='btn-hide'><svg id='hide-arrow' class='icon'><use xlink:href='#icon-arrow-right'/></svg></button>
     </div>
@@ -907,6 +930,85 @@ map.on('load', () => {
     addCogeo()
   }
 })
+
+document.getElementById('btn-share-link').addEventListener('click', () => {
+  const rasterType = document.getElementById("toolbar").querySelector(".active").id;
+  
+  let params = new URLSearchParams();
+  params.append('url', scope.url);
+
+  if (rasterType === "1b") {
+
+    params.append('bidx', document.getElementById("layer-selector").selectedOptions[0].getAttribute("bidx"));
+    const colormap_name = document.getElementById('colormap-selector').value;
+    if (colormap_name != "b&w") {
+      params.append('colormap_name', colormap_name);
+    }
+  } else if (rasterType === "3b") {
+    params.append('bidx', document.getElementById("r-selector").selectedOptions[0].getAttribute("bidx"));
+    params.append('bidx', document.getElementById("g-selector").selectedOptions[0].getAttribute("bidx"));
+    params.append('bidx', document.getElementById("b-selector").selectedOptions[0].getAttribute("bidx"));
+  }
+
+  // Add rescale parameter for both 1b and 3b if applicable
+  if (["uint8", "int8"].indexOf(scope.data_type) === -1 && !scope.colormap) {
+    params.append('rescale', `${document.getElementById("data-min").value},${document.getElementById("data-max").value}`);
+  }
+
+  const path_name = `${window.location.pathname}`.replace("viewer", "map");
+  console.log("path_name: ", path_name);
+  const shareUrl = `${window.location.origin}${path_name}?${params.toString()}`;
+  
+  // Create a temporary input element to copy the URL
+  const tempInput = document.createElement('input');
+  tempInput.value = shareUrl;
+  document.body.appendChild(tempInput);
+  tempInput.select();
+  document.execCommand('copy');
+  document.body.removeChild(tempInput);
+
+  alert('Share link copied to clipboard!');
+});
+
+document.getElementById('btn-export').addEventListener('click', () => {
+  const rasterType = document.getElementById("toolbar").querySelector(".active").id;
+  params = {}
+  if (rasterType === "1b") {
+
+    params.bidx = document.getElementById("layer-selector").selectedOptions[0].getAttribute("bidx");
+    const colormap_name = document.getElementById('colormap-selector').value;
+    if (colormap_name != "b&w") {
+      params.colormap_name = colormap_name;
+    }
+  } 
+  // Add rescale parameter for both 1b and 3b if applicable
+  if (["uint8", "int8"].indexOf(scope.data_type) === -1 && !scope.colormap) {
+    params.rescale = `${document.getElementById("data-min").value},${document.getElementById("data-max").value}`;
+  }
+  showJsonPopup(params);
+});
+  function showJsonPopup(jsonContent) {
+    const popup = document.createElement('div');
+    popup.style.position = 'fixed';
+    popup.style.left = '50%';
+    popup.style.top = '50%';
+    popup.style.transform = 'translate(-50%, -50%)';
+    popup.style.backgroundColor = 'white';
+    popup.style.padding = '20px';
+    popup.style.border = '1px solid black';
+    popup.style.zIndex = '1000';
+
+    const pre = document.createElement('pre');
+    pre.textContent = JSON.stringify(jsonContent, null, 2);
+    popup.appendChild(pre);
+
+    const closeButton = document.createElement('button');
+    closeButton.textContent = 'Close';
+    closeButton.onclick = () => document.body.removeChild(popup);
+    popup.appendChild(closeButton);
+
+    document.body.appendChild(popup);
+  }
     </script>
   </body>
 </html>

--- a/src/titiler/extensions/titiler/extensions/templates/cog_viewer.html
+++ b/src/titiler/extensions/titiler/extensions/templates/cog_viewer.html
@@ -54,6 +54,9 @@
           display: block;
           padding: 5px;
       }
+      .share-button.hidden {
+        display: none !important;
+      }
       #menu {
         left: 0;
         top: 0;
@@ -300,7 +303,7 @@
             </button>
             <button
               id="btn-share-link"
-              class="btn bts--xs btn--stroke bg-darken25-on-hover inline-block txt-s color-black mx12 my12"
+              class="btn bts--xs btn--stroke bg-darken25-on-hover inline-block txt-s color-black mx12 my12 share-button"
             >
               Share Map
             </button>
@@ -334,6 +337,7 @@ var scope = {
 const tilejson_endpoint = '{{ tilejson_endpoint }}'
 const info_endpoint = '{{ info_endpoint }}'
 const stats_endpoint = '{{ statistics_endpoint }}'
+const viewer_enabled = '{{ viewer_enabled|tojson }}'
 
 const dtype_ranges = {
   'int8': [-128, 127],
@@ -345,6 +349,28 @@ const dtype_ranges = {
   'float32': [-3.4028235e+38, 3.4028235e+38],
   'float64': [-1.7976931348623157e+308, 1.7976931348623157e+308]
 }
+
+function updateShareButtonVisibility() {
+  console.log('updateShareButtonVisibility called');
+  console.log('viewer_enabled:', viewer_enabled);
+  
+  const shareButton = document.getElementById('btn-share-link');
+  if (!shareButton) {
+    console.log('Share button not found in the DOM');
+    return;
+  }
+  
+  console.log('shareButton:', shareButton);
+  
+  if (viewer_enabled === 'true') {
+    console.log('Setting button to visible');
+    shareButton.classList.remove('hidden');
+  } else {
+    console.log('Setting button to hidden');
+    shareButton.classList.add('hidden');
+  }
+}
+updateShareButtonVisibility();
 
 var map = new maplibregl.Map({
   container: 'map',

--- a/src/titiler/extensions/titiler/extensions/viewer.py
+++ b/src/titiler/extensions/titiler/extensions/viewer.py
@@ -36,8 +36,7 @@ class cogViewerExtension(FactoryExtension):
                     ),
                     "info_endpoint": factory.url_for(request, "info"),
                     "statistics_endpoint": factory.url_for(request, "statistics"),
-                    "viewer_enabled": hasattr(factory, "add_viewer")
-                    and getattr(factory, "add_viewer", False),
+                    "viewer_enabled": getattr(factory, "add_viewer", False),
                 },
                 media_type="text/html",
             )

--- a/src/titiler/extensions/titiler/extensions/viewer.py
+++ b/src/titiler/extensions/titiler/extensions/viewer.py
@@ -36,6 +36,8 @@ class cogViewerExtension(FactoryExtension):
                     ),
                     "info_endpoint": factory.url_for(request, "info"),
                     "statistics_endpoint": factory.url_for(request, "statistics"),
+                    "viewer_enabled": hasattr(factory, "add_viewer")
+                    and getattr(factory, "add_viewer", False),
                 },
                 media_type="text/html",
             )


### PR DESCRIPTION
If someone is using the `/cog/viewer` endpoint to figure out which render parameters make sense for their dataset it would be nice to add a `Show Render Parameters` button. It would also be nice to be able to share a link to a map with those parameters applied so the user could send someone a link to the exact image that they decided on. It might be better to link to `/cog/viewer` since `/cog/map` is deprecated, but right now you can't set render parameters in that endpoint (just `url`).

![image](https://github.com/user-attachments/assets/334c50c3-c43f-46df-a225-7c23dd32fbc8)

This idea came from Team 4 in the IMPACT X-athon with @anayeaye    @smk0033 @unhipcat