### PR TITLE
set min/maxNativeZoom in tileLayer instead of min/maxZoom

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,7 @@
 * Use `@attrs.define` instead of dataclass for factories **breaking change**
 * Use `@attrs.define` instead of dataclass for factory extensions **breaking change**
 * Handle `numpy` types in JSON/GeoJSON response
+* In the `map.html` template, use the tilejson's `minzoom` and `maxzoom` to populate `minNativeZoom` and `maxNativeZoom` parameters in leaflet `tileLayer` instead of `minZoom` and `maxZoom` 
 
 ### titiler.core
 

--- a/src/titiler/core/titiler/core/templates/map.html
+++ b/src/titiler/core/titiler/core/templates/map.html
@@ -129,8 +129,8 @@ fetch('{{ tilejson_endpoint|safe }}')
 
     L.tileLayer(
       data.tiles[0], {
-        minZoom: data.minzoom,
-        maxZoom: data.maxzoom,
+        maxNativeZoom: data.maxzoom,
+        minNativeZoom: data.minzoom,
         bounds: L.latLngBounds([bottom, left], [top, right]),
       }
     ).addTo(map);


### PR DESCRIPTION
The `minZoom` and `maxZoom` parameters in the `tileLayer` class just control which zoom levels on which tiles from the layer will be displayed. Setting `minNativeZoom` and `maxNativeZoom` to the `tilejson` `minzoom` and `maxzoom` makes more sense and allows us to show tiles from layers where the default `maxzoom` is very low (e.g. 0) which can happen for very low-resolution datasets.

> `maxNativeZoom`: Maximum zoom number the tile source has available. If it is specified, the tiles on all zoom levels higher than maxNativeZoom will be loaded from maxNativeZoom level and auto-scaled.

[leaflet API docs](https://leafletjs.com/reference.html#tilelayer-maxnativezoom)