### PR TITLE
Add output min and max metadata to slope algorithm

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## Unreleased
+
+### titiler.core
+
+* add `output_min` and `output_max` metadata attributes to `slope` algorithm (@tayden, https://github.com/developmentseed/titiler/pull/1089)
+
 ## 0.21.1 (2025-01-29)
 
 ### titiler.core

--- a/src/titiler/core/titiler/core/algorithm/dem.py
+++ b/src/titiler/core/titiler/core/algorithm/dem.py
@@ -76,6 +76,8 @@ class Slope(BaseAlgorithm):
     input_nbands: int = 1
     output_nbands: int = 1
     output_dtype: str = "float32"
+    output_min: float = 0
+    output_max: float = 90
 
     def __call__(self, img: ImageData) -> ImageData:
         """Calculate degrees slope from DEM dataset."""


### PR DESCRIPTION
This is just a small tweak to add more output metadata to the slope algorithm.