### PR TITLE
Update Dockerfile to move handler and set command for Lambda function

### DIFF
--- a/deployment/aws/lambda/Dockerfile
+++ b/deployment/aws/lambda/Dockerfile
@@ -21,5 +21,5 @@ RUN rm -rdf /asset/numpy/doc/ /asset/boto3* /asset/botocore* /asset/bin /asset/g
 RUN yum remove -y gcc-c++
 
 COPY lambda/handler.py /asset/handler.py
-
-CMD ["echo", "hello world"]
+RUN mv /asset/* ${LAMBDA_TASK_ROOT}/
+CMD ["handler.handler"]


### PR DESCRIPTION
## What I am changing
- Moving all files from the `/asset` directory into the Lambda task root (`${LAMBDA_TASK_ROOT}`).
- Updating the CMD instruction to invoke the correct Lambda handler (`handler.handler`) instead of the placeholder echo command.

## How I did it
- Inserted the command `RUN mv /asset/* ${LAMBDA_TASK_ROOT}/` in the Dockerfile to move all asset files to the correct directory.
- Changed the CMD line from `CMD ["echo", "hello world"]` to `CMD ["handler.handler"]`, ensuring AWS Lambda calls the proper function defined in `handler.py`.

## How you can test it
- Build the Docker image locally using the updated Dockerfile.
- Run the image with the Lambda runtime interface emulator (or deploy to AWS Lambda) and invoke the function.
- Verify that the Lambda function executes the handler from `handler.py` and returns the expected result.

## Related Issues
- (None)
