### PR TITLE
add `Layers` to wmts and reorder dependencies

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -76,6 +76,12 @@
 
 * `/bounds` endpoints now return a `crs: str` attribute in the response
 
+* update `wmts.xml` template to support multiple layers
+
+* re-order endpoints parameters
+
+* avoid `lat/lon` overflow in `map` viewer
+
 ### titiler.mosaic
 
 * Rename `reader` attribute to `backend` in `MosaicTilerFactory`  **breaking change**
@@ -85,6 +91,8 @@
 * `/bounds` endpoints now return a `crs: str` attribute in the response
 
 * Update `cogeo-mosaic` dependency to `>=8.0,<9.0`
+
+* re-order endpoints parameters
 
 ### titiler.extensions
 

--- a/src/titiler/application/tests/routes/test_cog.py
+++ b/src/titiler/application/tests/routes/test_cog.py
@@ -64,7 +64,7 @@ def test_wmts(rio, app):
         "http://testserver/cog/WebMercatorQuad/WMTSCapabilities.xml?url=https"
         in response.content.decode()
     )
-    assert "<ows:Identifier>Dataset</ows:Identifier>" in response.content.decode()
+    assert "<ows:Identifier>default</ows:Identifier>" in response.content.decode()
     assert (
         "http://testserver/cog/tiles/WebMercatorQuad/{TileMatrix}/{TileCol}/{TileRow}@1x.png?url=https"
         in response.content.decode()

--- a/src/titiler/core/titiler/core/dependencies.py
+++ b/src/titiler/core/titiler/core/dependencies.py
@@ -606,7 +606,7 @@ def CRSParams(
     crs: Annotated[
         Optional[str],
         Query(
-            description="Coordinate Reference System`.",
+            description="Coordinate Reference System.",
         ),
     ] = None,
 ) -> Optional[CRS]:

--- a/src/titiler/core/titiler/core/factory.py
+++ b/src/titiler/core/titiler/core/factory.py
@@ -82,7 +82,7 @@ from titiler.core.models.responses import (
     Statistics,
     StatisticsGeoJSON,
 )
-from titiler.core.resources.enums import ImageType, MediaType
+from titiler.core.resources.enums import ImageType
 from titiler.core.resources.responses import GeoJSONResponse, JSONResponse, XMLResponse
 from titiler.core.routing import EndpointScope
 from titiler.core.utils import render_image
@@ -430,13 +430,13 @@ class TilerFactory(BaseFactory):
         )
         def statistics(
             src_path=Depends(self.path_dependency),
+            reader_params=Depends(self.reader_dependency),
             layer_params=Depends(self.layer_dependency),
             dataset_params=Depends(self.dataset_dependency),
             image_params=Depends(self.img_preview_dependency),
             post_process=Depends(self.process_dependency),
             stats_params=Depends(self.stats_dependency),
             histogram_params=Depends(self.histogram_dependency),
-            reader_params=Depends(self.reader_dependency),
             env=Depends(self.environment_dependency),
         ):
             """Get Dataset statistics."""
@@ -475,6 +475,7 @@ class TilerFactory(BaseFactory):
                 Body(description="GeoJSON Feature or FeatureCollection."),
             ],
             src_path=Depends(self.path_dependency),
+            reader_params=Depends(self.reader_dependency),
             coord_crs=Depends(CoordCRSParams),
             dst_crs=Depends(DstCRSParams),
             layer_params=Depends(self.layer_dependency),
@@ -483,7 +484,6 @@ class TilerFactory(BaseFactory):
             post_process=Depends(self.process_dependency),
             stats_params=Depends(self.stats_dependency),
             histogram_params=Depends(self.histogram_dependency),
-            reader_params=Depends(self.reader_dependency),
             env=Depends(self.environment_dependency),
         ):
             """Get Statistics from a geojson feature or featureCollection."""
@@ -578,15 +578,15 @@ class TilerFactory(BaseFactory):
                 "Default will be automatically defined if the output image needs a mask (png) or not (jpeg).",
             ] = None,
             src_path=Depends(self.path_dependency),
+            reader_params=Depends(self.reader_dependency),
+            tile_params=Depends(self.tile_dependency),
             layer_params=Depends(self.layer_dependency),
             dataset_params=Depends(self.dataset_dependency),
-            tile_params=Depends(self.tile_dependency),
             post_process=Depends(self.process_dependency),
             rescale=Depends(self.rescale_dependency),
             color_formula=Depends(self.color_formula_dependency),
             colormap=Depends(self.colormap_dependency),
             render_params=Depends(self.render_dependency),
-            reader_params=Depends(self.reader_dependency),
             env=Depends(self.environment_dependency),
         ):
             """Create map tile from a dataset."""
@@ -641,7 +641,6 @@ class TilerFactory(BaseFactory):
                     description="Identifier selecting one of the TileMatrixSetId supported."
                 ),
             ],
-            src_path=Depends(self.path_dependency),
             tile_format: Annotated[
                 Optional[ImageType],
                 Query(
@@ -662,15 +661,16 @@ class TilerFactory(BaseFactory):
                 Optional[int],
                 Query(description="Overwrite default maxzoom."),
             ] = None,
+            src_path=Depends(self.path_dependency),
+            reader_params=Depends(self.reader_dependency),
+            tile_params=Depends(self.tile_dependency),
             layer_params=Depends(self.layer_dependency),
             dataset_params=Depends(self.dataset_dependency),
-            tile_params=Depends(self.tile_dependency),
             post_process=Depends(self.process_dependency),
             rescale=Depends(self.rescale_dependency),
             color_formula=Depends(self.color_formula_dependency),
             colormap=Depends(self.colormap_dependency),
             render_params=Depends(self.render_dependency),
-            reader_params=Depends(self.reader_dependency),
             env=Depends(self.environment_dependency),
         ):
             """Return TileJSON document for a dataset."""
@@ -726,7 +726,6 @@ class TilerFactory(BaseFactory):
                     description="Identifier selecting one of the TileMatrixSetId supported."
                 ),
             ],
-            src_path=Depends(self.path_dependency),
             tile_format: Annotated[
                 Optional[ImageType],
                 Query(
@@ -747,15 +746,16 @@ class TilerFactory(BaseFactory):
                 Optional[int],
                 Query(description="Overwrite default maxzoom."),
             ] = None,
+            src_path=Depends(self.path_dependency),
+            reader_params=Depends(self.reader_dependency),
+            tile_params=Depends(self.tile_dependency),
             layer_params=Depends(self.layer_dependency),
             dataset_params=Depends(self.dataset_dependency),
-            tile_params=Depends(self.tile_dependency),
             post_process=Depends(self.process_dependency),
             rescale=Depends(self.rescale_dependency),
             color_formula=Depends(self.color_formula_dependency),
             colormap=Depends(self.colormap_dependency),
             render_params=Depends(self.render_dependency),
-            reader_params=Depends(self.reader_dependency),
             env=Depends(self.environment_dependency),
         ):
             """Return TileJSON document for a dataset."""
@@ -791,7 +791,6 @@ class TilerFactory(BaseFactory):
                     description="Identifier selecting one of the TileMatrixSetId supported."
                 ),
             ],
-            src_path=Depends(self.path_dependency),
             tile_format: Annotated[
                 ImageType,
                 Query(description="Output image type. Default is png."),
@@ -816,15 +815,16 @@ class TilerFactory(BaseFactory):
                     description="Use EPSG code, not opengis.net, for the ows:SupportedCRS in the TileMatrixSet (set to True to enable ArcMap compatability)"
                 ),
             ] = False,
+            src_path=Depends(self.path_dependency),
+            reader_params=Depends(self.reader_dependency),
+            tile_params=Depends(self.tile_dependency),
             layer_params=Depends(self.layer_dependency),
             dataset_params=Depends(self.dataset_dependency),
-            tile_params=Depends(self.tile_dependency),
             post_process=Depends(self.process_dependency),
             rescale=Depends(self.rescale_dependency),
             color_formula=Depends(self.color_formula_dependency),
             colormap=Depends(self.colormap_dependency),
             render_params=Depends(self.render_dependency),
-            reader_params=Depends(self.reader_dependency),
             env=Depends(self.environment_dependency),
         ):
             """OGC WMTS endpoint."""
@@ -853,8 +853,6 @@ class TilerFactory(BaseFactory):
                 for (key, value) in request.query_params._list
                 if key.lower() not in qs_key_to_remove
             ]
-            if qs:
-                tiles_url += f"?{urlencode(qs)}"
 
             tms = self.supported_tms.get(tileMatrixSetId)
             with rasterio.Env(**env):
@@ -885,6 +883,16 @@ class TilerFactory(BaseFactory):
             else:
                 supported_crs = tms.crs.srs
 
+            layers = [
+                {
+                    "title": src_path if isinstance(src_path, str) else "TiTiler",
+                    "name": "default",
+                    "tiles_url": tiles_url,
+                    "query_string": urlencode(qs, doseq=True) if qs else None,
+                    "bounds": bounds,
+                },
+            ]
+
             bbox_crs_type = "WGS84BoundingBox"
             bbox_crs_uri = "urn:ogc:def:crs:OGC:2:84"
             if tms.rasterio_geographic_crs != WGS84_CRS:
@@ -895,18 +903,15 @@ class TilerFactory(BaseFactory):
                 request,
                 name="wmts.xml",
                 context={
-                    "tiles_endpoint": tiles_url,
-                    "bounds": bounds,
+                    "tileMatrixSetId": tms.id,
                     "tileMatrix": tileMatrix,
-                    "tms": tms,
                     "supported_crs": supported_crs,
                     "bbox_crs_type": bbox_crs_type,
                     "bbox_crs_uri": bbox_crs_uri,
-                    "title": src_path if isinstance(src_path, str) else "TiTiler",
-                    "layer_name": "Dataset",
+                    "layers": layers,
                     "media_type": tile_format.mediatype,
                 },
-                media_type=MediaType.xml.value,
+                media_type="application/xml",
             )
 
     ############################################################################
@@ -925,10 +930,10 @@ class TilerFactory(BaseFactory):
             lon: Annotated[float, Path(description="Longitude")],
             lat: Annotated[float, Path(description="Latitude")],
             src_path=Depends(self.path_dependency),
+            reader_params=Depends(self.reader_dependency),
             coord_crs=Depends(CoordCRSParams),
             layer_params=Depends(self.layer_dependency),
             dataset_params=Depends(self.dataset_dependency),
-            reader_params=Depends(self.reader_dependency),
             env=Depends(self.environment_dependency),
         ):
             """Get Point value for a dataset."""
@@ -963,16 +968,16 @@ class TilerFactory(BaseFactory):
                 "Default will be automatically defined if the output image needs a mask (png) or not (jpeg).",
             ] = None,
             src_path=Depends(self.path_dependency),
+            reader_params=Depends(self.reader_dependency),
             layer_params=Depends(self.layer_dependency),
-            dst_crs=Depends(DstCRSParams),
             dataset_params=Depends(self.dataset_dependency),
             image_params=Depends(self.img_preview_dependency),
+            dst_crs=Depends(DstCRSParams),
             post_process=Depends(self.process_dependency),
             rescale=Depends(self.rescale_dependency),
             color_formula=Depends(self.color_formula_dependency),
             colormap=Depends(self.colormap_dependency),
             render_params=Depends(self.render_dependency),
-            reader_params=Depends(self.reader_dependency),
             env=Depends(self.environment_dependency),
         ):
             """Create preview of a dataset."""
@@ -1029,17 +1034,17 @@ class TilerFactory(BaseFactory):
                 "Default will be automatically defined if the output image needs a mask (png) or not (jpeg).",
             ] = None,
             src_path=Depends(self.path_dependency),
-            dst_crs=Depends(DstCRSParams),
-            coord_crs=Depends(CoordCRSParams),
+            reader_params=Depends(self.reader_dependency),
             layer_params=Depends(self.layer_dependency),
             dataset_params=Depends(self.dataset_dependency),
             image_params=Depends(self.img_part_dependency),
+            dst_crs=Depends(DstCRSParams),
+            coord_crs=Depends(CoordCRSParams),
             post_process=Depends(self.process_dependency),
             rescale=Depends(self.rescale_dependency),
             color_formula=Depends(self.color_formula_dependency),
             colormap=Depends(self.colormap_dependency),
             render_params=Depends(self.render_dependency),
-            reader_params=Depends(self.reader_dependency),
             env=Depends(self.environment_dependency),
         ):
             """Create image from a bbox."""
@@ -1093,17 +1098,17 @@ class TilerFactory(BaseFactory):
                 "Default will be automatically defined if the output image needs a mask (png) or not (jpeg).",
             ] = None,
             src_path=Depends(self.path_dependency),
-            coord_crs=Depends(CoordCRSParams),
-            dst_crs=Depends(DstCRSParams),
+            reader_params=Depends(self.reader_dependency),
             layer_params=Depends(self.layer_dependency),
             dataset_params=Depends(self.dataset_dependency),
             image_params=Depends(self.img_part_dependency),
+            coord_crs=Depends(CoordCRSParams),
+            dst_crs=Depends(DstCRSParams),
             post_process=Depends(self.process_dependency),
             rescale=Depends(self.rescale_dependency),
             color_formula=Depends(self.color_formula_dependency),
             colormap=Depends(self.colormap_dependency),
             render_params=Depends(self.render_dependency),
-            reader_params=Depends(self.reader_dependency),
             env=Depends(self.environment_dependency),
         ):
             """Create image from a geojson feature."""
@@ -1178,8 +1183,8 @@ class MultiBaseTilerFactory(TilerFactory):
         )
         def info(
             src_path=Depends(self.path_dependency),
-            asset_params=Depends(self.assets_dependency),
             reader_params=Depends(self.reader_dependency),
+            asset_params=Depends(self.assets_dependency),
             env=Depends(self.environment_dependency),
         ):
             """Return dataset's basic info or the list of available assets."""
@@ -1201,8 +1206,8 @@ class MultiBaseTilerFactory(TilerFactory):
         )
         def info_geojson(
             src_path=Depends(self.path_dependency),
-            asset_params=Depends(self.assets_dependency),
             reader_params=Depends(self.reader_dependency),
+            asset_params=Depends(self.assets_dependency),
             crs=Depends(CRSParams),
             env=Depends(self.environment_dependency),
         ):
@@ -1266,12 +1271,12 @@ class MultiBaseTilerFactory(TilerFactory):
         )
         def asset_statistics(
             src_path=Depends(self.path_dependency),
+            reader_params=Depends(self.reader_dependency),
             asset_params=Depends(AssetsBidxParams),
             dataset_params=Depends(self.dataset_dependency),
             image_params=Depends(self.img_preview_dependency),
             stats_params=Depends(self.stats_dependency),
             histogram_params=Depends(self.histogram_dependency),
-            reader_params=Depends(self.reader_dependency),
             env=Depends(self.environment_dependency),
         ):
             """Per Asset statistics"""
@@ -1301,13 +1306,13 @@ class MultiBaseTilerFactory(TilerFactory):
         )
         def statistics(
             src_path=Depends(self.path_dependency),
+            reader_params=Depends(self.reader_dependency),
             layer_params=Depends(AssetsBidxExprParamsOptional),
             dataset_params=Depends(self.dataset_dependency),
             image_params=Depends(self.img_preview_dependency),
             post_process=Depends(self.process_dependency),
             stats_params=Depends(self.stats_dependency),
             histogram_params=Depends(self.histogram_dependency),
-            reader_params=Depends(self.reader_dependency),
             env=Depends(self.environment_dependency),
         ):
             """Merged assets statistics."""
@@ -1350,15 +1355,15 @@ class MultiBaseTilerFactory(TilerFactory):
                 Body(description="GeoJSON Feature or FeatureCollection."),
             ],
             src_path=Depends(self.path_dependency),
-            coord_crs=Depends(CoordCRSParams),
-            dst_crs=Depends(DstCRSParams),
+            reader_params=Depends(self.reader_dependency),
             layer_params=Depends(AssetsBidxExprParamsOptional),
             dataset_params=Depends(self.dataset_dependency),
+            coord_crs=Depends(CoordCRSParams),
+            dst_crs=Depends(DstCRSParams),
             post_process=Depends(self.process_dependency),
             image_params=Depends(self.img_part_dependency),
             stats_params=Depends(self.stats_dependency),
             histogram_params=Depends(self.histogram_dependency),
-            reader_params=Depends(self.reader_dependency),
             env=Depends(self.environment_dependency),
         ):
             """Get Statistics from a geojson feature or featureCollection."""
@@ -1436,8 +1441,8 @@ class MultiBandTilerFactory(TilerFactory):
         )
         def info(
             src_path=Depends(self.path_dependency),
-            bands_params=Depends(self.bands_dependency),
             reader_params=Depends(self.reader_dependency),
+            bands_params=Depends(self.bands_dependency),
             env=Depends(self.environment_dependency),
         ):
             """Return dataset's basic info."""
@@ -1459,8 +1464,8 @@ class MultiBandTilerFactory(TilerFactory):
         )
         def info_geojson(
             src_path=Depends(self.path_dependency),
-            bands_params=Depends(self.bands_dependency),
             reader_params=Depends(self.reader_dependency),
+            bands_params=Depends(self.bands_dependency),
             crs=Depends(CRSParams),
             env=Depends(self.environment_dependency),
         ):
@@ -1518,13 +1523,13 @@ class MultiBandTilerFactory(TilerFactory):
         )
         def statistics(
             src_path=Depends(self.path_dependency),
+            reader_params=Depends(self.reader_dependency),
             bands_params=Depends(BandsExprParamsOptional),
             dataset_params=Depends(self.dataset_dependency),
             image_params=Depends(self.img_preview_dependency),
             post_process=Depends(self.process_dependency),
             stats_params=Depends(self.stats_dependency),
             histogram_params=Depends(self.histogram_dependency),
-            reader_params=Depends(self.reader_dependency),
             env=Depends(self.environment_dependency),
         ):
             """Get Dataset statistics."""
@@ -1567,15 +1572,15 @@ class MultiBandTilerFactory(TilerFactory):
                 Body(description="GeoJSON Feature or FeatureCollection."),
             ],
             src_path=Depends(self.path_dependency),
-            coord_crs=Depends(CoordCRSParams),
-            dst_crs=Depends(DstCRSParams),
+            reader_params=Depends(self.reader_dependency),
             bands_params=Depends(BandsExprParamsOptional),
             dataset_params=Depends(self.dataset_dependency),
             image_params=Depends(self.img_part_dependency),
+            coord_crs=Depends(CoordCRSParams),
+            dst_crs=Depends(DstCRSParams),
             post_process=Depends(self.process_dependency),
             stats_params=Depends(self.stats_dependency),
             histogram_params=Depends(self.histogram_dependency),
-            reader_params=Depends(self.reader_dependency),
             env=Depends(self.environment_dependency),
         ):
             """Get Statistics from a geojson feature or featureCollection."""
@@ -1632,7 +1637,7 @@ class TMSFactory(BaseFactory):
             responses={
                 200: {
                     "content": {
-                        MediaType.json.value: {},
+                        "application/json": {},
                     },
                 },
             },
@@ -1673,7 +1678,7 @@ class TMSFactory(BaseFactory):
             responses={
                 200: {
                     "content": {
-                        MediaType.json.value: {},
+                        "application/json": {},
                     },
                 },
             },

--- a/src/titiler/core/titiler/core/templates/map.html
+++ b/src/titiler/core/titiler/core/templates/map.html
@@ -86,20 +86,33 @@ fetch('{{ tilejson_endpoint|safe }}')
 
     let bounds = [...data.bounds]
 
+    var left = bounds[0],
+      bottom = bounds[1],
+      right = bounds[2],
+      top = bounds[3];
+
+    if (left < right) {
+      left = Math.max(left, {{ tms.bbox.left }})
+      right = Math.min(right, {{ tms.bbox.right }})
+    }
+    bottom = Math.max(bottom, {{ tms.bbox.bottom }})
+    top = Math.min(top, {{ tms.bbox.top }})
+    console.log(left, bottom, right, top)
+
     let geo;
     // handle files that span accross dateline
-    if (bounds[0] > bounds[2]) {
+    if (left > right) {
       geo = {
         "type": "FeatureCollection",
         "features": [
-          bboxPolygon([-180, bounds[1], bounds[2], bounds[3]]),
-          bboxPolygon([bounds[0], bounds[1], 180, bounds[3]]),
+          bboxPolygon([-180, bottom, right, top]),
+          bboxPolygon([left, bottom, 180, top]),
         ]
       }
     } else {
       geo = {
         "type": "FeatureCollection",
-        "features": [bboxPolygon(bounds)]
+        "features": [bboxPolygon([left, bottom, right, top])]
       }
     }
     console.log(geo)
@@ -110,13 +123,9 @@ fetch('{{ tilejson_endpoint|safe }}')
     map.fitBounds(aoi.getBounds());
 
     // Bounds crossing dateline
-    if (bounds[0] > bounds[2]) {
-      bounds[0] = bounds[0] - 360
+    if (left > right) {
+      left = right - 360
     }
-    var left = bounds[0],
-      bottom = bounds[1],
-      right = bounds[2],
-      top = bounds[3];
 
     L.tileLayer(
       data.tiles[0], {

--- a/src/titiler/core/titiler/core/templates/wmts.xml
+++ b/src/titiler/core/titiler/core/templates/wmts.xml
@@ -33,25 +33,27 @@
         </ows:Operation>
     </ows:OperationsMetadata>
     <Contents>
+    {% for layer in layers %}
         <Layer>
-            <ows:Title>{{ title }}</ows:Title>
-            <ows:Identifier>{{ layer_name }}</ows:Identifier>
-            <ows:Abstract>{{ title }}</ows:Abstract>
+            <ows:Title>{{ layer.title }}</ows:Title>
+            <ows:Identifier>{{ layer.name }}</ows:Identifier>
+            <ows:Abstract>{{ layer.name }}</ows:Abstract>
             <ows:{{ bbox_crs_type }} crs="{{ bbox_crs_uri }}">
-                <ows:LowerCorner>{{ bounds[0] }} {{ bounds[1] }}</ows:LowerCorner>
-                <ows:UpperCorner>{{ bounds[2] }} {{ bounds[3] }}</ows:UpperCorner>
+                <ows:LowerCorner>{{ layer.bounds[0] }} {{ layer.bounds[1] }}</ows:LowerCorner>
+                <ows:UpperCorner>{{ layer.bounds[2] }} {{ layer.bounds[3] }}</ows:UpperCorner>
             </ows:{{ bbox_crs_type }}>
             <Style isDefault="true">
                 <ows:Identifier>default</ows:Identifier>
             </Style>
             <Format>{{ media_type }}</Format>
             <TileMatrixSetLink>
-                <TileMatrixSet>{{ tms.id }}</TileMatrixSet>
+                <TileMatrixSet>{{ tileMatrixSetId }}</TileMatrixSet>
             </TileMatrixSetLink>
-            <ResourceURL format="{{ media_type }}" resourceType="tile" template="{{ tiles_endpoint | escape }}" />
+            <ResourceURL format="{{ media_type }}" resourceType="tile" template="{{ layer.tiles_url }}?{{ layer.query_string | escape }}" />
         </Layer>
+    {% endfor %}
         <TileMatrixSet>
-            <ows:Identifier>{{ tms.id }}</ows:Identifier>
+            <ows:Identifier>{{ tileMatrixSetId }}</ows:Identifier>
             <ows:SupportedCRS>{{ supported_crs }}</ows:SupportedCRS>
             {% for item in tileMatrix %}
             {{ item | safe }}

--- a/src/titiler/extensions/titiler/extensions/wms.py
+++ b/src/titiler/extensions/titiler/extensions/wms.py
@@ -284,13 +284,13 @@ class wmsExtension(FactoryExtension):
         def wms(  # noqa: C901
             request: Request,
             # vendor (titiler) parameters
+            reader_params=Depends(factory.reader_dependency),
             layer_params=Depends(factory.layer_dependency),
             dataset_params=Depends(factory.dataset_dependency),
             post_process=Depends(factory.process_dependency),
             rescale=Depends(RescalingParams),
             color_formula=Depends(ColorFormulaParams),
             colormap=Depends(factory.colormap_dependency),
-            reader_params=Depends(factory.reader_dependency),
             env=Depends(factory.environment_dependency),
         ):
             """Return a WMS query for a single COG.

--- a/src/titiler/mosaic/titiler/mosaic/factory.py
+++ b/src/titiler/mosaic/titiler/mosaic/factory.py
@@ -45,7 +45,7 @@ from titiler.core.dependencies import (
 )
 from titiler.core.factory import DEFAULT_TEMPLATES, BaseFactory, img_endpoint_params
 from titiler.core.models.mapbox import TileJSON
-from titiler.core.resources.enums import ImageType, MediaType, OptionalHeader
+from titiler.core.resources.enums import ImageType, OptionalHeader
 from titiler.core.resources.responses import GeoJSONResponse, JSONResponse, XMLResponse
 from titiler.core.utils import render_image
 from titiler.mosaic.models.responses import Point
@@ -316,6 +316,8 @@ class MosaicTilerFactory(BaseFactory):
                 "Default will be automatically defined if the output image needs a mask (png) or not (jpeg).",
             ] = None,
             src_path=Depends(self.path_dependency),
+            backend_params=Depends(self.backend_dependency),
+            reader_params=Depends(self.reader_dependency),
             layer_params=Depends(self.layer_dependency),
             dataset_params=Depends(self.dataset_dependency),
             pixel_selection=Depends(self.pixel_selection_dependency),
@@ -325,8 +327,6 @@ class MosaicTilerFactory(BaseFactory):
             color_formula=Depends(self.color_formula_dependency),
             colormap=Depends(self.colormap_dependency),
             render_params=Depends(self.render_dependency),
-            backend_params=Depends(self.backend_dependency),
-            reader_params=Depends(self.reader_dependency),
             env=Depends(self.environment_dependency),
         ):
             """Create map tile from a COG."""
@@ -410,7 +410,6 @@ class MosaicTilerFactory(BaseFactory):
                     description="Identifier selecting one of the TileMatrixSetId supported."
                 ),
             ],
-            src_path=Depends(self.path_dependency),
             tile_format: Annotated[
                 Optional[ImageType],
                 Query(
@@ -431,6 +430,9 @@ class MosaicTilerFactory(BaseFactory):
                 Optional[int],
                 Query(description="Overwrite default maxzoom."),
             ] = None,
+            src_path=Depends(self.path_dependency),
+            backend_params=Depends(self.backend_dependency),
+            reader_params=Depends(self.reader_dependency),
             layer_params=Depends(self.layer_dependency),
             dataset_params=Depends(self.dataset_dependency),
             pixel_selection=Depends(self.pixel_selection_dependency),
@@ -440,8 +442,6 @@ class MosaicTilerFactory(BaseFactory):
             color_formula=Depends(self.color_formula_dependency),
             colormap=Depends(self.colormap_dependency),
             render_params=Depends(self.render_dependency),
-            backend_params=Depends(self.backend_dependency),
-            reader_params=Depends(self.reader_dependency),
             env=Depends(self.environment_dependency),
         ):
             """Return TileJSON document for a COG."""
@@ -504,7 +504,6 @@ class MosaicTilerFactory(BaseFactory):
                     description="Identifier selecting one of the TileMatrixSetId supported."
                 ),
             ],
-            src_path=Depends(self.path_dependency),
             tile_format: Annotated[
                 Optional[ImageType],
                 Query(
@@ -525,6 +524,9 @@ class MosaicTilerFactory(BaseFactory):
                 Optional[int],
                 Query(description="Overwrite default maxzoom."),
             ] = None,
+            src_path=Depends(self.path_dependency),
+            backend_params=Depends(self.backend_dependency),
+            reader_params=Depends(self.reader_dependency),
             layer_params=Depends(self.layer_dependency),
             dataset_params=Depends(self.dataset_dependency),
             pixel_selection=Depends(self.pixel_selection_dependency),
@@ -534,8 +536,6 @@ class MosaicTilerFactory(BaseFactory):
             color_formula=Depends(self.color_formula_dependency),
             colormap=Depends(self.colormap_dependency),
             render_params=Depends(self.render_dependency),
-            backend_params=Depends(self.backend_dependency),
-            reader_params=Depends(self.reader_dependency),
             env=Depends(self.environment_dependency),
         ):
             """Return TileJSON document for a dataset."""
@@ -571,7 +571,6 @@ class MosaicTilerFactory(BaseFactory):
                     description="Identifier selecting one of the TileMatrixSetId supported."
                 ),
             ],
-            src_path=Depends(self.path_dependency),
             tile_format: Annotated[
                 ImageType,
                 Query(description="Output image type. Default is png."),
@@ -596,6 +595,9 @@ class MosaicTilerFactory(BaseFactory):
                     description="Use EPSG code, not opengis.net, for the ows:SupportedCRS in the TileMatrixSet (set to True to enable ArcMap compatability)"
                 ),
             ] = False,
+            src_path=Depends(self.path_dependency),
+            backend_params=Depends(self.backend_dependency),
+            reader_params=Depends(self.reader_dependency),
             layer_params=Depends(self.layer_dependency),
             dataset_params=Depends(self.dataset_dependency),
             pixel_selection=Depends(self.pixel_selection_dependency),
@@ -605,8 +607,6 @@ class MosaicTilerFactory(BaseFactory):
             color_formula=Depends(self.color_formula_dependency),
             colormap=Depends(self.colormap_dependency),
             render_params=Depends(self.render_dependency),
-            backend_params=Depends(self.backend_dependency),
-            reader_params=Depends(self.reader_dependency),
             env=Depends(self.environment_dependency),
         ):
             """OGC WMTS endpoint."""
@@ -635,8 +635,6 @@ class MosaicTilerFactory(BaseFactory):
                 for (key, value) in request.query_params._list
                 if key.lower() not in qs_key_to_remove
             ]
-            if qs:
-                tiles_url += f"?{urlencode(qs)}"
 
             tms = self.supported_tms.get(tileMatrixSetId)
             with rasterio.Env(**env):
@@ -671,6 +669,18 @@ class MosaicTilerFactory(BaseFactory):
             else:
                 supported_crs = tms.crs.srs
 
+            layers = [
+                {
+                    "title": src_path
+                    if isinstance(src_path, str)
+                    else "TiTiler Mosaic",
+                    "name": "default",
+                    "tiles_url": tiles_url,
+                    "query_string": urlencode(qs, doseq=True) if qs else None,
+                    "bounds": bounds,
+                },
+            ]
+
             bbox_crs_type = "WGS84BoundingBox"
             bbox_crs_uri = "urn:ogc:def:crs:OGC:2:84"
             if tms.rasterio_geographic_crs != WGS84_CRS:
@@ -681,20 +691,15 @@ class MosaicTilerFactory(BaseFactory):
                 request,
                 name="wmts.xml",
                 context={
-                    "tiles_endpoint": tiles_url,
-                    "bounds": bounds,
+                    "tileMatrixSetId": tms.id,
                     "tileMatrix": tileMatrix,
-                    "tms": tms,
                     "supported_crs": supported_crs,
                     "bbox_crs_type": bbox_crs_type,
                     "bbox_crs_uri": bbox_crs_uri,
-                    "title": src_path
-                    if isinstance(src_path, str)
-                    else "TiTiler Mosaic",
-                    "layer_name": "Mosaic",
+                    "layers": layers,
                     "media_type": tile_format.mediatype,
                 },
-                media_type=MediaType.xml.value,
+                media_type="application/xml",
             )
 
     ############################################################################
@@ -714,11 +719,11 @@ class MosaicTilerFactory(BaseFactory):
             lon: Annotated[float, Path(description="Longitude")],
             lat: Annotated[float, Path(description="Latitude")],
             src_path=Depends(self.path_dependency),
+            backend_params=Depends(self.backend_dependency),
+            reader_params=Depends(self.reader_dependency),
             coord_crs=Depends(CoordCRSParams),
             layer_params=Depends(self.layer_dependency),
             dataset_params=Depends(self.dataset_dependency),
-            backend_params=Depends(self.backend_dependency),
-            reader_params=Depends(self.reader_dependency),
             env=Depends(self.environment_dependency),
         ):
             """Get Point value for a Mosaic."""
@@ -768,9 +773,9 @@ class MosaicTilerFactory(BaseFactory):
             maxx: Annotated[float, Path(description="Bounding box max X")],
             maxy: Annotated[float, Path(description="Bounding box max Y")],
             src_path=Depends(self.path_dependency),
-            coord_crs=Depends(CoordCRSParams),
             backend_params=Depends(self.backend_dependency),
             reader_params=Depends(self.reader_dependency),
+            coord_crs=Depends(CoordCRSParams),
             env=Depends(self.environment_dependency),
         ):
             """Return a list of assets which overlap a bounding box"""


### PR DESCRIPTION
This PR takes some modification from #1007 

- update WMTS template to add `layers` (would be used by STAC+render) 
- reorder dependencies (for OpenAPI docs)
- fix bounds overflow on `map` viewer 