### PR TITLE
fix: disable telemetry by default

### DIFF
--- a/src/titiler/application/titiler/application/settings.py
+++ b/src/titiler/application/titiler/application/settings.py
@@ -22,7 +22,7 @@ class ApiSettings(BaseSettings):
 
     lower_case_query_parameters: bool = False
 
-    telemetry_enabled: bool = True
+    telemetry_enabled: bool = False
 
     # an API key required to access any endpoint, passed via the ?access_token= query parameter
     global_access_token: Optional[str] = None


### PR DESCRIPTION
Telemetry should be disabled by default in titiler.application because you need to configure external services in order for it to work.

Resolves #1194 