### PR TITLE
feat(mosaic): add zoom level params which override values from tiler backend.

### DIFF
--- a/src/titiler/mosaic/titiler/mosaic/factory.py
+++ b/src/titiler/mosaic/titiler/mosaic/factory.py
@@ -3,6 +3,7 @@
 import logging
 import os
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Annotated, Any, Literal
 from urllib.parse import urlencode
 
@@ -83,6 +84,14 @@ def DatasetPathParams(url: Annotated[str, Query(description="Mosaic URL")]) -> s
     return url
 
 
+@dataclass
+class ZoomLevelParams:
+    """Zoom level constraint parameters"""
+
+    minzoom: int | None = None
+    maxzoom: int | None = None
+
+
 @define(kw_only=True)
 class MosaicTilerFactory(BaseFactory):
     """MosaicTiler Factory."""
@@ -107,6 +116,9 @@ class MosaicTilerFactory(BaseFactory):
 
     # Tile/Tilejson Dependencies
     tile_dependency: type[DefaultDependency] = TileParams
+
+    # Zoom level Dependencies
+    zoom_level_dependency: type[DefaultDependency] = ZoomLevelParams
 
     # Post Processing Dependencies (algorithm)
     process_dependency: Callable[..., BaseAlgorithm | None] = (
@@ -603,6 +615,7 @@ class MosaicTilerFactory(BaseFactory):
             dataset_params=Depends(self.dataset_dependency),
             pixel_selection=Depends(self.pixel_selection_dependency),
             tile_params=Depends(self.tile_dependency),
+            zoom_level_params=Depends(self.zoom_level_dependency),
             post_process=Depends(self.process_dependency),
             colormap=Depends(self.colormap_dependency),
             render_params=Depends(self.render_dependency),
@@ -621,12 +634,12 @@ class MosaicTilerFactory(BaseFactory):
                     reader_options=reader_params.as_dict(),
                     **backend_params.as_dict(),
                 ) as src_dst:
-                    if MOSAIC_STRICT_ZOOM and (
-                        z < src_dst.minzoom or z > src_dst.maxzoom
-                    ):
+                    minzoom = zoom_level_params.minzoom or src_dst.minzoom
+                    maxzoom = zoom_level_params.maxzoom or src_dst.maxzoom
+                    if MOSAIC_STRICT_ZOOM and (z < minzoom or z > maxzoom):
                         raise HTTPException(
                             400,
-                            f"Invalid ZOOM level {z}. Should be between {src_dst.minzoom} and {src_dst.maxzoom}",
+                            f"Invalid ZOOM level {z}. Should be between {minzoom} and {maxzoom}",
                         )
 
                     image, assets = src_dst.tile(


### PR DESCRIPTION
## What I am changing
<!-- What were the high-level goals of the change? -->
Adding zoom level dependency to MosaicTilerFactory, and use if set instead of tiler backend values.

## How I did it
<!-- How did you go about achieving these goals? Any considerations made along the way? -->

Minimal change required to achieve expected behaviour of HTTP 400 response if MOSAIC_STRICT_ZOOM set and `minzoom/maxzoom` parameter passed to `/tiles` endpoint.

## How you can test it
<!-- How might a reviewer test your changes to verify that they work as expected? -->

Here is a repo which asserts expected behaviour https://github.com/underchemist/titiler-pgstac-zoom-override-example


## Related Issues
<!-- Reference any issues that inspired this PR. Use a keyword to auto-close any issues when this PR is merged (eg "closes #1") -->
- related https://github.com/stac-utils/titiler-pgstac/issues/272
