### PR TITLE
feat(#1458): control XML layer identifiers

### DIFF
--- a/src/titiler/extensions/tests/test_wmts.py
+++ b/src/titiler/extensions/tests/test_wmts.py
@@ -2,12 +2,14 @@
 
 import io
 import os
+import re
 import xml.etree.ElementTree as ET
+from typing import cast
 
 import pytest
 import rasterio
 from fastapi import FastAPI
-from owslib.wmts import WebMapTileService
+from owslib.wmts import ContentMetadata, WebMapTileService
 from rasterio.crs import CRS
 from rio_tiler.utils import CRS_to_urn
 from starlette.testclient import TestClient
@@ -280,3 +282,38 @@ def test_wmtsExtension_with_renders_old():
 
         assert wmts.provider.name == "TiTiler"
         assert wmts.provider.url == "https://developmentseed.org/titiler/"
+
+
+def test_wmtsExtension_layer_identifier_provider():
+    """Test wmtsExtension class with a custom layer identifier provider."""
+    layer_identifier_prefix = "layer_prefix_"
+    tiler_plus_wmts = TilerFactory(
+        extensions=[
+            wmtsExtension(
+                layer_identifier_provider=lambda src_path: (
+                    f"{layer_identifier_prefix}{src_path}"
+                )
+            )
+        ],
+    )
+    app = FastAPI()
+    app.include_router(tiler_plus_wmts.router)
+    with TestClient(app) as client:
+        data_url = f"{DATA_DIR}/cog.tif"
+        response = client.get(f"/WMTSCapabilities.xml?url={data_url}")
+        assert response.status_code == 200
+        wmts = WebMapTileService(
+            f"/WMTSCapabilities.xml?url={data_url}", xml=response.content
+        )
+        for id, content in wmts.contents.items():
+            identifier_regex = re.compile(
+                f"^{re.escape(layer_identifier_prefix)}{re.escape(data_url)}_.+_default$"
+            )
+            for location, value in (
+                ("key", id),
+                ("object.id", cast(ContentMetadata, content).id),
+                ("object.title", cast(ContentMetadata, content).title),
+            ):
+                assert re.match(identifier_regex, cast(str, value)) is not None, (
+                    f"unexpected value in {location} for {id}"
+                )

--- a/src/titiler/extensions/titiler/extensions/wmts.py
+++ b/src/titiler/extensions/titiler/extensions/wmts.py
@@ -54,7 +54,9 @@ class wmtsExtension(FactoryExtension):
     # Note: Those dependencies should only require Query() inputs
     tile_dependencies: list[Callable] | None = field(default=None)
 
-    layer_identifier_provider: Callable[[Any], str] | None = field(default=None)
+    layer_identifier_provider: Callable[[Any], str] = field(
+        default=lambda x: x if isinstance(x, str) else "TiTiler"
+    )
 
     # TODO: Remove in 3.0
     def __attrs_post_init__(self):
@@ -192,10 +194,7 @@ class wmtsExtension(FactoryExtension):
                     )
 
                 layers: list[dict[str, Any]] = []
-                if self.layer_identifier_provider is None:
-                    title = src_path if isinstance(src_path, str) else "TiTiler"
-                else:
-                    title = self.layer_identifier_provider(src_path)
+                title = self.layer_identifier_provider(src_path)
                 for render in renders:
                     # NOTE: Default bounds and CRS for the dataset
                     bounds = dataset_bounds

--- a/src/titiler/extensions/titiler/extensions/wmts.py
+++ b/src/titiler/extensions/titiler/extensions/wmts.py
@@ -54,6 +54,8 @@ class wmtsExtension(FactoryExtension):
     # Note: Those dependencies should only require Query() inputs
     tile_dependencies: list[Callable] | None = field(default=None)
 
+    layer_identifier_provider: Callable[[Any], str] | None = field(default=None)
+
     # TODO: Remove in 3.0
     def __attrs_post_init__(self):
         """Warn about deprecation of `get_renders` attribute."""
@@ -190,7 +192,10 @@ class wmtsExtension(FactoryExtension):
                     )
 
                 layers: list[dict[str, Any]] = []
-                title = src_path if isinstance(src_path, str) else "TiTiler"
+                if self.layer_identifier_provider is None:
+                    title = src_path if isinstance(src_path, str) else "TiTiler"
+                else:
+                    title = self.layer_identifier_provider(src_path)
                 for render in renders:
                     # NOTE: Default bounds and CRS for the dataset
                     bounds = dataset_bounds

--- a/src/titiler/mosaic/titiler/mosaic/extensions/wmts.py
+++ b/src/titiler/mosaic/titiler/mosaic/extensions/wmts.py
@@ -55,7 +55,9 @@ class wmtsExtension(FactoryExtension):
     # Note: Those dependencies should only require Query() inputs
     tile_dependencies: list[Callable] | None = field(default=None)
 
-    layer_identifier_provider: Callable[[Any], str] | None = field(default=None)
+    layer_identifier_provider: Callable[[Any], str] = field(
+        default=lambda x: x if isinstance(x, str) else "TiTiler Mosaic"
+    )
 
     # TODO: Remove in 3.0
     def __attrs_post_init__(self):
@@ -202,10 +204,7 @@ class wmtsExtension(FactoryExtension):
                     )
 
                 layers: list[dict[str, Any]] = []
-                if self.layer_identifier_provider is None:
-                    title = src_path if isinstance(src_path, str) else "TiTiler Mosaic"
-                else:
-                    title = self.layer_identifier_provider(src_path)
+                title = self.layer_identifier_provider(src_path)
                 for render in renders:
                     # NOTE: Default bounds and CRS for the dataset
                     bounds = dataset_bounds

--- a/src/titiler/mosaic/titiler/mosaic/extensions/wmts.py
+++ b/src/titiler/mosaic/titiler/mosaic/extensions/wmts.py
@@ -55,6 +55,8 @@ class wmtsExtension(FactoryExtension):
     # Note: Those dependencies should only require Query() inputs
     tile_dependencies: list[Callable] | None = field(default=None)
 
+    layer_identifier_provider: Callable[[Any], str] | None = field(default=None)
+
     # TODO: Remove in 3.0
     def __attrs_post_init__(self):
         """Warn about deprecation of `get_renders` attribute."""
@@ -200,7 +202,10 @@ class wmtsExtension(FactoryExtension):
                     )
 
                 layers: list[dict[str, Any]] = []
-                title = src_path if isinstance(src_path, str) else "TiTiler Mosaic"
+                if self.layer_identifier_provider is None:
+                    title = src_path if isinstance(src_path, str) else "TiTiler Mosaic"
+                else:
+                    title = self.layer_identifier_provider(src_path)
                 for render in renders:
                     # NOTE: Default bounds and CRS for the dataset
                     bounds = dataset_bounds


### PR DESCRIPTION
Closes #1458 

I added a test for titiler.extentions.wmts, however I did not add one for titiler.mosaic.extentions.wmts as there are no existing tests for this module.

The following commands execute successfully:

```sh
uv run pytest src/titiler/extensions --cov=titiler.extensions --cov-report=term-missing && uv run pytest src/titiler/mosaic --cov=titiler.mosaic --cov-report=term-missing
```
```sh
uv run pre-commit run --all-files
```