### PR TITLE
fix: update mypy type-ignore code in dem algorithm to [call-overload]

### DIFF
--- a/src/titiler/core/titiler/core/algorithm/dem.py
+++ b/src/titiler/core/titiler/core/algorithm/dem.py
@@ -179,7 +179,7 @@ class Terrarium(BaseAlgorithm):
         """Encode DEM into RGB."""
         data = numpy.clip(img.array[0] + 32768.0, 0.0, 65535.0)
         if self.nodata_height is not None:
-            data[img.array.mask[0]] = numpy.clip(  # type: ignore [index]
+            data[img.array.mask[0]] = numpy.clip(  # type: ignore [call-overload]
                 self.nodata_height + 32768.0, 0.0, 65535.0
             )
         r = data / 256
@@ -239,7 +239,7 @@ class TerrainRGB(BaseAlgorithm):
             raise ValueError(f"Data of {datarange} larger than 256 ** 3")
 
         if self.nodata_height is not None:
-            data[img.array.mask[0]] = (  # type: ignore [index]
+            data[img.array.mask[0]] = (  # type: ignore [call-overload]
                 self.nodata_height - self.baseval
             ) / self.interval
 


### PR DESCRIPTION
## What

The mypy CI step is currently failing on `main` (and therefore on every open PR)
because the numpy typing stubs now report the masked-array assignments in the
DEM algorithms as `[call-overload]` errors instead of `[index]`:

```
src/titiler/core/titiler/core/algorithm/dem.py:182: error: No overload variant of "__getitem__" of "generic" matches argument type "int"  [call-overload]
src/titiler/core/titiler/core/algorithm/dem.py:182: note: Error code "call-overload" not covered by "type: ignore[index]" comment
```

The existing `# type: ignore [index]` comments no longer cover the reported
error code, so mypy fails.

This PR updates the two ignore comments to `[call-overload]` to match the code
numpy now emits. No runtime behavior changes.

## Changes

- `titiler/core/algorithm/dem.py`: `# type: ignore [index]` -> `# type: ignore [call-overload]` (lines 182 and 242)

I noticed this while working on #1448 — the failure is unrelated to that PR and
pre-existing on `main` (e.g. the CI run for the merge commit on main also fails
with the same two `dem.py` errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
