### PR TITLE
[xarray] add preview endpoints

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,9 +10,13 @@
 
 * add OpenTelemetry tracing to the FastAPI application
 
+### titiler.xarray
+
+* add `add_preview` in factory attribute (default to `False`)
+
 ### Misc
 
-* Add otel-collector and jaeger to the docker network 
+* Add otel-collector and jaeger to the docker network
 
 ## 0.22.4 (2025-07-02)
 

--- a/docs/src/advanced/endpoints_factories.md
+++ b/docs/src/advanced/endpoints_factories.md
@@ -359,9 +359,9 @@ class: `titiler.xarray.factory.TilerFactory`
 - **environment_dependency**: Dependency to define GDAL environment at runtime. Default to `lambda: {}`.
 - **supported_tms**: List of available TileMatrixSets. Defaults to `morecantile.tms`.
 - **templates**: *Jinja2* templates to use in endpoints. Defaults to `titiler.core.factory.DEFAULT_TEMPLATES`.
-- **add_part**: . Add `/bbox` and `/feature` endpoints to the router. Defaults to `True`.
-- **add_viewer**: . Add `/map.html` endpoints to the router. Defaults to `True`.
-
+- **add_part**: Add `/bbox` and `/feature` endpoints to the router. Defaults to `True`.
+- **add_viewer**: Add `/map.html` endpoints to the router. Defaults to `True`.
+- **add_preview**: Add `/preview` endpoints to the router. Default to `False`.
 
 ```python
 from fastapi import FastAPI
@@ -373,8 +373,9 @@ app = FastAPI()
 
 # Create router and register set of endpoints
 md = TilerFactory(
-    add_part=True,
-    add_viewer=True,
+    add_part=True,     # default to True
+    add_viewer=True,   # default to True
+    add_preview=True,  # default to False
 )
 
 # add router endpoint to the main application
@@ -398,6 +399,7 @@ app.include_router(md.router)
 | `GET`  | `/point/{lon},{lat}`                                            | JSON ([Point][point_model])                 | return pixel values from a dataset
 | `GET`  | `/bbox/{minx},{miny},{maxx},{maxy}[/{width}x{height}].{format}` | image/bin                                   | create an image from part of a dataset **Optional**
 | `POST` | `/feature[/{width}x{height}][.{format}]`                        | image/bin                                   | create an image from a GeoJSON feature **Optional**
+| `GET`  | `/preview[/{width}x{height}][.{format}]`                        | image/bin                                   | create a preview image from a dataset **Optional**
 
 
 [bounds_model]: https://github.com/cogeotiff/rio-tiler/blob/9aaa88000399ee8d36e71d176f67b6ea3ec53f2d/rio_tiler/models.py#L43-L46

--- a/src/titiler/xarray/titiler/xarray/dependencies.py
+++ b/src/titiler/xarray/titiler/xarray/dependencies.py
@@ -145,3 +145,37 @@ class PartFeatureParams(DefaultDependency):
         """Post Init."""
         if self.width or self.height:
             self.max_size = None
+
+
+# Custom PreviewParams which add `resampling`
+@dataclass
+class PreviewParams(DefaultDependency):
+    """Common Preview parameters."""
+
+    max_size: Annotated[
+        Optional[int], Field(description="Maximum image size to read onto.")
+    ] = 1024
+    height: Annotated[
+        Optional[int], Field(description="Force output image height.")
+    ] = None
+    width: Annotated[Optional[int], Field(description="Force output image width.")] = (
+        None
+    )
+    resampling_method: Annotated[
+        Optional[RIOResampling],
+        Query(
+            alias="resampling",
+            description="RasterIO resampling algorithm. Defaults to `nearest`.",
+        ),
+    ] = None
+
+    def __post_init__(self):
+        """Post Init."""
+        if self.width or self.height:
+            self.max_size = None
+
+        # NOTE: By default we don't exclude None when we forward the parameter to the preview() method
+        # because we need to be able to pass max_size=None
+        # So we need to set the `resampling_method` to a default = 'nearest'
+        # https://github.com/developmentseed/titiler/blob/b8cc304382d0cb3b4f16cea9dbb0cfba35517085/src/titiler/core/titiler/core/factory.py#L1300
+        self.resampling_method = self.resampling_method or "nearest"


### PR DESCRIPTION
add `/preview` endpoint to Xarray TilerFactory.

Those endpoint are disabled by default because Xarray dataset might not be suitable for `previews`