### PR TITLE
feat!: set values.yaml tag to ""

### DIFF
--- a/deployment/k8s/charts/Chart.yaml
+++ b/deployment/k8s/charts/Chart.yaml
@@ -2,8 +2,10 @@ apiVersion: v1
 appVersion: 2.0.0a1
 description: A dynamic Web Map tile server
 name: titiler
-version: 1.4.0
+version: 2.0.0
 icon: https://raw.githubusercontent.com/developmentseed/titiler/main/docs/logos/TiTiler_logo_small.png
 maintainers:
   - name: emmanuelmathot  # Emmanuel Mathot
     url: https://github.com/emmanuelmathot
+  - name: ciaransweet     # Ciaran Sweet
+    url: https://github.com/ciaransweet

--- a/deployment/k8s/charts/values.yaml
+++ b/deployment/k8s/charts/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/developmentseed/titiler
-  tag: latest
+  tag: ""
   pullPolicy: IfNotPresent
   command: "uvicorn"
   args:


### PR DESCRIPTION
# What this PR is

This is somewhat opinioated, but right now, because we're hardcoding `tag: latest`, `appVersion` is _never_ chosen (ergo, pointless updating)

I've opted to blank out `tag` so that the default is the `appVersion` _unless_ the deployer overrides the `tag` value. This feels more 'helm-y'

Also bumped the chart to a major version, given the major version change in titiler.
