### PR TITLE
Bump cdk to 2.185.0

### DIFF
--- a/deployment/aws/cdk/app.py
+++ b/deployment/aws/cdk/app.py
@@ -4,14 +4,14 @@ import os
 from typing import Any, Dict, List, Optional, Union
 
 from aws_cdk import App, CfnOutput, Duration, Stack, Tags
-from aws_cdk import aws_apigatewayv2_alpha as apigw
+from aws_cdk import aws_apigatewayv2 as apigw
 from aws_cdk import aws_ec2 as ec2
 from aws_cdk import aws_ecs as ecs
 from aws_cdk import aws_ecs_patterns as ecs_patterns
 from aws_cdk import aws_iam as iam
 from aws_cdk import aws_lambda
 from aws_cdk import aws_logs as logs
-from aws_cdk.aws_apigatewayv2_integrations_alpha import HttpLambdaIntegration
+from aws_cdk.aws_apigatewayv2_integrations import HttpLambdaIntegration
 from config import StackSettings
 from constructs import Construct
 

--- a/deployment/aws/package-lock.json
+++ b/deployment/aws/package-lock.json
@@ -9,13 +9,14 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "cdk": "2.94.0"
+        "cdk": "2.1005.0"
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.94.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.94.0.tgz",
-      "integrity": "sha512-9bJkzxFDYZDwPDfZi/DSUODn4HFRzuXWPhpFgIIgRykfT18P+iAIJ1AEhaaCmlqrrog5yQgN+2iYd9BwDsiBeg==",
+      "version": "2.1005.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1005.0.tgz",
+      "integrity": "sha512-4ejfGGrGCEl0pg1xcqkxK0lpBEZqNI48wtrXhk6dYOFYPYMZtqn1kdla29ONN+eO2unewkNF4nLP1lPYhlf9Pg==",
+      "license": "Apache-2.0",
       "bin": {
         "cdk": "bin/cdk"
       },
@@ -27,11 +28,12 @@
       }
     },
     "node_modules/cdk": {
-      "version": "2.94.0",
-      "resolved": "https://registry.npmjs.org/cdk/-/cdk-2.94.0.tgz",
-      "integrity": "sha512-dMgSTaMtfpPxY2biMSHlNrwrJcq0iJkihvkVuSSQyhlHyLmH0s9fSBzO8zrGFAoEp/cDofg6iDfGzmwrHQ55LA==",
+      "version": "2.1005.0",
+      "resolved": "https://registry.npmjs.org/cdk/-/cdk-2.1005.0.tgz",
+      "integrity": "sha512-G0M16zulF+9bd9TF99qrAe6M/b0plNzeEofwG2KIqSnobNNfmLNRqRQG11Z8EUV2KfsRPrlpN+iP9svO+xFv9Q==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "aws-cdk": "2.94.0"
+        "aws-cdk": "^2.1005.0"
       },
       "bin": {
         "cdk": "bin/cdk"
@@ -45,6 +47,7 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "hasInstallScript": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -56,19 +59,19 @@
   },
   "dependencies": {
     "aws-cdk": {
-      "version": "2.94.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.94.0.tgz",
-      "integrity": "sha512-9bJkzxFDYZDwPDfZi/DSUODn4HFRzuXWPhpFgIIgRykfT18P+iAIJ1AEhaaCmlqrrog5yQgN+2iYd9BwDsiBeg==",
+      "version": "2.1005.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1005.0.tgz",
+      "integrity": "sha512-4ejfGGrGCEl0pg1xcqkxK0lpBEZqNI48wtrXhk6dYOFYPYMZtqn1kdla29ONN+eO2unewkNF4nLP1lPYhlf9Pg==",
       "requires": {
         "fsevents": "2.3.2"
       }
     },
     "cdk": {
-      "version": "2.94.0",
-      "resolved": "https://registry.npmjs.org/cdk/-/cdk-2.94.0.tgz",
-      "integrity": "sha512-dMgSTaMtfpPxY2biMSHlNrwrJcq0iJkihvkVuSSQyhlHyLmH0s9fSBzO8zrGFAoEp/cDofg6iDfGzmwrHQ55LA==",
+      "version": "2.1005.0",
+      "resolved": "https://registry.npmjs.org/cdk/-/cdk-2.1005.0.tgz",
+      "integrity": "sha512-G0M16zulF+9bd9TF99qrAe6M/b0plNzeEofwG2KIqSnobNNfmLNRqRQG11Z8EUV2KfsRPrlpN+iP9svO+xFv9Q==",
       "requires": {
-        "aws-cdk": "2.94.0"
+        "aws-cdk": "^2.1005.0"
       }
     },
     "fsevents": {

--- a/deployment/aws/package.json
+++ b/deployment/aws/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "private": true,
   "dependencies": {
-    "cdk": "2.94.0"
+    "cdk": "2.1005.0"
   },
   "scripts": {
     "cdk": "cdk"

--- a/deployment/aws/requirements-cdk.txt
+++ b/deployment/aws/requirements-cdk.txt
@@ -1,7 +1,7 @@
 # aws cdk
-aws-cdk-lib==2.94.0
-aws_cdk-aws_apigatewayv2_alpha==2.94.0a0
-aws_cdk-aws_apigatewayv2_integrations_alpha==2.94.0a0
+aws-cdk-lib==2.185.0
+# aws_cdk-aws_apigatewayv2_alpha==2.185.0
+# aws_cdk-aws_apigatewayv2_integrations_alpha==2.185.0
 constructs>=10.0.0
 
 # pydantic settings

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON_VERSION=3.12
+ARG PYTHON_VERSION=3.13
 
 FROM bitnami/python:${PYTHON_VERSION}
 RUN apt update && apt upgrade -y \


### PR DESCRIPTION
## Bump cdk to 2.185.0

(Not sure how to use this template)

+ Bump cdk to 2.185.0
+ Use python 3.13 in dockerfiles/Dockerfile

I guess that it should be possible to test this, and when accept it.
I have tested the dockerfile using tiss env:

    docker-compose up --build titiler
