### PR TITLE
fix: use minZoom instead of minNativeZoom

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 * add `/preview/{width}x{height}.{format}` endpoints
 * update rio-tiler requirement to `>=7.7,<8.0`
 * allow users to pass only one of `width` or `heigh` size parameters for `preview`, `part` and `feature` requests
+* use `minZoom` instead of `minNativeZoom` in the `/map.html` html template
 
 ### titiler.application
 

--- a/src/titiler/core/titiler/core/templates/map.html
+++ b/src/titiler/core/titiler/core/templates/map.html
@@ -206,7 +206,7 @@
           const tileLayer = L.tileLayer(
             data.tiles[0], {
               maxNativeZoom: data.maxzoom,
-              minNativeZoom: data.minzoom,
+              minZoom: data.minzoom,
               bounds: L.latLngBounds([bottom, left], [top, right]),
             }
           );
@@ -221,7 +221,7 @@
         .catch(err => {
           console.warn(err);
         });
-      
+
       // run point query on right-click
       map.on('contextmenu', function(e) {
         const lat = e.latlng.lat.toFixed(3);
@@ -285,7 +285,6 @@
           }
         });
       });
-
     </script>
   </body>
 </html>


### PR DESCRIPTION
By setting `minNativeZoom` we were constructing low zoom tiles from many higher-zoom tile requests! This is not the intended effect of the minzoom setting. We can still overzoom by using maxNativeZoom.