### PR TITLE
fix: trigger PyPI publish/deploy by authoring releases with the DS_RELEASE_BOT app token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,8 @@ jobs:
       - uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         id: app-token
         with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
-          private-key: ${{ secrets.RELEASE_APP_KEY }}
+          app-id: ${{ secrets.DS_RELEASE_BOT_ID }}
+          private-key: ${{ secrets.DS_RELEASE_BOT_PRIVATE_KEY }}
           # Scope the minted token to least privilege instead of inheriting the App's
           # blanket installation permissions (zizmor: dangerous-github-app-tokens).
           # release-please only needs Contents (tags/release) + Pull requests (release PR).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,9 +19,19 @@ jobs:
       contents: write # Needed for release-please to create PRs
       pull-requests: write # Needed for release-please to create PRs
     steps:
+      # Mint a GitHub App token so the release-please-created release is authored by the
+      # App, not github-actions[bot]. Events from the default GITHUB_TOKEN do NOT trigger
+      # new workflow runs (GitHub anti-recursion), which is why bot-created releases never
+      # fired `release: published` and the build/upload_pypi/deploy jobs below were skipped.
+      - uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        id: app-token
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_KEY }}
+
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,11 @@ jobs:
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_KEY }}
+          # Scope the minted token to least privilege instead of inheriting the App's
+          # blanket installation permissions (zizmor: dangerous-github-app-tokens).
+          # release-please only needs Contents (tags/release) + Pull requests (release PR).
+          permission-contents: write
+          permission-pull-requests: write
 
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -9,7 +9,7 @@ Releases are automated via [release-please](https://github.com/googleapis/releas
    - Bumps the version in `pyproject.toml`, all sub-package `pyproject.toml` files, and `__init__.py` files
    - Bumps `appVersion` in `deployment/k8s/charts/Chart.yaml`
    - Updates `CHANGES.md` with the changelog for the new version
-3. When that PR is merged, release-please creates a GitHub release tagged `X.Y.Z`, which triggers the PyPI publish workflow.
+3. When that PR is merged, release-please creates a GitHub release tagged `X.Y.Z`. The release is authored via a **GitHub App token** (not the default `GITHUB_TOKEN`), which is what lets the `release: published` event trigger the PyPI publish and AWS deploy workflows — events from the default `GITHUB_TOKEN` do **not** cascade into new workflow runs, so a bot-authored release would otherwise publish nothing.
 
 ## Helm chart version
 


### PR DESCRIPTION
## What this does

Fixes #1406: bot-authored releases never trigger PyPI publish/deploy.

release-please currently uses the default `GITHUB_TOKEN`, so releases are authored by `github-actions[bot]`. GitHub does **not** cascade workflow runs from default-`GITHUB_TOKEN` events (anti-recursion), so `release: published` never fired for 2.0.3 → `build` / `upload_pypi` (gated on `github.event_name == 'release'`) and `deploy.yml` were skipped, and 2.0.3 was never published.

This mints a short-lived **GitHub App** installation token and passes it to `release-please-action`. Events from an App token **do** create new workflow runs, so the existing publish + deploy workflows cascade automatically — no change to `build`, `upload_pypi`, or `deploy.yml`.

Uses the existing org-level release App (secrets `DS_RELEASE_BOT_ID` / `DS_RELEASE_BOT_PRIVATE_KEY`) — no new App or secrets needed. The minted token is scoped to least privilege (Contents + Pull requests, R/W) so it doesn't inherit the App's blanket installation permissions.

## Changes
- `.github/workflows/release.yml`: add `actions/create-github-app-token` (SHA-pinned, v2.2.2) step using `DS_RELEASE_BOT_ID` / `DS_RELEASE_BOT_PRIVATE_KEY`, scoped to `permission-contents: write` + `permission-pull-requests: write`; pass its token to release-please instead of `secrets.GITHUB_TOKEN`.
- `RELEASING.md`: document that the release is authored via the App token, which is what makes publish/deploy trigger.

## Before merge — verify (org admin)
- [ ] The `DS_RELEASE_BOT` App is **installed on this repo** and has **Contents: R/W + Pull requests: R/W**.
- [x] The org secrets `DS_RELEASE_BOT_ID` / `DS_RELEASE_BOT_PRIVATE_KEY` are **visible to `developmentseed/titiler`**.

Once confirmed, the real test is the next `chore: release` PR: the release should be authored by the App (not `github-actions[bot]`) and publish/deploy automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
