### PR TITLE
fix: use environment_dependency in cogeo extension

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Issues and pull requests are more than welcome: https://github.com/developmentseed/titiler/issues
 
-We recommand using [`uv`](https://docs.astral.sh/uv) as project manager for development.
+We recommend using [`uv`](https://docs.astral.sh/uv) as project manager for development.
 
 See https://docs.astral.sh/uv/getting-started/installation/ for installation 
 

--- a/src/titiler/extensions/titiler/extensions/cogeo.py
+++ b/src/titiler/extensions/titiler/extensions/cogeo.py
@@ -2,6 +2,7 @@
 
 from typing import Annotated
 
+import rasterio
 from attrs import define
 from fastapi import Depends, Query
 
@@ -39,6 +40,8 @@ class cogValidateExtension(FactoryExtension):
                 bool,
                 Query(description="Treat warnings as errors"),
             ] = False,
+            env=Depends(factory.environment_dependency),
         ):
             """Validate a COG"""
-            return cog_info(src_path, strict=strict)
+            with rasterio.Env(**env):
+                return cog_info(src_path, strict=strict)


### PR DESCRIPTION
I use the `environment_dependency` to configure GDAL to use a non-AWS S3 bucket.

I noticed that this dependency was not being used in the `cogeo` extension, making the extension not functional for my use-case.

This PR wraps the call to `rio-cogeo` around a `rasterio.Env` using the dependency parameters as is done elsewhere.

Note: I only use the `cogeo` extension so I don't know for sure if this problem applies to other extensions:
- `wms` and `wmts` already use the `environment_dependency`.
- At first glance, the `stac` extension may benefit from the same patch (i.e. wrap the call to `rio-stac` around a `rasterio.Env`).
- I'm not sure what the `render` and `viewer` extensions do, so I can't tell if adding the dependency there would make sense.