### PR TITLE
Include rasterio.show_versions() output in healthz endpoint

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,12 @@
 ## Unreleased
 
 ### titiler.core
+
 * Add layer control to map viewer template (author @hrodmn, https://github.com/developmentseed/titiler/pull/1051)
+
+### titiler.application
+
+* update `/healthz` endpoint to return dependencies versions (titiler, rasterio, gdal, ...) (author @scottyhq, https://github.com/developmentseed/titiler/pull/1056)
 
 ## 0.19.2 (2024-11-28)
 

--- a/src/titiler/application/tests/test_main.py
+++ b/src/titiler/application/tests/test_main.py
@@ -5,7 +5,8 @@ def test_health(app):
     """Test /healthz endpoint."""
     response = app.get("/healthz")
     assert response.status_code == 200
-    assert set(response["versions"].keys()) == {
+    resp = response.json()
+    assert set(resp["versions"].keys()) == {
         "titiler",
         "gdal",
         "geos",

--- a/src/titiler/application/tests/test_main.py
+++ b/src/titiler/application/tests/test_main.py
@@ -5,7 +5,13 @@ def test_health(app):
     """Test /healthz endpoint."""
     response = app.get("/healthz")
     assert response.status_code == 200
-    assert response.json() == {"ping": "pong!"}
+    assert set(response["versions"].keys()) == {
+        "titiler",
+        "gdal",
+        "geos",
+        "proj",
+        "rasterio",
+    }
 
     response = app.get("/api")
     assert response.status_code == 200

--- a/src/titiler/application/titiler/application/main.py
+++ b/src/titiler/application/titiler/application/main.py
@@ -1,13 +1,11 @@
 """titiler app."""
-import io
 import logging
 import re
-from contextlib import redirect_stdout
 
 import jinja2
+import rasterio
 from fastapi import Depends, FastAPI, HTTPException, Security
 from fastapi.security.api_key import APIKeyQuery
-from rasterio import show_versions
 from rio_tiler.io import Reader, STACReader
 from starlette.middleware.cors import CORSMiddleware
 from starlette.requests import Request
@@ -217,10 +215,15 @@ if api_settings.lower_case_query_parameters:
 )
 def ping():
     """Health check."""
-    with redirect_stdout(io.StringIO()) as f:
-        show_versions()
-    rasterio_versions = f.getvalue().splitlines()
-    return {"Hello from titiler!": rasterio_versions}
+    return {
+        "versions": {
+            "titiler": titiler_version,
+            "rasterio": rasterio.__version__,
+            "gdal": rasterio.__gdal_version__,
+            "proj": rasterio.__proj_version__,
+            "geos": rasterio.__geos_version__,
+        }
+    }
 
 
 @app.get("/", response_class=HTMLResponse, include_in_schema=False)

--- a/src/titiler/application/titiler/application/main.py
+++ b/src/titiler/application/titiler/application/main.py
@@ -1,11 +1,13 @@
 """titiler app."""
-
+import io
 import logging
 import re
+from contextlib import redirect_stdout
 
 import jinja2
 from fastapi import Depends, FastAPI, HTTPException, Security
 from fastapi.security.api_key import APIKeyQuery
+from rasterio import show_versions
 from rio_tiler.io import Reader, STACReader
 from starlette.middleware.cors import CORSMiddleware
 from starlette.requests import Request
@@ -215,7 +217,10 @@ if api_settings.lower_case_query_parameters:
 )
 def ping():
     """Health check."""
-    return {"ping": "pong!"}
+    with redirect_stdout(io.StringIO()) as f:
+        show_versions()
+    rasterio_versions = f.getvalue().splitlines()
+    return {"Hello from titiler!": rasterio_versions}
 
 
 @app.get("/", response_class=HTMLResponse, include_in_schema=False)

--- a/src/titiler/application/titiler/application/main.py
+++ b/src/titiler/application/titiler/application/main.py
@@ -213,7 +213,7 @@ if api_settings.lower_case_query_parameters:
     operation_id="healthCheck",
     tags=["Health Check"],
 )
-def ping():
+def application_health_check():
     """Health check."""
     return {
         "versions": {


### PR DESCRIPTION
This is a hasty attempt to add `rasterio.show_versions()` to the `healthz` endpoint as discussed in https://github.com/developmentseed/titiler/discussions/731 . It "works" but formatting could be improved...

```bash
curl -X 'GET' \
  'http://127.0.0.1:8000/healthz' \
  -H 'accept: application/json' | jq
```

```
{
  "Hello from titiler!": [
    "rasterio info:",
    "  rasterio: 1.4.3",
    "      GDAL: 3.9.3",
    "      PROJ: 9.4.1",
    "      GEOS: 0.0.0",
    " PROJ DATA: /Users/scotthenderson/miniforge3/envs/titiler/lib/python3.11/site-packages/rasterio/proj_data",
    " GDAL DATA: /Users/scotthenderson/miniforge3/envs/titiler/lib/python3.11/site-packages/rasterio/gdal_data",
    "",
    "System:",
    "    python: 3.11.11 | packaged by conda-forge | (main, Dec  5 2024, 14:21:42) [Clang 18.1.8 ]",
    "executable: /Users/scotthenderson/miniforge3/envs/titiler/bin/python",
    "   machine: macOS-15.2-arm64-arm-64bit",
    "",
    "Python deps:",
    "    affine: 2.4.0",
    "     attrs: 24.3.0",
    "   certifi: 2024.12.14",
    "     click: 8.1.7",
    "     cligj: 0.7.2",
    "    cython: None",
    "     numpy: 2.2.0",
    "click-plugins: None",
    "setuptools: 75.6.0"
  ]
}
```