### PR TITLE
Fix TerrainRGB algorithm and param user-controlled nodata-height

### DIFF
--- a/docs/src/advanced/Algorithms.md
+++ b/docs/src/advanced/Algorithms.md
@@ -9,8 +9,8 @@ We added a set of custom algorithms:
 - `hillshade`: Create hillshade from elevation dataset
 - `contours`: Create contours lines (raster) from elevation dataset
 - `slope`: Create degrees of slope from elevation dataset 
-- `terrarium`: Mapzen's format to encode elevation value in RGB values (https://github.com/tilezen/joerd/blob/master/docs/formats.md#terrarium)
-- `terrainrgb`: Mapbox's format to encode elevation value in RGB values (https://docs.mapbox.com/data/tilesets/guides/access-elevation-data/)
+- `terrarium`: [Mapzen's format]((https://github.com/tilezen/joerd/blob/master/docs/formats.md#terrarium)) to encode elevation value in RGB values  `elevation = (red * 256 + green + blue / 256) - 32768`
+- `terrainrgb`: [Mapbox](https://docs.mapbox.com/data/tilesets/guides/access-elevation-data/)/[Maptiler](https://docs.maptiler.com/guides/map-tilling-hosting/data-hosting/rgb-terrain-by-maptiler/)'s format to encode elevation value in RGB values `elevation = -10000 + ((red * 256 * 256 + green * 256 + blue) * 0.1)`
 - `normalizedIndex`: Normalized Difference Index (e.g NDVI)
 - `cast`: Cast data to integer
 - `floor`: Round data to the smallest integer

--- a/docs/src/advanced/Algorithms.md
+++ b/docs/src/advanced/Algorithms.md
@@ -6,8 +6,8 @@ The algorithms are meant to overcome the limitation of `expression` (using [nume
 
 We added a set of custom algorithms:
 
-- `hillshade`: Create hillshade from elevation dataset
-- `contours`: Create contours lines (raster) from elevation dataset
+- `hillshade`: Create hillshade from elevation dataset (parameters: azimuth (45), angle_altitude(45))
+- `contours`: Create contours lines (raster) from elevation dataset (parameters: increment (35), thickness (1))
 - `slope`: Create degrees of slope from elevation dataset 
 - `terrarium`: [Mapzen's format]((https://github.com/tilezen/joerd/blob/master/docs/formats.md#terrarium)) to encode elevation value in RGB values  `elevation = (red * 256 + green + blue / 256) - 32768`
 - `terrainrgb`: [Mapbox](https://docs.mapbox.com/data/tilesets/guides/access-elevation-data/)/[Maptiler](https://docs.maptiler.com/guides/map-tilling-hosting/data-hosting/rgb-terrain-by-maptiler/)'s format to encode elevation value in RGB values `elevation = -10000 + ((red * 256 * 256 + green * 256 + blue) * 0.1)`

--- a/docs/src/advanced/Algorithms.md
+++ b/docs/src/advanced/Algorithms.md
@@ -8,6 +8,7 @@ We added a set of custom algorithms:
 
 - `hillshade`: Create hillshade from elevation dataset
 - `contours`: Create contours lines (raster) from elevation dataset
+- `slope`: Create degrees of slope from elevation dataset 
 - `terrarium`: Mapzen's format to encode elevation value in RGB values (https://github.com/tilezen/joerd/blob/master/docs/formats.md#terrarium)
 - `terrainrgb`: Mapbox's format to encode elevation value in RGB values (https://docs.mapbox.com/data/tilesets/guides/access-elevation-data/)
 - `normalizedIndex`: Normalized Difference Index (e.g NDVI)

--- a/src/titiler/core/tests/test_algorithms.py
+++ b/src/titiler/core/tests/test_algorithms.py
@@ -106,6 +106,25 @@ def test_terrain_algo():
     elevation = (data[0] * 256 + data[1] + data[2] / 256) - 32768
     numpy.testing.assert_array_equal(elevation, arr[0])
 
+    # # test nodata_height 
+    # # MAPBOX Terrain RGB
+    # response = client.get("/", params={"algorithm": "terrainrgb", "algorithm_params":json.dumps({"nodata_height":10.0})})
+    # assert response.status_code == 200
+    # with MemoryFile(response.content) as mem:
+    #     with mem.open() as dst:
+    #         data = dst.read().astype(numpy.float64)
+    # elevation = -10000 + (((data[0] * 256 * 256) + (data[1] * 256) + data[2]) * 0.1)
+    # numpy.testing.assert_array_equal(elevation, arr[0])
+
+    # # TILEZEN Terrarium
+    # response = client.get("/", params={"algorithm": "terrarium", "algorithm_params":json.dumps({"nodata_height":10.0})})
+    # assert response.status_code == 200
+    # with MemoryFile(response.content) as mem:
+    #     with mem.open() as dst:
+    #         data = dst.read().astype(numpy.float64)
+    # elevation = (data[0] * 256 + data[1] + data[2] / 256) - 32768
+    # numpy.testing.assert_array_equal(elevation, arr[0])
+
 
 def test_normalized_index():
     """test ndi."""
@@ -236,6 +255,14 @@ def test_terrarium():
     assert out.array.dtype == "uint8"
     assert out.array[0, 0, 0] is numpy.ma.masked
 
+    # works on the above masked array img, with algo which was passed nodata_height
+    nodata_height = 10.0
+    algo = default_algorithms.get("terrarium")(nodata_height=nodata_height)
+    out = algo(img)
+    masked = out.array[:, arr.mask[0,:,:]]
+    masked_height = (masked[0] * 256 + masked[1] + masked[2] / 256) - 32768
+    numpy.testing.assert_array_equal(masked_height, nodata_height * numpy.ones((100 * 100), dtype="bool"))
+
 
 def test_terrainrgb():
     """test terrainrgb."""
@@ -258,6 +285,14 @@ def test_terrainrgb():
     assert out.array.shape == (3, 256, 256)
     assert out.array.dtype == "uint8"
     assert out.array[0, 0, 0] is numpy.ma.masked
+
+    # works on the above masked array img, with algo which was passed nodata_height
+    nodata_height = 10.0
+    algo = default_algorithms.get("terrainrgb")(nodata_height=nodata_height)
+    out = algo(img)
+    masked = out.array[:, arr.mask[0,:,:]]
+    masked_height = -10000 + (((masked[0] * 256 * 256) + (masked[1] * 256) + masked[2]) * 0.1)
+    numpy.testing.assert_array_equal(masked_height, nodata_height * numpy.ones((100 * 100), dtype="bool"))
 
 
 def test_ops():

--- a/src/titiler/core/tests/test_algorithms.py
+++ b/src/titiler/core/tests/test_algorithms.py
@@ -106,26 +106,6 @@ def test_terrain_algo():
     elevation = (data[0] * 256 + data[1] + data[2] / 256) - 32768
     numpy.testing.assert_array_equal(elevation, arr[0])
 
-    # # test nodata_height 
-    # # MAPBOX Terrain RGB
-    # response = client.get("/", params={"algorithm": "terrainrgb", "algorithm_params":json.dumps({"nodata_height":10.0})})
-    # assert response.status_code == 200
-    # with MemoryFile(response.content) as mem:
-    #     with mem.open() as dst:
-    #         data = dst.read().astype(numpy.float64)
-    # elevation = -10000 + (((data[0] * 256 * 256) + (data[1] * 256) + data[2]) * 0.1)
-    # numpy.testing.assert_array_equal(elevation, arr[0])
-
-    # # TILEZEN Terrarium
-    # response = client.get("/", params={"algorithm": "terrarium", "algorithm_params":json.dumps({"nodata_height":10.0})})
-    # assert response.status_code == 200
-    # with MemoryFile(response.content) as mem:
-    #     with mem.open() as dst:
-    #         data = dst.read().astype(numpy.float64)
-    # elevation = (data[0] * 256 + data[1] + data[2] / 256) - 32768
-    # numpy.testing.assert_array_equal(elevation, arr[0])
-
-
 def test_normalized_index():
     """test ndi."""
     algo = default_algorithms.get("normalizedIndex")()

--- a/src/titiler/core/tests/test_algorithms.py
+++ b/src/titiler/core/tests/test_algorithms.py
@@ -106,6 +106,7 @@ def test_terrain_algo():
     elevation = (data[0] * 256 + data[1] + data[2] / 256) - 32768
     numpy.testing.assert_array_equal(elevation, arr[0])
 
+
 def test_normalized_index():
     """test ndi."""
     algo = default_algorithms.get("normalizedIndex")()
@@ -239,9 +240,11 @@ def test_terrarium():
     nodata_height = 10.0
     algo = default_algorithms.get("terrarium")(nodata_height=nodata_height)
     out = algo(img)
-    masked = out.array[:, arr.mask[0,:,:]]
+    masked = out.array[:, arr.mask[0, :, :]]
     masked_height = (masked[0] * 256 + masked[1] + masked[2] / 256) - 32768
-    numpy.testing.assert_array_equal(masked_height, nodata_height * numpy.ones((100 * 100), dtype="bool"))
+    numpy.testing.assert_array_equal(
+        masked_height, nodata_height * numpy.ones((100 * 100), dtype="bool")
+    )
 
 
 def test_terrainrgb():
@@ -270,9 +273,13 @@ def test_terrainrgb():
     nodata_height = 10.0
     algo = default_algorithms.get("terrainrgb")(nodata_height=nodata_height)
     out = algo(img)
-    masked = out.array[:, arr.mask[0,:,:]]
-    masked_height = -10000 + (((masked[0] * 256 * 256) + (masked[1] * 256) + masked[2]) * 0.1)
-    numpy.testing.assert_array_equal(masked_height, nodata_height * numpy.ones((100 * 100), dtype="bool"))
+    masked = out.array[:, arr.mask[0, :, :]]
+    masked_height = -10000 + (
+        ((masked[0] * 256 * 256) + (masked[1] * 256) + masked[2]) * 0.1
+    )
+    numpy.testing.assert_array_equal(
+        masked_height, nodata_height * numpy.ones((100 * 100), dtype="bool")
+    )
 
 
 def test_ops():

--- a/src/titiler/core/titiler/core/algorithm/dem.py
+++ b/src/titiler/core/titiler/core/algorithm/dem.py
@@ -167,8 +167,7 @@ class Terrarium(BaseAlgorithm):
 
     title: str = "Terrarium"
     description: str = "Encode DEM into RGB (Mapzen Terrarium)."
-    use_nodata_height: bool = Field(False)
-    nodata_height: float = Field(0.0, ge=-99999.0, le=99999.0)
+    nodata_height: Optional[float] = Field(None, ge=-99999.0, le=99999.0)
 
     # metadata
     input_nbands: int = 1

--- a/src/titiler/core/titiler/core/algorithm/dem.py
+++ b/src/titiler/core/titiler/core/algorithm/dem.py
@@ -1,6 +1,7 @@
 """titiler.core.algorithm DEM."""
 
 import numpy
+from typing import Optional
 from pydantic import Field
 from rasterio import windows
 from rio_tiler.colormap import apply_cmap, cmap

--- a/src/titiler/core/titiler/core/algorithm/dem.py
+++ b/src/titiler/core/titiler/core/algorithm/dem.py
@@ -235,7 +235,7 @@ class TerrainRGB(BaseAlgorithm):
         if _range_check(datarange):
             raise ValueError(f"Data of {datarange} larger than 256 ** 3")
 
-        if self.use_nodata_height: 
+        if self.nodata_height is not None: 
             data[img.array.mask[0]] = (self.nodata_height - self.baseval) / self.interval
 
         data_int32 = data.astype(numpy.int32)

--- a/src/titiler/core/titiler/core/algorithm/dem.py
+++ b/src/titiler/core/titiler/core/algorithm/dem.py
@@ -22,6 +22,7 @@ class HillShade(BaseAlgorithm):
     azimuth: int = Field(45, ge=0, le=360)
     angle_altitude: float = Field(45.0, ge=-90.0, le=90.0)
     buffer: int = Field(3, ge=0, le=99)
+    z_exaggeration: float = Field(1., ge=1e-6, le=1e6)
 
     # metadata
     input_nbands: int = 1
@@ -31,6 +32,8 @@ class HillShade(BaseAlgorithm):
     def __call__(self, img: ImageData) -> ImageData:
         """Create hillshade from DEM dataset."""
         x, y = numpy.gradient(img.array[0])
+        x *= self.z_exaggeration
+        y *= self.z_exaggeration
         slope = numpy.pi / 2.0 - numpy.arctan(numpy.sqrt(x * x + y * y))
         aspect = numpy.arctan2(-x, y)
         azimuth = 360.0 - self.azimuth
@@ -71,6 +74,7 @@ class Slope(BaseAlgorithm):
 
     # parameters
     buffer: int = Field(3, ge=0, le=99, description="Buffer size for edge effects")
+    z_exaggeration: float = Field(1., ge=1e-6, le=1e6)
 
     # metadata
     input_nbands: int = 1
@@ -86,6 +90,8 @@ class Slope(BaseAlgorithm):
         pixel_size_y = abs(img.transform[4])
 
         x, y = numpy.gradient(img.array[0])
+        x *= self.z_exaggeration
+        y *= self.z_exaggeration
         dx = x / pixel_size_x
         dy = y / pixel_size_y
 

--- a/src/titiler/core/titiler/core/algorithm/dem.py
+++ b/src/titiler/core/titiler/core/algorithm/dem.py
@@ -1,7 +1,8 @@
 """titiler.core.algorithm DEM."""
 
-import numpy
 from typing import Optional
+
+import numpy
 from pydantic import Field
 from rasterio import windows
 from rio_tiler.colormap import apply_cmap, cmap
@@ -23,7 +24,7 @@ class HillShade(BaseAlgorithm):
     azimuth: int = Field(45, ge=0, le=360)
     angle_altitude: float = Field(45.0, ge=-90.0, le=90.0)
     buffer: int = Field(3, ge=0, le=99)
-    z_exaggeration: float = Field(1., ge=1e-6, le=1e6)
+    z_exaggeration: float = Field(1.0, ge=1e-6, le=1e6)
 
     # metadata
     input_nbands: int = 1
@@ -75,7 +76,7 @@ class Slope(BaseAlgorithm):
 
     # parameters
     buffer: int = Field(3, ge=0, le=99, description="Buffer size for edge effects")
-    z_exaggeration: float = Field(1., ge=1e-6, le=1e6)
+    z_exaggeration: float = Field(1.0, ge=1e-6, le=1e6)
 
     # metadata
     input_nbands: int = 1
@@ -178,8 +179,10 @@ class Terrarium(BaseAlgorithm):
     def __call__(self, img: ImageData) -> ImageData:
         """Encode DEM into RGB."""
         data = numpy.clip(img.array[0] + 32768.0, 0.0, 65535.0)
-        if self.nodata_height is not None: 
-            data[img.array.mask[0]] = numpy.clip(self.nodata_height + 32768.0, 0.0, 65535.0)
+        if self.nodata_height is not None:
+            data[img.array.mask[0]] = numpy.clip(
+                self.nodata_height + 32768.0, 0.0, 65535.0
+            )
         r = data / 256
         g = data % 256
         b = (data * 256) % 256
@@ -235,13 +238,15 @@ class TerrainRGB(BaseAlgorithm):
         if _range_check(datarange):
             raise ValueError(f"Data of {datarange} larger than 256 ** 3")
 
-        if self.nodata_height is not None: 
-            data[img.array.mask[0]] = (self.nodata_height - self.baseval) / self.interval
+        if self.nodata_height is not None:
+            data[img.array.mask[0]] = (
+                self.nodata_height - self.baseval
+            ) / self.interval
 
         data_int32 = data.astype(numpy.int32)
-        b = (data_int32) & 0xff 
-        g = (data_int32 >> 8) & 0xff
-        r = (data_int32 >> 16) & 0xff
+        b = (data_int32) & 0xFF
+        g = (data_int32 >> 8) & 0xFF
+        r = (data_int32 >> 16) & 0xFF
 
         return ImageData(
             numpy.ma.stack([r, g, b]).astype(self.output_dtype),

--- a/src/titiler/core/titiler/core/algorithm/dem.py
+++ b/src/titiler/core/titiler/core/algorithm/dem.py
@@ -177,7 +177,7 @@ class Terrarium(BaseAlgorithm):
     def __call__(self, img: ImageData) -> ImageData:
         """Encode DEM into RGB."""
         data = numpy.clip(img.array[0] + 32768.0, 0.0, 65535.0)
-        if self.use_nodata_height: 
+        if self.nodata_height is not None: 
             data[img.array.mask[0]] = numpy.clip(self.nodata_height + 32768.0, 0.0, 65535.0)
         r = data / 256
         g = data % 256

--- a/src/titiler/core/titiler/core/algorithm/dem.py
+++ b/src/titiler/core/titiler/core/algorithm/dem.py
@@ -227,7 +227,7 @@ class TerrainRGB(BaseAlgorithm):
             raise ValueError(f"Data of {datarange} larger than 256 ** 3")
 
         if self.use_nodata_height: 
-            data[img.array.mask[0]] = (0 - self.baseval) / self.interval
+            data[img.array.mask[0]] = (self.nodata_height - self.baseval) / self.interval
 
         data_int32 = data.astype(numpy.int32)
         b = (data_int32) & 0xff 

--- a/src/titiler/core/titiler/core/algorithm/dem.py
+++ b/src/titiler/core/titiler/core/algorithm/dem.py
@@ -201,8 +201,7 @@ class TerrainRGB(BaseAlgorithm):
     # parameters
     interval: float = Field(0.1, ge=0.0, le=1.0)
     baseval: float = Field(-10000.0, ge=-99999.0, le=99999.0)
-    use_nodata_height: bool = Field(False)
-    nodata_height: float = Field(0.0, ge=-99999.0, le=99999.0)
+    nodata_height: Optional[float] = Field(None, ge=-99999.0, le=99999.0)
 
     # metadata
     input_nbands: int = 1

--- a/src/titiler/core/titiler/core/algorithm/dem.py
+++ b/src/titiler/core/titiler/core/algorithm/dem.py
@@ -161,6 +161,8 @@ class Terrarium(BaseAlgorithm):
 
     title: str = "Terrarium"
     description: str = "Encode DEM into RGB (Mapzen Terrarium)."
+    use_nodata_height: bool = Field(False)
+    nodata_height: float = Field(0.0, ge=-99999.0, le=99999.0)
 
     # metadata
     input_nbands: int = 1
@@ -170,6 +172,8 @@ class Terrarium(BaseAlgorithm):
     def __call__(self, img: ImageData) -> ImageData:
         """Encode DEM into RGB."""
         data = numpy.clip(img.array[0] + 32768.0, 0.0, 65535.0)
+        if self.use_nodata_height: 
+            data[img.array.mask[0]] = numpy.clip(self.nodata_height + 32768.0, 0.0, 65535.0)
         r = data / 256
         g = data % 256
         b = (data * 256) % 256

--- a/src/titiler/extensions/titiler/extensions/templates/cog_viewer.html
+++ b/src/titiler/extensions/titiler/extensions/templates/cog_viewer.html
@@ -260,11 +260,10 @@
           <!-- Algorithm -->
           <div id='algorithm-section'>
             <div class='txt-h5 mb6 color-black'><svg class='icon icon--l inline-block'><use xlink:href='#icon-functions'/></svg> Algorithm</div>
-            <div class='select-container wmax-full grid'>
-              <select id='algorithm-selector' class='select select--s select--stroke wmax-full color-black row'>
-                <option value='no-algo'>None</option>
+            <div class='select-container wmax-full'>
+              <select id='algorithm-selector' class='select select--s select--stroke wmax-full color-black'>
               </select>
-              <!-- <div class='select-arrow color-black'></div> -->
+              <div class='select-arrow color-black'></div>
             </div>
           </div>
         </section>
@@ -491,20 +490,11 @@ const set1bViz = () => {
     params.rescale = `${document.getElementById('data-min').value},${document.getElementById('data-max').value}`
   }
 
-  const algorithmSelector = document.getElementById('algorithm-selector');
-  const algorithm = algorithmSelector.selectedOptions[0].value; 
-  if (algorithm !== 'no-algo') {
-    params.algorithm = algorithm
-    params.algorithm_params = JSON.stringify({})
-  }
-  // const params = scope.algorithms[selected]['parameters']; 
-
   const cmap = document.getElementById('colormap-selector')[document.getElementById('colormap-selector').selectedIndex]
   if (cmap.value !== 'b&w') params.colormap_name = cmap.value
 
   const url_params = Object.keys(params).map(i => `${i}=${params[i]}`).join('&')
   let url = `${tilejson_endpoint}?${url_params}`
-  console.log(url)
   setMapLayers(url)
   if (scope.dataset_statistics) addHisto1Band()
 }
@@ -939,54 +929,56 @@ const addCogeo = () => {
       throw new Error('Network response was not ok.')
     })
     .then(algorithms => {
-      // console.log('ALGORITHMS', algorithms)
-      scope.algorithms = algorithms;
+      console.log('ALGORITHMS', algorithms)
+      scope.algorithms = algorithms
       const algorithmSelector = document.getElementById('algorithm-selector');
       for (const algo_id in algorithms) {
-        const algo = algorithms[algo_id];
+        const algo = algorithms[algo_id]
+        console.log(algo)
         const opt = document.createElement('option');
         opt.value = algo_id;
         opt.innerHTML = algo['title'];
         algorithmSelector.appendChild(opt);
       }
-      algorithmSelector.addEventListener('change', updateAlgorithmParams);
+      algorithmSelector.addEventListener('change', updateAlgorithmParams)
     })
     .catch(err => {
-      console.warn(err);
+      console.warn(err)
     })
 }
 
 function updateAlgorithmParams() {
   const algorithmSelector = document.getElementById('algorithm-selector');
+  console.log('algorithmSelector', algorithmSelector)
   const selected = algorithmSelector.selectedOptions[0].value; 
+  console.log("selected", selected)
   const params = scope.algorithms[selected]['parameters']; 
+  console.log(params)
 
   // Recreate div to host params
-  const paramsElOld = Array.from(algorithmSelector.parentNode.children).find(el => el.id == 'algorithm-params');
+  const paramsElOld = Array.from(algorithmSelector.parentNode.children).find(el => el.id == 'algorithm-params')
   if (paramsElOld) {
-    paramsElOld.remove();
+    paramsElOld.remove()
   }
   // Reproduce the div + form from lat/lon inputs
   const paramsEl = document.createElement('div');
-  paramsEl.className = 'grid px12 py12 w-full grid';
+  paramsEl.className = 'px6 py6 w-full'
   paramsEl.id = 'algorithm-params';
-  algorithmSelector.parentNode.appendChild(paramsEl);
+  algorithmSelector.parentNode.appendChild(paramsEl)
   const paramsForm = document.createElement('form');
-  paramsForm.className = 'grid grid--gut12 mx12 mt12';
+  paramsForm.className = 'grid grid--gut12 mx12 mt12'
   paramsForm.id = 'algorithm-params-form';
-  paramsEl.appendChild(paramsForm);
+  paramsEl.appendChild(paramsForm)
   for (const param_id in params) {
-    const param = params[param_id];
+    const param = params[param_id]
     const paramEl = document.createElement('div');
-    paramEl.className = 'row';
+    paramEl.className = 'row'
     paramsForm.appendChild(paramEl);
     paramEl.innerHTML = `
       <label for="param_${param_id}" class='col'>${param_id}:</label>
-      <input name="${param_id}" id="param_${param_id}" type="${(['integer', 'number'].includes(param.type)) ? 'number' : 'text'}" class="input input--s col" step=1 value="${param.default}"/>
-    `;
+      <input name="${param_id}" id="param_${param_id}" type="text" class="input input--s col"> ${param.default} </input>
+    `
   }
-  // Update to react to params change
-  updateViz();
 }
 
 document.getElementById('launch').addEventListener('click', () => {

--- a/src/titiler/extensions/titiler/extensions/templates/cog_viewer.html
+++ b/src/titiler/extensions/titiler/extensions/templates/cog_viewer.html
@@ -256,16 +256,6 @@
               <div class='select-arrow color-black'></div>
             </div>
           </div>
-
-          <!-- Algorithm -->
-          <div id='algorithm-section'>
-            <div class='txt-h5 mb6 color-black'><svg class='icon icon--l inline-block'><use xlink:href='#icon-functions'/></svg> Algorithm</div>
-            <div class='select-container wmax-full'>
-              <select id='algorithm-selector' class='select select--s select--stroke wmax-full color-black'>
-              </select>
-              <div class='select-arrow color-black'></div>
-            </div>
-          </div>
         </section>
 
         <!-- Min/Max -->
@@ -348,8 +338,7 @@ var scope = {
   dataset_statistics: undefined,
   data_type: undefined,
   band_descriptions: undefined,
-  colormap: undefined, 
-  algorithms: undefined, 
+  colormap: undefined
 }
 
 const tilejson_endpoint = '{{ tilejson_endpoint }}'
@@ -852,6 +841,7 @@ const addCogeo = () => {
       throw new Error('Network response was not ok.')
     })
     .then(data => {
+      console.log(data)
       scope.data_type = data.properties.dtype
       scope.colormap = data.properties.colormap
 
@@ -920,65 +910,6 @@ const addCogeo = () => {
     .catch(err => {
       console.warn(err)
     })
-
-    
-  // fetch(`/colorMaps`) then /colorMaps/accent?format=png but one request per colormap pretty heavy
-  fetch(`/algorithms`)
-    .then(res => {
-      if (res.ok) return res.json()
-      throw new Error('Network response was not ok.')
-    })
-    .then(algorithms => {
-      console.log('ALGORITHMS', algorithms)
-      scope.algorithms = algorithms
-      const algorithmSelector = document.getElementById('algorithm-selector');
-      for (const algo_id in algorithms) {
-        const algo = algorithms[algo_id]
-        console.log(algo)
-        const opt = document.createElement('option');
-        opt.value = algo_id;
-        opt.innerHTML = algo['title'];
-        algorithmSelector.appendChild(opt);
-      }
-      algorithmSelector.addEventListener('change', updateAlgorithmParams)
-    })
-    .catch(err => {
-      console.warn(err)
-    })
-}
-
-function updateAlgorithmParams() {
-  const algorithmSelector = document.getElementById('algorithm-selector');
-  console.log('algorithmSelector', algorithmSelector)
-  const selected = algorithmSelector.selectedOptions[0].value; 
-  console.log("selected", selected)
-  const params = scope.algorithms[selected]['parameters']; 
-  console.log(params)
-
-  // Recreate div to host params
-  const paramsElOld = Array.from(algorithmSelector.parentNode.children).find(el => el.id == 'algorithm-params')
-  if (paramsElOld) {
-    paramsElOld.remove()
-  }
-  // Reproduce the div + form from lat/lon inputs
-  const paramsEl = document.createElement('div');
-  paramsEl.className = 'px6 py6 w-full'
-  paramsEl.id = 'algorithm-params';
-  algorithmSelector.parentNode.appendChild(paramsEl)
-  const paramsForm = document.createElement('form');
-  paramsForm.className = 'grid grid--gut12 mx12 mt12'
-  paramsForm.id = 'algorithm-params-form';
-  paramsEl.appendChild(paramsForm)
-  for (const param_id in params) {
-    const param = params[param_id]
-    const paramEl = document.createElement('div');
-    paramEl.className = 'row'
-    paramsForm.appendChild(paramEl);
-    paramEl.innerHTML = `
-      <label for="param_${param_id}" class='col'>${param_id}:</label>
-      <input name="${param_id}" id="param_${param_id}" type="text" class="input input--s col"> ${param.default} </input>
-    `
-  }
 }
 
 document.getElementById('launch').addEventListener('click', () => {

--- a/src/titiler/extensions/titiler/extensions/templates/cog_viewer.html
+++ b/src/titiler/extensions/titiler/extensions/templates/cog_viewer.html
@@ -256,6 +256,16 @@
               <div class='select-arrow color-black'></div>
             </div>
           </div>
+
+          <!-- Algorithm -->
+          <div id='algorithm-section'>
+            <div class='txt-h5 mb6 color-black'><svg class='icon icon--l inline-block'><use xlink:href='#icon-functions'/></svg> Algorithm</div>
+            <div class='select-container wmax-full'>
+              <select id='algorithm-selector' class='select select--s select--stroke wmax-full color-black'>
+              </select>
+              <div class='select-arrow color-black'></div>
+            </div>
+          </div>
         </section>
 
         <!-- Min/Max -->
@@ -338,7 +348,8 @@ var scope = {
   dataset_statistics: undefined,
   data_type: undefined,
   band_descriptions: undefined,
-  colormap: undefined
+  colormap: undefined, 
+  algorithms: undefined, 
 }
 
 const tilejson_endpoint = '{{ tilejson_endpoint }}'
@@ -841,7 +852,6 @@ const addCogeo = () => {
       throw new Error('Network response was not ok.')
     })
     .then(data => {
-      console.log(data)
       scope.data_type = data.properties.dtype
       scope.colormap = data.properties.colormap
 
@@ -910,6 +920,65 @@ const addCogeo = () => {
     .catch(err => {
       console.warn(err)
     })
+
+    
+  // fetch(`/colorMaps`) then /colorMaps/accent?format=png but one request per colormap pretty heavy
+  fetch(`/algorithms`)
+    .then(res => {
+      if (res.ok) return res.json()
+      throw new Error('Network response was not ok.')
+    })
+    .then(algorithms => {
+      console.log('ALGORITHMS', algorithms)
+      scope.algorithms = algorithms
+      const algorithmSelector = document.getElementById('algorithm-selector');
+      for (const algo_id in algorithms) {
+        const algo = algorithms[algo_id]
+        console.log(algo)
+        const opt = document.createElement('option');
+        opt.value = algo_id;
+        opt.innerHTML = algo['title'];
+        algorithmSelector.appendChild(opt);
+      }
+      algorithmSelector.addEventListener('change', updateAlgorithmParams)
+    })
+    .catch(err => {
+      console.warn(err)
+    })
+}
+
+function updateAlgorithmParams() {
+  const algorithmSelector = document.getElementById('algorithm-selector');
+  console.log('algorithmSelector', algorithmSelector)
+  const selected = algorithmSelector.selectedOptions[0].value; 
+  console.log("selected", selected)
+  const params = scope.algorithms[selected]['parameters']; 
+  console.log(params)
+
+  // Recreate div to host params
+  const paramsElOld = Array.from(algorithmSelector.parentNode.children).find(el => el.id == 'algorithm-params')
+  if (paramsElOld) {
+    paramsElOld.remove()
+  }
+  // Reproduce the div + form from lat/lon inputs
+  const paramsEl = document.createElement('div');
+  paramsEl.className = 'px6 py6 w-full'
+  paramsEl.id = 'algorithm-params';
+  algorithmSelector.parentNode.appendChild(paramsEl)
+  const paramsForm = document.createElement('form');
+  paramsForm.className = 'grid grid--gut12 mx12 mt12'
+  paramsForm.id = 'algorithm-params-form';
+  paramsEl.appendChild(paramsForm)
+  for (const param_id in params) {
+    const param = params[param_id]
+    const paramEl = document.createElement('div');
+    paramEl.className = 'row'
+    paramsForm.appendChild(paramEl);
+    paramEl.innerHTML = `
+      <label for="param_${param_id}" class='col'>${param_id}:</label>
+      <input name="${param_id}" id="param_${param_id}" type="text" class="input input--s col"> ${param.default} </input>
+    `
+  }
 }
 
 document.getElementById('launch').addEventListener('click', () => {

--- a/src/titiler/extensions/titiler/extensions/templates/cog_viewer.html
+++ b/src/titiler/extensions/titiler/extensions/templates/cog_viewer.html
@@ -260,10 +260,11 @@
           <!-- Algorithm -->
           <div id='algorithm-section'>
             <div class='txt-h5 mb6 color-black'><svg class='icon icon--l inline-block'><use xlink:href='#icon-functions'/></svg> Algorithm</div>
-            <div class='select-container wmax-full'>
-              <select id='algorithm-selector' class='select select--s select--stroke wmax-full color-black'>
+            <div class='select-container wmax-full grid'>
+              <select id='algorithm-selector' class='select select--s select--stroke wmax-full color-black row'>
+                <option value='no-algo'>None</option>
               </select>
-              <div class='select-arrow color-black'></div>
+              <!-- <div class='select-arrow color-black'></div> -->
             </div>
           </div>
         </section>
@@ -490,11 +491,20 @@ const set1bViz = () => {
     params.rescale = `${document.getElementById('data-min').value},${document.getElementById('data-max').value}`
   }
 
+  const algorithmSelector = document.getElementById('algorithm-selector');
+  const algorithm = algorithmSelector.selectedOptions[0].value; 
+  if (algorithm !== 'no-algo') {
+    params.algorithm = algorithm
+    params.algorithm_params = JSON.stringify({})
+  }
+  // const params = scope.algorithms[selected]['parameters']; 
+
   const cmap = document.getElementById('colormap-selector')[document.getElementById('colormap-selector').selectedIndex]
   if (cmap.value !== 'b&w') params.colormap_name = cmap.value
 
   const url_params = Object.keys(params).map(i => `${i}=${params[i]}`).join('&')
   let url = `${tilejson_endpoint}?${url_params}`
+  console.log(url)
   setMapLayers(url)
   if (scope.dataset_statistics) addHisto1Band()
 }
@@ -929,56 +939,54 @@ const addCogeo = () => {
       throw new Error('Network response was not ok.')
     })
     .then(algorithms => {
-      console.log('ALGORITHMS', algorithms)
-      scope.algorithms = algorithms
+      // console.log('ALGORITHMS', algorithms)
+      scope.algorithms = algorithms;
       const algorithmSelector = document.getElementById('algorithm-selector');
       for (const algo_id in algorithms) {
-        const algo = algorithms[algo_id]
-        console.log(algo)
+        const algo = algorithms[algo_id];
         const opt = document.createElement('option');
         opt.value = algo_id;
         opt.innerHTML = algo['title'];
         algorithmSelector.appendChild(opt);
       }
-      algorithmSelector.addEventListener('change', updateAlgorithmParams)
+      algorithmSelector.addEventListener('change', updateAlgorithmParams);
     })
     .catch(err => {
-      console.warn(err)
+      console.warn(err);
     })
 }
 
 function updateAlgorithmParams() {
   const algorithmSelector = document.getElementById('algorithm-selector');
-  console.log('algorithmSelector', algorithmSelector)
   const selected = algorithmSelector.selectedOptions[0].value; 
-  console.log("selected", selected)
   const params = scope.algorithms[selected]['parameters']; 
-  console.log(params)
 
   // Recreate div to host params
-  const paramsElOld = Array.from(algorithmSelector.parentNode.children).find(el => el.id == 'algorithm-params')
+  const paramsElOld = Array.from(algorithmSelector.parentNode.children).find(el => el.id == 'algorithm-params');
   if (paramsElOld) {
-    paramsElOld.remove()
+    paramsElOld.remove();
   }
   // Reproduce the div + form from lat/lon inputs
   const paramsEl = document.createElement('div');
-  paramsEl.className = 'px6 py6 w-full'
+  paramsEl.className = 'grid px12 py12 w-full grid';
   paramsEl.id = 'algorithm-params';
-  algorithmSelector.parentNode.appendChild(paramsEl)
+  algorithmSelector.parentNode.appendChild(paramsEl);
   const paramsForm = document.createElement('form');
-  paramsForm.className = 'grid grid--gut12 mx12 mt12'
+  paramsForm.className = 'grid grid--gut12 mx12 mt12';
   paramsForm.id = 'algorithm-params-form';
-  paramsEl.appendChild(paramsForm)
+  paramsEl.appendChild(paramsForm);
   for (const param_id in params) {
-    const param = params[param_id]
+    const param = params[param_id];
     const paramEl = document.createElement('div');
-    paramEl.className = 'row'
+    paramEl.className = 'row';
     paramsForm.appendChild(paramEl);
     paramEl.innerHTML = `
       <label for="param_${param_id}" class='col'>${param_id}:</label>
-      <input name="${param_id}" id="param_${param_id}" type="text" class="input input--s col"> ${param.default} </input>
-    `
+      <input name="${param_id}" id="param_${param_id}" type="${(['integer', 'number'].includes(param.type)) ? 'number' : 'text'}" class="input input--s col" step=1 value="${param.default}"/>
+    `;
   }
+  // Update to react to params change
+  updateViz();
 }
 
 document.getElementById('launch').addEventListener('click', () => {


### PR DESCRIPTION
- [x] Fixes Terrain-RGB algorithm 
- [x] Added two params `use_nodata_height and nodata_height` (or could have used a field which could be either undefined or that height value?). 
- [x] Also added user-controlled nodata-height parametrization for terrarium


Can be tested via 
        
> 'tiles': ['http://localhost:8000/cog/tiles/WebMercatorQuad/{z}/{x}/{y}@1x.png?algorithm=terrainrgb&algorithm_params={"use_nodata_height":true,"nodata_height":0.0}&nodata=-9999&url=https://3d.iconem.com/greece/amphipolis/Amphipolis_general_dsm_10cm_cog_cropped_alpha.tif'] 


**TODO**: Also should take a moment to add suggested updates from discussion https://github.com/developmentseed/titiler/discussions/1110
 - [ ] terrarium/terrain-rgb intepretation for dem-related algorithms like hillshade & slope
 - [x] z-exaggeration algorithm-param
 - [x] algorithms doc update
 - [x] ~Just noticed also the /cog/viewer endpoint to help users play with url-params, bands expressions etc. Extend single-band user-parametrization to also allow for algorithms and a few other url-params like rescale etc?~ other PR https://github.com/developmentseed/titiler/pull/1119

