### PR TITLE
Chore/update plausible snippet

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -12,7 +12,7 @@ site_url: "https://developmentseed.org/titiler/"
 extra:
   analytics:
     provider: plausible
-    domain: developmentseed.org
+    domain: developmentseed.org/titiler
 
     feedback:
       title: Was this page helpful?


### PR DESCRIPTION
Plausible recently updated their script tag. We're still on the legacy one. This PR switches to the new Plausible script and initialize tracking using the new snippet format. Should future proof of for when Plausible stops supporting the old format.