### PR TITLE
add attribution

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Misc
+
+* add attribution in `/tilejson.json` response. Controled with `TITILER_DEFAULT_ATTRIBUTION` environment variable.
+
 ## 0.23.1 (2025-08-27)
 
 ### titiler.core

--- a/src/titiler/core/titiler/core/factory.py
+++ b/src/titiler/core/titiler/core/factory.py
@@ -2,6 +2,7 @@
 
 import abc
 import logging
+import os
 import warnings
 from typing import (
     Any,
@@ -630,10 +631,13 @@ class TilerFactory(BaseFactory):
             ]
             query_string = f"?{urlencode(qs)}" if qs else ""
 
+            attribution = os.environ.get("TITILER_DEFAULT_ATTRIBUTION")
+
             tilesets = []
             for tms in self.supported_tms.list():
                 tileset = {
                     "title": f"tileset tiled using {tms} TileMatrixSet",
+                    "attribution": attribution,
                     "dataType": "map",
                     "crs": self.supported_tms.get(tms).crs,
                     "boundingBox": collection_bbox,
@@ -807,6 +811,7 @@ class TilerFactory(BaseFactory):
                     "boundingBox": collection_bbox,
                     "links": links,
                     "tileMatrixSetLimits": tilematrix_limit,
+                    "attribution": os.environ.get("TITILER_DEFAULT_ATTRIBUTION"),
                 }
             )
 
@@ -1009,6 +1014,7 @@ class TilerFactory(BaseFactory):
                         "minzoom": minzoom if minzoom is not None else src_dst.minzoom,
                         "maxzoom": maxzoom if maxzoom is not None else src_dst.maxzoom,
                         "tiles": [tiles_url],
+                        "attribution": os.environ.get("TITILER_DEFAULT_ATTRIBUTION"),
                     }
 
     def map_viewer(self):  # noqa: C901

--- a/src/titiler/core/titiler/core/templates/map.html
+++ b/src/titiler/core/titiler/core/templates/map.html
@@ -208,6 +208,7 @@
               maxNativeZoom: data.maxzoom,
               minZoom: data.minzoom,
               bounds: L.latLngBounds([bottom, left], [top, right]),
+              attribution: data.attribution,
             }
           );
 

--- a/src/titiler/core/titiler/core/templates/wmts.xml
+++ b/src/titiler/core/titiler/core/templates/wmts.xml
@@ -1,9 +1,14 @@
 <Capabilities xmlns="http://www.opengis.net/wmts/1.0" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:gml="http://www.opengis.net/gml" xsi:schemaLocation="http://www.opengis.net/wmts/1.0 http://schemas.opengis.net/wmts/1.0/wmtsGetCapabilities_response.xsd" version="1.0.0">
     <ows:ServiceIdentification>
-        <ows:Title>{{ title }}</ows:Title>
+        <ows:Title>Web Map Tile Service by TiTiler</ows:Title>
         <ows:ServiceType>OGC WMTS</ows:ServiceType>
         <ows:ServiceTypeVersion>1.0.0</ows:ServiceTypeVersion>
     </ows:ServiceIdentification>
+    <ows:ServiceProvider>
+        <ows:ProviderName>TiTiler</ows:ProviderName>
+        <ows:ProviderSite xlink:href="https://developmentseed.org/titiler/"/>
+        <ows:ServiceContact/>
+    </ows:ServiceProvider>
     <ows:OperationsMetadata>
         <ows:Operation name="GetCapabilities">
             <ows:DCP>

--- a/src/titiler/mosaic/titiler/mosaic/factory.py
+++ b/src/titiler/mosaic/titiler/mosaic/factory.py
@@ -782,6 +782,7 @@ class MosaicTilerFactory(BaseFactory):
                         "minzoom": minzoom if minzoom is not None else src_dst.minzoom,
                         "maxzoom": maxzoom if maxzoom is not None else src_dst.maxzoom,
                         "tiles": [tiles_url],
+                        "attribution": os.environ.get("TITILER_DEFAULT_ATTRIBUTION"),
                     }
 
     def map_viewer(self):  # noqa: C901


### PR DESCRIPTION
This PR adds `attribution` field in /tilejson.json, /tiles and /tiles/{tileMatrixSetId} responses. The attribution is defined using `TITILER_DEFAULT_ATTRIBUTION` environment variable.

ref https://github.com/developmentseed/titiler/discussions/1214

cc @mradamcox 

