### PR TITLE
style: use generator expression in CacheControlMiddleware.any()

### DIFF
--- a/src/titiler/core/titiler/core/middleware.py
+++ b/src/titiler/core/titiler/core/middleware.py
@@ -50,10 +50,7 @@ class CacheControlMiddleware:
                         scope["method"] in ["HEAD", "GET"]
                         and message["status"] < self.cachecontrol_max_http_code
                         and not any(
-                            [
-                                re.match(path, scope["path"])
-                                for path in self.exclude_path
-                            ]
+                            re.match(path, scope["path"]) for path in self.exclude_path
                         )
                     ):
                         response_headers["Cache-Control"] = self.cachecontrol


### PR DESCRIPTION
Since any() doesn't require a materialized list, simplify the code to use generator expression instead of a list comprehension. Makes it ~tiny bit performant and readable. cc @vincentsarago 