### PR TITLE
fix(#1455): correct type annotation issue

### DIFF
--- a/src/titiler/core/titiler/core/routing.py
+++ b/src/titiler/core/titiler/core/routing.py
@@ -21,7 +21,7 @@ def add_route_dependencies(
     routes: list[BaseRoute],
     *,
     scopes: list[EndpointScope],
-    dependencies=list[params.Depends],
+    dependencies: list[params.Depends],
 ):
     """Add dependencies to routes.
 


### PR DESCRIPTION
Closes #1455 

`uv run pytest src/titiler/core --cov=titiler.core -cov-report=term-missing` reports no issues. pre-commit hooks complete successfully.
