### PR TITLE
update starlette-cramjam dependency

### DIFF
--- a/src/titiler/application/pyproject.toml
+++ b/src/titiler/application/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "titiler.core==0.18.9",
     "titiler.extensions[cogeo,stac]==0.18.9",
     "titiler.mosaic==0.18.9",
-    "starlette-cramjam>=0.3,<0.4",
+    "starlette-cramjam>=0.4,<0.5",
     "pydantic-settings~=2.0",
 ]
 

--- a/src/titiler/application/titiler/application/main.py
+++ b/src/titiler/application/titiler/application/main.py
@@ -188,6 +188,7 @@ app.add_middleware(
         "image/jp2",
         "image/webp",
     },
+    compression_level=6,
 )
 
 app.add_middleware(


### PR DESCRIPTION

Also set default compression level to 6 so we don't default to 11 for Brotli 

ref: https://github.com/milesgranger/cramjam/issues/187