### PR TITLE
Add slope algorithm

### DIFF
--- a/src/titiler/core/tests/test_algorithms.py
+++ b/src/titiler/core/tests/test_algorithms.py
@@ -168,6 +168,29 @@ def test_hillshade():
     assert out.array[0, 0, 0] is numpy.ma.masked
 
 
+def test_slope():
+    """test slope."""
+    algo = default_algorithms.get("slope")()
+
+    arr = numpy.random.randint(0, 5000, (1, 262, 262), dtype="uint16")
+    img = ImageData(arr)
+    out = algo(img)
+    assert out.array.shape == (1, 256, 256)
+    assert out.array.dtype == "float32"
+
+    arr = numpy.ma.MaskedArray(
+        numpy.random.randint(0, 5000, (1, 262, 262), dtype="uint16"),
+        mask=numpy.zeros((1, 262, 262), dtype="bool"),
+    )
+    arr.mask[0, 0:100, 0:100] = True
+
+    img = ImageData(arr)
+    out = algo(img)
+    assert out.array.shape == (1, 256, 256)
+    assert out.array.dtype == "float32"
+    assert out.array[0, 0, 0] is numpy.ma.masked
+
+
 def test_contours():
     """test contours."""
     algo = default_algorithms.get("contours")()

--- a/src/titiler/core/titiler/core/algorithm/__init__.py
+++ b/src/titiler/core/titiler/core/algorithm/__init__.py
@@ -11,12 +11,13 @@ from typing_extensions import Annotated
 
 from titiler.core.algorithm.base import AlgorithmMetadata  # noqa
 from titiler.core.algorithm.base import BaseAlgorithm
-from titiler.core.algorithm.dem import Contours, HillShade, TerrainRGB, Terrarium
+from titiler.core.algorithm.dem import Contours, HillShade, Slope, TerrainRGB, Terrarium
 from titiler.core.algorithm.index import NormalizedIndex
 from titiler.core.algorithm.ops import CastToInt, Ceil, Floor
 
 default_algorithms: Dict[str, Type[BaseAlgorithm]] = {
     "hillshade": HillShade,
+    "slope": Slope,
     "contours": Contours,
     "normalizedIndex": NormalizedIndex,
     "terrarium": Terrarium,


### PR DESCRIPTION
Adds a slope algorithm that computes the slope of a raster in degrees from the horizontal. The intended range of output values is from 0 (horizontal) to 90 (vertical). 

Since it's possible to convert to percentage slope using raster band math (`b1/90`), I didn't bother to include any parameters for controlling wether or not the algorithm outputs degrees or percent slope.

The only parameter for the algorithm is `buffer`, which follows the hillshade defaults. This can be used to reduce edge artifacts in the computed slope. Users should specify the same buffer for the tile request as they do for the algorithm parameter (which defaults to 3).

<img width="676" alt="image" src="https://github.com/user-attachments/assets/84802b27-c0e8-4b8d-a0ad-e7f67ebbb722" />
