### PR TITLE
chore: align plausible analytics domain

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -12,7 +12,7 @@ site_url: "https://developmentseed.org/titiler/"
 extra:
   analytics:
     provider: plausible
-    domain: developmentseed.org/titiler
+    domain: developmentseed.org
 
     feedback:
       title: Was this page helpful?


### PR DESCRIPTION
Update docs analytics to use developmentseed.org so TiTiler traffic reports to the shared Plausible site.

This will make tracking analytics across our different pages underneath developmentseed.org easier for @kcarini