### PR TITLE
Fix typo in documentation(docs/src/external_links.md) URL

### DIFF
--- a/docs/src/external_links.md
+++ b/docs/src/external_links.md
@@ -19,7 +19,7 @@
 
 * [developmentseed/titiler-xarray](https://github.com/developmentseed/titiler-xarray): TiTiler extension for xarray
 
-* [developmentseed/titiler-images](https://github.com/developmentseed/titiler-images): TiTiler demo application for Sentinel-2 Digital Twin dataset
+* [developmentseed/titiler-image](https://github.com/developmentseed/titiler-image): TiTiler demo application for Sentinel-2 Digital Twin dataset
 
 
 ## Projects / Demo using TiTiler


### PR DESCRIPTION
## What I am changing
<!-- What were the high-level goals of the change? -->
- Fix typo in documentation URL to ensure correct linking
  - Corrected URL from https://github.com/developmentseed/titiler-images to https://github.com/developmentseed/titiler-image
- Improve documentation accuracy for better user experience

## How I did it
<!-- How did you go about achieving these goals? Any considerations made along the way? -->
- Identified incorrect URL in the documentation
- Updated the URL to the correct destination
- Verified the new URL works as expected

## How you can test it
<!-- How might a reviewer test your changes to verify that they work as expected? -->
- Clone the repository
- Navigate to the updated documentation
- Click on the corrected URL to verify it leads to the intended destination
- Alternatively, you can check the rendered documentation on the PR preview

## Related Issues
<!-- Reference any issues that inspired this PR. Use a keyword to auto-close any issues when this PR is merged (eg "closes #1") -->
No related issues. This is a straightforward documentation fix.