### PR TITLE
fix(docker): keep pip in the application virtualenv

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -60,7 +60,8 @@ RUN apt-get update && \
 COPY --from=builder /opt/venv /opt/venv
 
 RUN groupadd -g 1000 user && \
-    useradd -u 1000 -g user -s /bin/bash -m user
+    useradd -u 1000 -g user -s /bin/bash -m user && \
+    chown -R user:user /opt/venv
 
 USER user
 

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -33,6 +33,9 @@ COPY pyproject.toml uv.lock README.md LICENSE ./
 COPY src/titiler/ ./src/titiler/
 RUN uv sync --frozen --no-dev --no-editable --group server
 RUN uv pip install --no-deps --no-editable .
+# Keep pip inside the runtime venv so downstream images install into the
+# environment used by the application rather than the system interpreter.
+RUN uv pip install --python /opt/venv/bin/python pip
 
 # Runtime stage
 FROM python:${PYTHON_VERSION}-slim


### PR DESCRIPTION
## Summary

The 2.2.2 image runs the application from `/opt/venv`, but the uv-created
virtual environment does not contain `pip`. As a result, a downstream
Dockerfile's bare `pip install` resolves to the system interpreter instead of
the environment used by TiTiler.

## Changes

- Install `pip` into `/opt/venv` during the builder stage.
- Make the copied virtual environment writable by the existing non-root runtime user.
- Keep the existing runtime PATH and application dependency layout unchanged.

## Issue

Closes #1495

## Verification

- `uv sync --frozen` and the project mypy command in the official `codex-ci/python:3.14-build` pre-PR runner — PASS (54 source files, task `prepr-20260911T045200Z-15993`).
- Fixed downstream-container simulation — PASS: as `uid=1000(user)`, bare `pip` resolves to `/opt/venv/bin/pip`, `pip install mangum` succeeds, and `/opt/venv/bin/python` imports it from `/opt/venv/lib/python3.14/site-packages`.
- Core, xarray, and mosaic test modules in the same runner — PASS (92, 59, and 10 tests respectively).
- Application tests in the same runner — 39 passed, 1 failed in an existing Brotli/httpx2 compatibility path (`Decompressor.decompress()` does not accept `output_buffer_limit`); the failure is outside this Dockerfile-only change.
- `docker build --file dockerfiles/Dockerfile ...` — BLOCKED: a retry reached the Dockerfile but failed at the existing runtime `apt-get update` layer because the configured mirror returned a connection failure/404 for Debian trixie `Packages`, before the new `pip`/`chown` layers were evaluated. An earlier attempt failed while resolving `python:3.14`.

## Known limitations

- The local Docker image build is blocked by the configured Docker/Debian mirrors. The hosted pull-request workflows currently require repository-maintainer approval, and the repository's Docker publish workflow is not configured as a pull-request check.
- The pre-PR runner's `pre-commit` invocation could not use its generated Git snapshot, so that hook was not independently verified there.
