### PR TITLE
allow timezone aware time selection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### titiler.xarray
+
+* add support for timezone aware time selection (e.g `sel="time=2023-01-01T00:00:00+03:00"`)
+
 ## 0.22.2 (2025-06-02)
 
 ### titiler.application

--- a/src/titiler/xarray/titiler/xarray/io.py
+++ b/src/titiler/xarray/titiler/xarray/io.py
@@ -8,6 +8,7 @@ import numpy
 import pandas
 import xarray
 from morecantile import TileMatrixSet
+from pandas._libs.tslibs.parsing import DateParseError
 from rio_tiler.constants import WEB_MERCATOR_TMS
 from rio_tiler.io.xarray import XarrayReader
 from xarray.namedarray.utils import module_available
@@ -142,6 +143,12 @@ def _cast_to_type(value, dtype: Any) -> Any:
 
     elif numpy.issubdtype(dtype, numpy.floating):
         value = float(value)
+
+    elif numpy.issubdtype(dtype, numpy.datetime64) or dtype == "O":
+        try:
+            value = pandas.Timestamp(value).to_datetime64()
+        except DateParseError:
+            pass
 
     return value
 


### PR DESCRIPTION
closes #1170 

### This PR does:

Convert any `time` dimension selection parameter to `numpy.datetime64` which will return time in UTC using `value = pandas.Timestamp(value).to_datetime64()` 

We assume all input dataset will have their `<time>` dimension as UTC (because xarray only support numpy.datetime64) 

ref https://github.com/developmentseed/titiler/issues/1170#issuecomment-2968560888