### PR TITLE
Updating Azure Functions Commands

### DIFF
--- a/deployment/azure/README.md
+++ b/deployment/azure/README.md
@@ -40,9 +40,9 @@ $ cd titiler/deployment/azure
 
 $ az login
 $ az group create --name AzureFunctionsTiTiler-rg --location eastus
-$ az storage account create --name titilerstorage --sku Standard_LRS -g AzureFunctionsTiTiler-rg
-$ az functionapp create --consumption-plan-location eastus --runtime python --runtime-version 3.8 --functions-version 3 --name titiler --os-type linux -g AzureFunctionsTiTiler-rg -s titilerstorage
-$ func azure functionapp publish titiler
+$ az storage account create --name {your-new-storage-name} --sku Standard_LRS -g AzureFunctionsTiTiler-rg
+$ az functionapp create --consumption-plan-location eastus --runtime python --runtime-version 3.9 --functions-version 4 --name {your-new-function-name} --os-type linux -g AzureFunctionsTiTiler-rg -s {your-new-storage-name}
+$ func azure functionapp publish titiler --python
 ```
 
 or


### PR DESCRIPTION
Changed:

- Python runtime version from 3.8 to 3.9 (azure function no longer supports 3.8)

- Functions version was updated from 3 to 4 (you wont be able to create a new app function on version 3). 

- Added the --python flag at the end of the publishing command, infering the FUNCTIONS_WORKER_RUNTIME.

Here's some testing I made that backs the points above:
![image](https://github.com/user-attachments/assets/0a3b71e6-c081-4fbd-add5-bd36b68566a1)
![image](https://github.com/user-attachments/assets/9d610d6c-6a76-4358-95cb-b71890d4b22c)
![image](https://github.com/user-attachments/assets/c8912ed1-6770-4f56-aad7-52fb33b0c306)

Alternatively, I have added variables instead of fixed values for container name and app name, given that it must be a unique name for each new instance and that can confuse people not familiar with how blob storage works.
