### PR TITLE
fix: fall back to WKT for WMTS BoundingBox crs when CRS cannot be resolved to a URN

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### titiler.extensions
+
+* fall back to WKT (with a warning) for the WMTS `BoundingBox` crs attribute when the CRS cannot be resolved to a URN (https://github.com/developmentseed/titiler/issues/1043)
+
+### titiler.mosaic
+
+* fall back to WKT (with a warning) for the WMTS `BoundingBox` crs attribute when the CRS cannot be resolved to a URN (https://github.com/developmentseed/titiler/issues/1043)
+
 ## 2.0.5 (2026-06-18)
 
 ## What's Changed

--- a/src/titiler/extensions/tests/test_wmts.py
+++ b/src/titiler/extensions/tests/test_wmts.py
@@ -2,10 +2,14 @@
 
 import io
 import os
+import xml.etree.ElementTree as ET
 
+import pytest
 import rasterio
 from fastapi import FastAPI
 from owslib.wmts import WebMapTileService
+from rasterio.crs import CRS
+from rio_tiler.utils import CRS_to_urn
 from starlette.testclient import TestClient
 
 from titiler.core.factory import TilerFactory
@@ -113,6 +117,33 @@ def test_wmtsExtension():
         assert ["5", "6", "7", "8"] == list(
             layer.tilematrixsetlinks["WorldCRS84Quad"].tilematrixlimits
         )
+
+
+def test_wmtsExtension_crs_without_urn():
+    """Test BoundingBox CRS fallback to WKT when the CRS cannot be resolved to a URN.
+
+    ref: https://github.com/developmentseed/titiler/issues/1043
+    """
+    # Custom CRS (tweaked polar stereographic) which cannot be resolved to an authority
+    custom_crs = CRS.from_proj4(
+        "+proj=stere +lat_0=90 +lat_ts=71.3 +lon_0=-42.5 +x_0=0 +y_0=0 +a=6378137.1 +b=6356752.3 +units=m +no_defs"
+    )
+    assert CRS_to_urn(custom_crs) is None
+
+    tiler_plus_wmts = TilerFactory(extensions=[wmtsExtension(crs=custom_crs)])
+
+    app = FastAPI()
+    app.include_router(tiler_plus_wmts.router)
+    with TestClient(app) as client:
+        with pytest.warns(UserWarning, match="Could not resolve a URN for CRS"):
+            response = client.get(f"/WMTSCapabilities.xml?url={DATA_DIR}/cog.tif")
+        assert response.status_code == 200
+
+        root = ET.fromstring(response.content)
+        bboxes = root.findall(".//{http://www.opengis.net/ows/1.1}BoundingBox")
+        assert bboxes
+        for bbox in bboxes:
+            assert bbox.attrib["crs"] == custom_crs.to_wkt()
 
 
 def test_wmtsExtension_with_renders():

--- a/src/titiler/extensions/titiler/extensions/wmts.py
+++ b/src/titiler/extensions/titiler/extensions/wmts.py
@@ -189,14 +189,15 @@ class wmtsExtension(FactoryExtension):
                     wmts_bbox = bounds
                     if geographic_crs != WGS84_CRS:
                         bbox_crs_type = "BoundingBox"
-                        bbox_crs_uri = CRS_to_urn(geographic_crs)
-                        if not bbox_crs_uri:
+                        crs_urn = CRS_to_urn(geographic_crs)
+                        if not crs_urn:
                             warnings.warn(
                                 f"Could not resolve a URN for CRS '{geographic_crs}', falling back to WKT for the BoundingBox crs attribute",
                                 UserWarning,
                                 stacklevel=2,
                             )
-                            bbox_crs_uri = geographic_crs.to_wkt()
+                            crs_urn = geographic_crs.to_wkt()
+                        bbox_crs_uri = crs_urn
                         # WGS88BoundingBox is always xy ordered, but BoundingBox must match the CRS order
                         proj_crs = rio_crs_to_pyproj(geographic_crs)
                         if crs_axis_inverted(proj_crs):

--- a/src/titiler/extensions/titiler/extensions/wmts.py
+++ b/src/titiler/extensions/titiler/extensions/wmts.py
@@ -189,7 +189,14 @@ class wmtsExtension(FactoryExtension):
                     wmts_bbox = bounds
                     if geographic_crs != WGS84_CRS:
                         bbox_crs_type = "BoundingBox"
-                        bbox_crs_uri = CRS_to_urn(geographic_crs)  # type: ignore
+                        bbox_crs_uri = CRS_to_urn(geographic_crs)
+                        if not bbox_crs_uri:
+                            warnings.warn(
+                                f"Could not resolve a URN for CRS '{geographic_crs}', falling back to WKT for the BoundingBox crs attribute",
+                                UserWarning,
+                                stacklevel=2,
+                            )
+                            bbox_crs_uri = geographic_crs.to_wkt()
                         # WGS88BoundingBox is always xy ordered, but BoundingBox must match the CRS order
                         proj_crs = rio_crs_to_pyproj(geographic_crs)
                         if crs_axis_inverted(proj_crs):

--- a/src/titiler/mosaic/tests/test_factory.py
+++ b/src/titiler/mosaic/tests/test_factory.py
@@ -2,6 +2,7 @@
 
 import os
 import tempfile
+import xml.etree.ElementTree as ET
 from contextlib import contextmanager
 from dataclasses import dataclass
 from io import BytesIO
@@ -11,12 +12,15 @@ from unittest.mock import patch
 import attr
 import morecantile
 import numpy
+import pytest
 from cogeo_mosaic.backends import FileBackend
 from cogeo_mosaic.backends import MosaicBackend as MosaicJSONBackend
 from cogeo_mosaic.mosaic import MosaicJSON
 from fastapi import FastAPI, Query
 from owslib.wmts import WebMapTileService
+from rasterio.crs import CRS
 from rio_tiler.mosaic.methods import PixelSelectionMethod
+from rio_tiler.utils import CRS_to_urn
 from starlette.testclient import TestClient
 
 from titiler.core.dependencies import DefaultDependency
@@ -882,6 +886,38 @@ def test_wmts_extension_mosaic():
             assert ["0", "1"] == list(
                 layer.tilematrixsetlinks["WebMercatorQuad"].tilematrixlimits
             )
+
+
+def test_wmts_extension_mosaic_crs_without_urn():
+    """Test BoundingBox CRS fallback to WKT when the CRS cannot be resolved to a URN.
+
+    ref: https://github.com/developmentseed/titiler/issues/1043
+    """
+    # Custom CRS (tweaked polar stereographic) which cannot be resolved to an authority
+    custom_crs = CRS.from_proj4(
+        "+proj=stere +lat_0=90 +lat_ts=71.3 +lon_0=-42.5 +x_0=0 +y_0=0 +a=6378137.1 +b=6356752.3 +units=m +no_defs"
+    )
+    assert CRS_to_urn(custom_crs) is None
+
+    mosaic = MosaicTilerFactory(
+        backend=MosaicJSONBackend,
+        extensions=[wmtsExtension(crs=custom_crs)],
+    )
+    app = FastAPI()
+    app.include_router(mosaic.router)
+    add_exception_handlers(app, MOSAIC_STATUS_CODES)
+
+    with TestClient(app) as client:
+        with tmpmosaic() as mosaic_file:
+            with pytest.warns(UserWarning, match="Could not resolve a URN for CRS"):
+                response = client.get(f"/WMTSCapabilities.xml?url={mosaic_file}")
+            assert response.status_code == 200
+
+            root = ET.fromstring(response.content)
+            bboxes = root.findall(".//{http://www.opengis.net/ows/1.1}BoundingBox")
+            assert bboxes
+            for bbox in bboxes:
+                assert bbox.attrib["crs"] == custom_crs.to_wkt()
 
 
 def test_mosaic_statistics_featurecollection():

--- a/src/titiler/mosaic/titiler/mosaic/extensions/wmts.py
+++ b/src/titiler/mosaic/titiler/mosaic/extensions/wmts.py
@@ -200,14 +200,15 @@ class wmtsExtension(FactoryExtension):
                     wmts_bbox = bounds
                     if geographic_crs != WGS84_CRS:
                         bbox_crs_type = "BoundingBox"
-                        bbox_crs_uri = CRS_to_urn(geographic_crs)
-                        if not bbox_crs_uri:
+                        crs_urn = CRS_to_urn(geographic_crs)
+                        if not crs_urn:
                             warnings.warn(
                                 f"Could not resolve a URN for CRS '{geographic_crs}', falling back to WKT for the BoundingBox crs attribute",
                                 UserWarning,
                                 stacklevel=2,
                             )
-                            bbox_crs_uri = geographic_crs.to_wkt()
+                            crs_urn = geographic_crs.to_wkt()
+                        bbox_crs_uri = crs_urn
                         # WGS88BoundingBox is always xy ordered, but BoundingBox must match the CRS order
                         proj_crs = rio_crs_to_pyproj(geographic_crs)
                         if crs_axis_inverted(proj_crs):

--- a/src/titiler/mosaic/titiler/mosaic/extensions/wmts.py
+++ b/src/titiler/mosaic/titiler/mosaic/extensions/wmts.py
@@ -200,7 +200,14 @@ class wmtsExtension(FactoryExtension):
                     wmts_bbox = bounds
                     if geographic_crs != WGS84_CRS:
                         bbox_crs_type = "BoundingBox"
-                        bbox_crs_uri = CRS_to_urn(geographic_crs)  # type: ignore
+                        bbox_crs_uri = CRS_to_urn(geographic_crs)
+                        if not bbox_crs_uri:
+                            warnings.warn(
+                                f"Could not resolve a URN for CRS '{geographic_crs}', falling back to WKT for the BoundingBox crs attribute",
+                                UserWarning,
+                                stacklevel=2,
+                            )
+                            bbox_crs_uri = geographic_crs.to_wkt()
                         # WGS88BoundingBox is always xy ordered, but BoundingBox must match the CRS order
                         proj_crs = rio_crs_to_pyproj(geographic_crs)
                         if crs_axis_inverted(proj_crs):


### PR DESCRIPTION
closes #1043

## What

When the `wmtsExtension` is configured with a custom CRS that cannot be
resolved to an authority identifier (e.g. a slightly tweaked polar
stereographic projection), `CRS_to_urn()` returns `None` and the WMTS
Capabilities document ends up with an invalid bounding box CRS:

```xml
<ows:BoundingBox crs="None">
```

This breaks WMTS clients such as QGIS.

This PR implements the fallback discussed in #1043: when no URN can be
resolved, we now emit a `UserWarning` and use the WKT representation of the CRS
for the `crs` attribute. WKT is not strictly compliant with the WMTS 1.0.0
expectation that this value be a CRS URI/URN, but GDAL/QGIS handle it
correctly, and it is preferable to emitting `crs="None"`.

The same fix is applied to both `titiler.extensions.wmtsExtension` and
`titiler.mosaic.extensions.wmtsExtension`, and the now-unneeded
`# type: ignore` comments are removed.

## Changes

- `titiler/extensions/wmts.py` / `titiler/mosaic/extensions/wmts.py`: fall back
  to `geographic_crs.to_wkt()` (with a `UserWarning`) when
  `CRS_to_urn(geographic_crs)` returns `None`
- add tests for both extensions using a custom CRS that cannot be resolved to
  an authority, asserting that a `UserWarning` is emitted and that the `crs`
  attribute of `ows:BoundingBox` contains the WKT string
- update `CHANGES.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
