### PR TITLE
Fix type used for group argument in xarray tests

### DIFF
--- a/src/titiler/xarray/tests/test_io_tools.py
+++ b/src/titiler/xarray/tests/test_io_tools.py
@@ -129,13 +129,13 @@ def test_reader(protocol, filename):
 
 @pytest.mark.parametrize(
     "group",
-    ["0", "1", "2"],
+    [0, 1, 2],
 )
 def test_zarr_group(group):
     """test reader."""
     src_path = os.path.join(prefix, "pyramid.zarr")
 
-    with Reader(src_path, variable="dataset", group=group) as src:
+    with Reader(src_path, variable="dataset", group=str(group)) as src:
         assert src.info()
         assert src.tile(0, 0, 0)
         assert src.point(0, 0).data[0] == group * 2 + 1

--- a/src/titiler/xarray/tests/test_io_tools.py
+++ b/src/titiler/xarray/tests/test_io_tools.py
@@ -129,7 +129,7 @@ def test_reader(protocol, filename):
 
 @pytest.mark.parametrize(
     "group",
-    [0, 1, 2],
+    ["0", "1", "2"],
 )
 def test_zarr_group(group):
     """test reader."""


### PR DESCRIPTION
Keys for Zarr stores should be ASCII strings in both the v2 and v3 specifications, but Zarr-Python 3.0 is less lenient than Zarr-Python 2.0 and does not cast types. This PR updates the tests to use a valid group key (str rather than int).

Progress towards https://github.com/developmentseed/titiler/issues/1068