### PR TITLE
fix(ci): fix docker publish action for helm tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
 
   publish-docker:
     needs: [tests]
-    if: github.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/tags') || github.event_name == 'release'
+    if: github.ref == 'refs/heads/main' || (startsWith(github.event.ref, 'refs/tags') && !startsWith(github.ref, 'refs/tags/helm-')) || github.event_name == 'release'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
   ".": "2.0.1",
-  "deployment/k8s/charts": "2.1.1"
+  "deployment/k8s/charts": "2.1.2"
 }


### PR DESCRIPTION
The job failed because CI was triggered by the push of the helm-2.1.1 tag, and the docker/metadata-action uses type=semver,pattern={{version}} which doesn't match          
  helm-2.1.1 (not a valid semver). So it generates no Docker image tags, and docker/build-push-action fails with:                                                             
                                                                                                                                                                              
  ERROR: failed to build: tag is needed when pushing to registry                                
  
 ->  Solution:  skip publish job when the triggering tag starts with `helm-*`
 
 
 In addition  "deployment/k8s/charts" in `.release-please-manifest.json` was not the correct version