### PR TITLE
chore: refactor dockerfile to use uv lock file

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -1,24 +1,65 @@
 ARG PYTHON_VERSION=3.14
 
-FROM python:${PYTHON_VERSION}
-RUN apt update && apt upgrade -y \
-  && apt install curl -y \
-  && rm -rf /var/lib/apt/lists/*
+FROM python:${PYTHON_VERSION}  AS builder
 
-# Ensure root certificates are always updated at evey container build
-# and curl is using the latest version of them
-# RUN mkdir /usr/local/share/ca-certificates/cacert.org
-# RUN cd /usr/local/share/ca-certificates/cacert.org && curl -k -O https://www.cacert.org/certs/root.crt
-# RUN cd /usr/local/share/ca-certificates/cacert.org && curl -k -O https://www.cacert.org/certs/class3.crt
-# ENV CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
-RUN update-ca-certificates
+# Set build labels
+LABEL stage=builder
+LABEL org.opencontainers.image.source="https://github.com/developmentseed/titiler"
+LABEL org.opencontainers.image.description="TiTiler"
+LABEL org.opencontainers.image.licenses="MIT"
 
-RUN python -m pip install -U pip
-RUN python -m pip install uvicorn uvicorn-worker gunicorn
+# Set environment variables
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
 
-COPY src/titiler/ /tmp/titiler/
-RUN python -m pip install /tmp/titiler/core /tmp/titiler/extensions["cogeo,stac"] /tmp/titiler/mosaic["mosaicjson"] /tmp/titiler/xarray /tmp/titiler/application --no-cache-dir --upgrade
-RUN rm -rf /tmp/titiler
+# Install build dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    libexpat1 curl && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install uv
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
+
+# Configure uv-managed virtual environment
+ENV UV_LINK_MODE=copy \
+    UV_PROJECT_ENVIRONMENT=/opt/venv \
+    PATH="/opt/venv/bin:${PATH}"
+
+WORKDIR /tmp
+
+# Copy project metadata and code
+COPY pyproject.toml uv.lock README.md LICENSE ./
+COPY src/titiler/ ./src/titiler/
+RUN uv sync --frozen --no-dev --no-editable --group server
+RUN uv pip install --no-deps --no-editable .
+
+# Runtime stage
+FROM python:${PYTHON_VERSION}-slim
+
+# Set runtime labels
+LABEL org.opencontainers.image.source="https://github.com/developmentseed/titiler"
+LABEL org.opencontainers.image.description="TiTiler"
+LABEL org.opencontainers.image.licenses="MIT"
+
+# Set environment variables
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PATH="/opt/venv/bin:$PATH"
+
+# Install runtime dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    libexpat1 curl && \
+    rm -rf /var/lib/apt/lists/*
+
+# Copy virtual environment from builder
+COPY --from=builder /opt/venv /opt/venv
+
+RUN groupadd -g 1000 user && \
+    useradd -u 1000 -g user -s /bin/bash -m user
+
+USER user
 
 ###################################################
 # For compatibility (might be removed at one point)

--- a/dockerfiles/Dockerfile.xarray
+++ b/dockerfiles/Dockerfile.xarray
@@ -20,6 +20,8 @@ COPY src/titiler/ /tmp/titiler/
 RUN python -m pip install /tmp/titiler/core["telemetry"] /tmp/titiler/xarray --no-cache-dir --upgrade
 RUN rm -rf /tmp/titiler
 
+LABEL deprecated=TRUE
+
 ###################################################
 # For compatibility (might be removed at one point)
 ENV MODULE_NAME=titiler.xarray.main

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,9 @@ docs = [
     "mkdocstrings[python]>=0.25.1",
 ]
 server = [
-    "uvicorn",
+    "uvicorn[standard]>=0.12.0",
+    "uvicorn-worker",
+    "gunicorn",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -1753,6 +1753,18 @@ wheels = [
 ]
 
 [[package]]
+name = "gunicorn"
+version = "26.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/b7/a4a3f632f823e432ce6bc65f62961b7980c898c77f075a2f7118cb3846fe/gunicorn-26.0.0.tar.gz", hash = "sha256:ca9346f85e3a4aeeb64d491045c16b9a35647abd37ea15efe53080eb8b090baf", size = 727286, upload-time = "2026-05-05T06:38:25.529Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/40/9c2384fc2be4ad25dd4a49decd5ad9ea5a3639814c11bd40ab77cb9f0a14/gunicorn-26.0.0-py3-none-any.whl", hash = "sha256:40233d26a5f0d1872916188c276e21641155111c2853f0c2cd55260aec0d24fc", size = 212009, upload-time = "2026-05-05T06:38:23.007Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3811,7 +3823,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -5655,7 +5667,7 @@ wheels = [
 
 [[package]]
 name = "titiler"
-version = "2.2.0"
+version = "2.2.1"
 source = { virtual = "." }
 dependencies = [
     { name = "titiler-application" },
@@ -5700,7 +5712,9 @@ docs = [
     { name = "mkdocstrings", extra = ["python"] },
 ]
 server = [
-    { name = "uvicorn" },
+    { name = "gunicorn" },
+    { name = "uvicorn", extra = ["standard"] },
+    { name = "uvicorn-worker" },
 ]
 telemetry = [
     { name = "opentelemetry-api" },
@@ -5751,7 +5765,11 @@ docs = [
     { name = "mkdocs-material", extras = ["imaging"], specifier = ">=9.5" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=0.25.1" },
 ]
-server = [{ name = "uvicorn" }]
+server = [
+    { name = "gunicorn" },
+    { name = "uvicorn", extras = ["standard"], specifier = ">=0.12.0" },
+    { name = "uvicorn-worker" },
+]
 telemetry = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp" },
@@ -6199,6 +6217,19 @@ standard = [
     { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'" },
     { name = "watchfiles" },
     { name = "websockets" },
+]
+
+[[package]]
+name = "uvicorn-worker"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gunicorn" },
+    { name = "uvicorn" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/80/59/9101b9c0680fd80e9d26c07deb822a5d18a324339fcf9cd017885ee808ad/uvicorn_worker-0.4.0.tar.gz", hash = "sha256:8ee5306070d8f38dce124adce488c3c0b50f20cf0c0222b12c66188da7214493", size = 9361, upload-time = "2025-09-20T10:47:01.218Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/25/09cd7a90c8bb7fb693be0d6704fccd5f9778d5513214b7a01cc4a94ff314/uvicorn_worker-0.4.0-py3-none-any.whl", hash = "sha256:e2ed952cef976f5e9e429d7269640bbcafbd36c80aa80f1003c8c77a6797abde", size = 5364, upload-time = "2025-09-20T10:46:59.776Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Technical Context
- **Related Issues:** Fixes # (issue number)
- **Breaking Changes:** [Yes/No] (If yes, please describe the impact and migration path)

## Description

This PR refactor the Dockerfile to use the uv lockfile and also add deprecated note in titiler-xarray image 

---

## Checklist
- [ ] **Linting:** Code is formatted and linted (`uv run pre-commit run --all-files`)
- [ ] **Tests:** Tests pass. I have included new tests for these changes where applicable.
- [ ] **Edge Cases:** I have manually verified "unhappy paths" and edge cases beyond the basic success criteria (e.g., database connection timeouts, malformed input, strict mapping rejections).
- [ ] **Documentation:** I have updated `README.md` to reflect any new environment variables, configuration changes, or breaking updates.
- [ ] **Accountability:** I can explain the implementation logic for every line of code submitted.

---

## AI tool usage
 - [x] AI (Copilot or something similar) supported my development of this PR. Use of AI tools *HAVE TO* be indicated.
 ---
 > **Policy:** We require a "human-in-the-loop." You are the author and are fully accountable for all submitted code. Please ensure all tool-generated content is thoroughly reviewed before submission to ensure it is not an "extractive contribution" that squanders maintainer time.