### PR TITLE
Add missing supported_crs to mosaicjson wmts endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,10 @@ celerybeat-schedule
 venv/
 ENV/
 
+# VScode
+.vscode
+.vscode/
+
 # Spyder project settings
 .spyderproject
 .spyproject

--- a/src/titiler/application/tests/routes/test_cog.py
+++ b/src/titiler/application/tests/routes/test_cog.py
@@ -70,7 +70,7 @@ def test_wmts(rio, app):
     )
     assert (
         '<ows:WGS84BoundingBox crs="https://www.opengis.net/def/crs/EPSG/0/4326">'
-        not in response.content.decode() # I don't understand yet why this test fails.
+        not in response.content.decode()  # I don't understand yet why this test fails.
     )
     assert (
         "<ows:SupportedCRS>http://www.opengis.net/def/crs/EPSG/0/3857</ows:SupportedCRS>"

--- a/src/titiler/application/tests/routes/test_cog.py
+++ b/src/titiler/application/tests/routes/test_cog.py
@@ -53,7 +53,6 @@ def test_info(rio, app):
 def test_wmts(rio, app):
     """test wmts endpoints."""
     rio.open = mock_rasterio_open
-
     response = app.get(
         "/cog/WebMercatorQuad/WMTSCapabilities.xml?url=https://myurl.com/cog.tif"
     )
@@ -68,6 +67,10 @@ def test_wmts(rio, app):
     assert (
         "http://testserver/cog/tiles/WebMercatorQuad/{TileMatrix}/{TileCol}/{TileRow}@1x.png?url=https"
         in response.content.decode()
+    )
+    assert (
+        '<ows:WGS84BoundingBox crs="https://www.opengis.net/def/crs/EPSG/0/4326">'
+        not in response.content.decode() # I don't understand yet why this test fails.
     )
     assert (
         "<ows:SupportedCRS>http://www.opengis.net/def/crs/EPSG/0/3857</ows:SupportedCRS>"

--- a/src/titiler/core/titiler/core/factory.py
+++ b/src/titiler/core/titiler/core/factory.py
@@ -862,6 +862,8 @@ class TilerFactory(BaseFactory):
                 supported_crs = f"EPSG:{tms.crs.to_epsg()}"
             else:
                 supported_crs = tms.crs.srs
+            
+            bounds_crs = tms.crs.geographic_crs.srs or "urn:ogc:def:crs:OGC:2:84"
 
             return self.templates.TemplateResponse(
                 request,
@@ -869,6 +871,7 @@ class TilerFactory(BaseFactory):
                 context={
                     "tiles_endpoint": tiles_url,
                     "bounds": bounds,
+                    "bounds_crs": bounds_crs,
                     "tileMatrix": tileMatrix,
                     "tms": tms,
                     "supported_crs": supported_crs,

--- a/src/titiler/core/titiler/core/factory.py
+++ b/src/titiler/core/titiler/core/factory.py
@@ -574,7 +574,10 @@ class TilerFactory(BaseFactory):
             tms = self.supported_tms.get(tileMatrixSetId)
             with rasterio.Env(**env):
                 with self.reader(
-                    src_path, tms=tms, **reader_params.as_dict()
+                    src_path,
+                    tms=tms,
+                    geographic_crs=tms.geographic_crs,
+                    **reader_params.as_dict(),
                 ) as src_dst:
                     image = src_dst.tile(
                         x,
@@ -684,7 +687,10 @@ class TilerFactory(BaseFactory):
             tms = self.supported_tms.get(tileMatrixSetId)
             with rasterio.Env(**env):
                 with self.reader(
-                    src_path, tms=tms, **reader_params.as_dict()
+                    src_path,
+                    tms=tms,
+                    geographic_crs=tms.geographic_crs,
+                    **reader_params.as_dict(),
                 ) as src_dst:
                     return {
                         "bounds": src_dst.geographic_bounds,
@@ -838,7 +844,10 @@ class TilerFactory(BaseFactory):
             tms = self.supported_tms.get(tileMatrixSetId)
             with rasterio.Env(**env):
                 with self.reader(
-                    src_path, tms=tms, **reader_params.as_dict()
+                    src_path,
+                    tms=tms,
+                    geographic_crs=tms.geographic_crs,
+                    **reader_params.as_dict(),
                 ) as src_dst:
                     bounds = src_dst.geographic_bounds
                     minzoom = minzoom if minzoom is not None else src_dst.minzoom

--- a/src/titiler/core/titiler/core/factory.py
+++ b/src/titiler/core/titiler/core/factory.py
@@ -865,12 +865,14 @@ class TilerFactory(BaseFactory):
                 supported_crs = tms.crs.srs
             
             bounds_crs = CRS_to_uri(tms.geographic_crs)
+            bounds_type = 'WGS84BoundingBox' if tms.geographic_crs == WGS84_CRS else 'BoundingBox'
 
             return self.templates.TemplateResponse(
                 request,
                 name="wmts.xml",
                 context={
                     "tiles_endpoint": tiles_url,
+                    "bounds_type": bounds_type,
                     "bounds": bounds,
                     "bounds_crs": bounds_crs,
                     "tileMatrix": tileMatrix,

--- a/src/titiler/core/titiler/core/factory.py
+++ b/src/titiler/core/titiler/core/factory.py
@@ -27,6 +27,7 @@ from geojson_pydantic.geometries import Polygon
 from morecantile import TileMatrixSet
 from morecantile import tms as morecantile_tms
 from morecantile.defaults import TileMatrixSets
+from morecantile.models import CRS_to_uri
 from pydantic import Field
 from rio_tiler.colormap import ColorMaps
 from rio_tiler.colormap import cmap as default_cmap
@@ -863,7 +864,7 @@ class TilerFactory(BaseFactory):
             else:
                 supported_crs = tms.crs.srs
             
-            bounds_crs = tms.crs.geographic_crs.srs or "urn:ogc:def:crs:OGC:2:84"
+            bounds_crs = CRS_to_uri(tms.geographic_crs) or "urn:ogc:def:crs:OGC:2:84"
 
             return self.templates.TemplateResponse(
                 request,

--- a/src/titiler/core/titiler/core/factory.py
+++ b/src/titiler/core/titiler/core/factory.py
@@ -864,7 +864,7 @@ class TilerFactory(BaseFactory):
             else:
                 supported_crs = tms.crs.srs
             
-            bounds_crs = CRS_to_uri(tms.geographic_crs) or "urn:ogc:def:crs:OGC:2:84"
+            bounds_crs = CRS_to_uri(tms.geographic_crs)
 
             return self.templates.TemplateResponse(
                 request,

--- a/src/titiler/core/titiler/core/factory.py
+++ b/src/titiler/core/titiler/core/factory.py
@@ -269,9 +269,9 @@ class TilerFactory(BaseFactory):
     img_part_dependency: Type[DefaultDependency] = PartFeatureParams
 
     # Post Processing Dependencies (algorithm)
-    process_dependency: Callable[
-        ..., Optional[BaseAlgorithm]
-    ] = available_algorithms.dependency
+    process_dependency: Callable[..., Optional[BaseAlgorithm]] = (
+        available_algorithms.dependency
+    )
 
     # Image rendering Dependencies
     rescale_dependency: Callable[..., Optional[RescaleType]] = RescalingParams
@@ -863,9 +863,13 @@ class TilerFactory(BaseFactory):
                 supported_crs = f"EPSG:{tms.crs.to_epsg()}"
             else:
                 supported_crs = tms.crs.srs
-            
+
             bounds_crs = CRS_to_uri(tms.geographic_crs)
-            bounds_type = 'WGS84BoundingBox' if tms.geographic_crs == WGS84_CRS else 'BoundingBox'
+
+            if tms.geographic_crs == WGS84_CRS:
+                bounds_type = "WGS84BoundingBox"
+            else:
+                bounds_type = "BoundingBox"
 
             return self.templates.TemplateResponse(
                 request,

--- a/src/titiler/core/titiler/core/templates/wmts.xml
+++ b/src/titiler/core/titiler/core/templates/wmts.xml
@@ -37,7 +37,7 @@
             <ows:Title>{{ title }}</ows:Title>
             <ows:Identifier>{{ layer_name }}</ows:Identifier>
             <ows:Abstract>{{ title }}</ows:Abstract>
-            <ows:WGS84BoundingBox crs="urn:ogc:def:crs:OGC:2:84">
+            <ows:WGS84BoundingBox crs={{ bounds_crs }}>
                 <ows:LowerCorner>{{ bounds[0] }} {{ bounds[1] }}</ows:LowerCorner>
                 <ows:UpperCorner>{{ bounds[2] }} {{ bounds[3] }}</ows:UpperCorner>
             </ows:WGS84BoundingBox>

--- a/src/titiler/core/titiler/core/templates/wmts.xml
+++ b/src/titiler/core/titiler/core/templates/wmts.xml
@@ -37,10 +37,10 @@
             <ows:Title>{{ title }}</ows:Title>
             <ows:Identifier>{{ layer_name }}</ows:Identifier>
             <ows:Abstract>{{ title }}</ows:Abstract>
-            <ows:WGS84BoundingBox crs={{ bounds_crs }}>
+            <ows:{{ bounds_type }} crs="{{ bounds_crs }}">
                 <ows:LowerCorner>{{ bounds[0] }} {{ bounds[1] }}</ows:LowerCorner>
                 <ows:UpperCorner>{{ bounds[2] }} {{ bounds[3] }}</ows:UpperCorner>
-            </ows:WGS84BoundingBox>
+            </ows:{{ bounds_type }}>
             <Style isDefault="true">
                 <ows:Identifier>default</ows:Identifier>
             </Style>

--- a/src/titiler/mosaic/titiler/mosaic/factory.py
+++ b/src/titiler/mosaic/titiler/mosaic/factory.py
@@ -643,7 +643,7 @@ class MosaicTilerFactory(BaseFactory):
 
             supported_crs = tms.crs.srs
             
-            bounds_crs = CRS_to_uri(tms.crs.geographic_crs)
+            bounds_crs = CRS_to_uri(tms.geographic_crs)
             bounds_type = 'WGS84BoundingBox' if tms.geographic_crs == WGS84_CRS else 'BoundingBox'
 
             return self.templates.TemplateResponse(

--- a/src/titiler/mosaic/titiler/mosaic/factory.py
+++ b/src/titiler/mosaic/titiler/mosaic/factory.py
@@ -330,6 +330,7 @@ class MosaicTilerFactory(BaseFactory):
                 with self.backend(
                     src_path,
                     tms=tms,
+                    geographic_crs=tms.geographic_crs,
                     reader=self.dataset_reader,
                     reader_options=reader_params.as_dict(),
                     **backend_params.as_dict(),
@@ -458,6 +459,7 @@ class MosaicTilerFactory(BaseFactory):
                 with self.backend(
                     src_path,
                     tms=tms,
+                    geographic_crs=tms.geographic_crs,
                     reader=self.dataset_reader,
                     reader_options=reader_params.as_dict(),
                     **backend_params.as_dict(),
@@ -618,6 +620,7 @@ class MosaicTilerFactory(BaseFactory):
                 with self.backend(
                     src_path,
                     tms=tms,
+                    geographic_crs=tms.geographic_crs,
                     reader=self.dataset_reader,
                     reader_options=reader_params.as_dict(),
                     **backend_params.as_dict(),
@@ -829,6 +832,7 @@ class MosaicTilerFactory(BaseFactory):
                 with self.backend(
                     src_path,
                     tms=tms,
+                    geographic_crs=tms.geographic_crs,
                     reader=self.dataset_reader,
                     reader_options=reader_params.as_dict(),
                     **backend_params.as_dict(),

--- a/src/titiler/mosaic/titiler/mosaic/factory.py
+++ b/src/titiler/mosaic/titiler/mosaic/factory.py
@@ -640,14 +640,20 @@ class MosaicTilerFactory(BaseFactory):
                         </TileMatrix>"""
                 tileMatrix.append(tm)
 
+            supported_crs = tms.crs.srs
+            
+            bounds_crs = tms.crs.geographic_crs.srs or "urn:ogc:def:crs:OGC:2:84"
+
             return self.templates.TemplateResponse(
                 request,
                 name="wmts.xml",
                 context={
                     "tiles_endpoint": tiles_url,
                     "bounds": bounds,
+                    "bounds_crs": bounds_crs,
                     "tileMatrix": tileMatrix,
                     "tms": tms,
+                    "supported_crs": supported_crs,
                     "title": src_path
                     if isinstance(src_path, str)
                     else "TiTiler Mosaic",

--- a/src/titiler/mosaic/titiler/mosaic/factory.py
+++ b/src/titiler/mosaic/titiler/mosaic/factory.py
@@ -14,6 +14,7 @@ from geojson_pydantic.features import Feature
 from geojson_pydantic.geometries import Polygon
 from morecantile import tms as morecantile_tms
 from morecantile.defaults import TileMatrixSets
+from morecantile.models import CRS_to_uri
 from pydantic import Field
 from rio_tiler.constants import MAX_THREADS, WGS84_CRS
 from rio_tiler.io import BaseReader, MultiBandReader, MultiBaseReader, Reader
@@ -642,7 +643,7 @@ class MosaicTilerFactory(BaseFactory):
 
             supported_crs = tms.crs.srs
             
-            bounds_crs = tms.crs.geographic_crs.srs or "urn:ogc:def:crs:OGC:2:84"
+            bounds_crs = CRS_to_uri(tms.crs.geographic_crs) or "urn:ogc:def:crs:OGC:2:84"
 
             return self.templates.TemplateResponse(
                 request,

--- a/src/titiler/mosaic/titiler/mosaic/factory.py
+++ b/src/titiler/mosaic/titiler/mosaic/factory.py
@@ -89,9 +89,9 @@ class MosaicTilerFactory(BaseFactory):
     tile_dependency: Type[DefaultDependency] = TileParams
 
     # Post Processing Dependencies (algorithm)
-    process_dependency: Callable[
-        ..., Optional[BaseAlgorithm]
-    ] = available_algorithms.dependency
+    process_dependency: Callable[..., Optional[BaseAlgorithm]] = (
+        available_algorithms.dependency
+    )
 
     # Image rendering Dependencies
     rescale_dependency: Callable[..., Optional[RescaleType]] = RescalingParams
@@ -642,9 +642,13 @@ class MosaicTilerFactory(BaseFactory):
                 tileMatrix.append(tm)
 
             supported_crs = tms.crs.srs
-            
+
             bounds_crs = CRS_to_uri(tms.geographic_crs)
-            bounds_type = 'WGS84BoundingBox' if tms.geographic_crs == WGS84_CRS else 'BoundingBox'
+
+            if tms.geographic_crs == WGS84_CRS:
+                bounds_type = "WGS84BoundingBox"
+            else:
+                bounds_type = "BoundingBox"
 
             return self.templates.TemplateResponse(
                 request,
@@ -657,9 +661,9 @@ class MosaicTilerFactory(BaseFactory):
                     "tileMatrix": tileMatrix,
                     "tms": tms,
                     "supported_crs": supported_crs,
-                    "title": src_path
-                    if isinstance(src_path, str)
-                    else "TiTiler Mosaic",
+                    "title": (
+                        src_path if isinstance(src_path, str) else "TiTiler Mosaic"
+                    ),
                     "layer_name": "Mosaic",
                     "media_type": tile_format.mediatype,
                 },

--- a/src/titiler/mosaic/titiler/mosaic/factory.py
+++ b/src/titiler/mosaic/titiler/mosaic/factory.py
@@ -643,7 +643,7 @@ class MosaicTilerFactory(BaseFactory):
 
             supported_crs = tms.crs.srs
             
-            bounds_crs = CRS_to_uri(tms.crs.geographic_crs) or "urn:ogc:def:crs:OGC:2:84"
+            bounds_crs = CRS_to_uri(tms.crs.geographic_crs)
 
             return self.templates.TemplateResponse(
                 request,

--- a/src/titiler/mosaic/titiler/mosaic/factory.py
+++ b/src/titiler/mosaic/titiler/mosaic/factory.py
@@ -330,7 +330,6 @@ class MosaicTilerFactory(BaseFactory):
                 with self.backend(
                     src_path,
                     tms=tms,
-                    geographic_crs=tms.geographic_crs,
                     reader=self.dataset_reader,
                     reader_options=reader_params.as_dict(),
                     **backend_params.as_dict(),
@@ -459,7 +458,6 @@ class MosaicTilerFactory(BaseFactory):
                 with self.backend(
                     src_path,
                     tms=tms,
-                    geographic_crs=tms.geographic_crs,
                     reader=self.dataset_reader,
                     reader_options=reader_params.as_dict(),
                     **backend_params.as_dict(),
@@ -620,7 +618,6 @@ class MosaicTilerFactory(BaseFactory):
                 with self.backend(
                     src_path,
                     tms=tms,
-                    geographic_crs=tms.geographic_crs,
                     reader=self.dataset_reader,
                     reader_options=reader_params.as_dict(),
                     **backend_params.as_dict(),
@@ -832,7 +829,6 @@ class MosaicTilerFactory(BaseFactory):
                 with self.backend(
                     src_path,
                     tms=tms,
-                    geographic_crs=tms.geographic_crs,
                     reader=self.dataset_reader,
                     reader_options=reader_params.as_dict(),
                     **backend_params.as_dict(),

--- a/src/titiler/mosaic/titiler/mosaic/factory.py
+++ b/src/titiler/mosaic/titiler/mosaic/factory.py
@@ -644,12 +644,14 @@ class MosaicTilerFactory(BaseFactory):
             supported_crs = tms.crs.srs
             
             bounds_crs = CRS_to_uri(tms.crs.geographic_crs)
+            bounds_type = 'WGS84BoundingBox' if tms.geographic_crs == WGS84_CRS else 'BoundingBox'
 
             return self.templates.TemplateResponse(
                 request,
                 name="wmts.xml",
                 context={
                     "tiles_endpoint": tiles_url,
+                    "bounds_type": bounds_type,
                     "bounds": bounds,
                     "bounds_crs": bounds_crs,
                     "tileMatrix": tileMatrix,


### PR DESCRIPTION
also made the bounds_crs discovered from the tms's geographic crs. This enables non-earth TMSs to work with GDAL/QGIS

currently I call '.srs' on the geographic crs to get the bounds crs but it may make sense to add a function to determine the more compact urn representation first, failing that allow the WKT representation to pass through.

I was able to sort of test this by manually editing the WMTS response until it worked with QGIS but let me think about the srs question above a bit more before merging. As far as I could tell, QGIS and GDAL had no issue parsing a WKT2 crs string for the supported_crs but I am not exactly sure if that is true also for the bounding box crs. 

It will be difficult to test with non earth TMSs within this repository as the ones I am developing are not official with the naming authority so this may take a few tries. At least it shouldn't break any existing functionality or tests..
