### PR TITLE
Update from deprecated path in benchmarks

### DIFF
--- a/.github/data/urls.txt
+++ b/.github/data/urls.txt
@@ -1,7 +1,7 @@
 PROT=http
 HOST=localhost
 PORT=8000
-PATH=cog/tiles/
+PATH=cog/tiles/WebMercatorQuad/
 EXT=.png
 QUERYSTRING=?url=/data/world.tif
 $(PROT)://$(HOST):$(PORT)/$(PATH)0/0/0$(EXT)$(QUERYSTRING)


### PR DESCRIPTION
The [benchmarks for the past few commits](https://developmentseed.org/titiler/benchmark.html) haven't been working for Web Mercator Quad tiles because the deprecated `/tiles/{z}/{x}/{y}.{format}` endpoint was removed in https://github.com/developmentseed/titiler/pull/943. This updates the path used for those benchmarks.