### PR TITLE
revert: restore titiler plausible domain

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -12,7 +12,7 @@ site_url: "https://developmentseed.org/titiler/"
 extra:
   analytics:
     provider: plausible
-    domain: developmentseed.org
+    domain: developmentseed.org/titiler
 
     feedback:
       title: Was this page helpful?


### PR DESCRIPTION
Undo shared analytics domain grouping and restore the TiTiler-specific Plausible domain value.

Apologies, I missed that Plausible has a consolidated site feature now. We'll use that and revert back to the old tracking method.